### PR TITLE
Add medication-interaction data layer for guardrail pipeline (SPEC-007 W3)

### DIFF
--- a/backend/agents/nutrition_meal_planning_team/guardrail/__init__.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/__init__.py
@@ -10,7 +10,13 @@ from __future__ import annotations
 import os
 
 from .checker import check_recommendation
-from .errors import GuardrailError, GuardrailNotImplementedError
+from .errors import GuardrailError, GuardrailNotImplementedError, InteractionDataError
+from .interactions import (
+    EMPTY_POLICY,
+    InteractionPolicy,
+    get_interaction_policies,
+    load_interactions,
+)
 from .version import GUARDRAIL_VERSION
 from .violations import GuardrailResult, Severity, Violation, ViolationReason
 
@@ -23,13 +29,18 @@ def is_guardrail_enabled() -> bool:
 
 
 __all__ = [
+    "EMPTY_POLICY",
     "GUARDRAIL_VERSION",
     "GuardrailError",
     "GuardrailNotImplementedError",
     "GuardrailResult",
+    "InteractionDataError",
+    "InteractionPolicy",
     "Severity",
     "Violation",
     "ViolationReason",
     "check_recommendation",
+    "get_interaction_policies",
     "is_guardrail_enabled",
+    "load_interactions",
 ]

--- a/backend/agents/nutrition_meal_planning_team/guardrail/data/interactions.yaml
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/data/interactions.yaml
@@ -1,0 +1,66 @@
+# SPEC-007 §4.4 step 4 — medication-class → food-interaction tag map v1.
+#
+# Closed table. Every key must be a clinical_taxonomy.Medication member;
+# every tag in hard/flag must be an ingredient_kb.taxonomy.InteractionTag
+# member. The loader fails fast on unknowns.
+#
+# Policy: default to flag (advisory) unless the interaction is both
+# acute and well-documented.  Only maoi × tyramine_high is hard in v1.
+# Promoting a flag to hard requires team-lead + clinical reviewer
+# sign-off per entry.
+#
+# Clinical review: [pending — to be recorded on PR approval]
+
+warfarin:
+  hard: []
+  flag: [vitamin_k_high]
+  note: "Coordinate vitamin K intake with INR monitoring."
+
+maoi:
+  hard: [tyramine_high]
+  flag: []
+  note: "Aged cheeses, cured meats, fermented foods excluded."
+
+ssri:
+  hard: []
+  flag: [st_johns_wort]
+
+acei_arb:
+  hard: []
+  flag: [potassium_high]
+
+k_sparing_diuretic:
+  hard: []
+  flag: [potassium_high]
+
+statin:
+  hard: []
+  flag: [grapefruit]
+
+amiodarone:
+  hard: []
+  flag: [grapefruit]
+
+glp1:
+  hard: []
+  flag: [very_high_fat]
+
+metformin:
+  hard: []
+  flag: []
+  note: "No specific food interactions in v1 scope."
+
+levothyroxine:
+  hard: []
+  flag: [caffeine_high]
+  note: "Take on empty stomach; caffeine may reduce absorption."
+
+lithium:
+  hard: []
+  flag: [sodium_very_high, caffeine_high]
+  note: "Consistent sodium and caffeine intake recommended."
+
+st_johns_wort:
+  hard: []
+  flag: [st_johns_wort]
+  note: "St. John's wort interacts with many medication classes."

--- a/backend/agents/nutrition_meal_planning_team/guardrail/errors.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/errors.py
@@ -9,3 +9,7 @@ class GuardrailError(Exception):
 
 class GuardrailNotImplementedError(GuardrailError, NotImplementedError):
     """W1 scaffolding stub — replaced by W2 ``checker.check_recommendation``."""
+
+
+class InteractionDataError(GuardrailError):
+    """Raised when ``interactions.yaml`` fails schema validation."""

--- a/backend/agents/nutrition_meal_planning_team/guardrail/interactions.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/interactions.py
@@ -1,0 +1,169 @@
+"""SPEC-007 §4.4 step 4 — medication-interaction policy loader.
+
+Loads ``interactions.yaml`` at first call (cached for process lifetime).
+Schema-validated: unknown medication keys or interaction tags fail loudly.
+Unknown medication strings from a profile are non-fatal — the caller
+gets an empty policy and an advisory list.
+
+Pure function after first load. No I/O, no LLM.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import yaml
+
+from ..clinical_taxonomy import Medication
+from ..ingredient_kb.taxonomy import InteractionTag
+from .errors import InteractionDataError
+
+_DATA_DIR = Path(__file__).resolve().parent / "data"
+
+_MEDICATION_VALUES = frozenset(m.value for m in Medication)
+_INTERACTION_TAG_VALUES = frozenset(t.value for t in InteractionTag)
+
+
+@dataclass(frozen=True)
+class InteractionPolicy:
+    """One medication class's forbidden-food-tag policy.
+
+    Preconditions:
+        ``medication`` is a ``Medication`` enum value string.
+        Every element in ``hard`` and ``flag`` is a valid ``InteractionTag``.
+        ``hard`` and ``flag`` are disjoint.
+
+    Postconditions:
+        Frozen; safe to hash, cache, and compare by value.
+
+    Invariants:
+        ``hard ∩ flag == ∅`` — a tag is either acute or advisory, never both.
+    """
+
+    medication: str
+    hard: frozenset[InteractionTag]
+    flag: frozenset[InteractionTag]
+    note: str = ""
+
+
+EMPTY_POLICY = InteractionPolicy(medication="", hard=frozenset(), flag=frozenset())
+
+
+def _coerce_tags(raw: list, field_name: str, medication: str) -> frozenset[InteractionTag]:
+    """Validate and convert a list of tag strings to a frozenset of InteractionTag.
+
+    Preconditions:
+        ``raw`` is a list (possibly empty) of strings.
+
+    Postconditions:
+        Returns a frozenset of InteractionTag members.
+        Raises InteractionDataError if any string is not a valid InteractionTag.
+    """
+    if not isinstance(raw, list):
+        raise InteractionDataError(
+            f"interactions.yaml: {medication}.{field_name} must be a list, got {type(raw).__name__}"
+        )
+    tags: list[InteractionTag] = []
+    for item in raw:
+        if item not in _INTERACTION_TAG_VALUES:
+            raise InteractionDataError(
+                f"interactions.yaml: unknown InteractionTag '{item}' in {medication}.{field_name}"
+            )
+        tags.append(InteractionTag(item))
+    return frozenset(tags)
+
+
+@lru_cache(maxsize=1)
+def load_interactions() -> Dict[str, InteractionPolicy]:
+    """Load and validate ``interactions.yaml``.
+
+    Preconditions:
+        ``data/interactions.yaml`` exists and is valid YAML.
+
+    Postconditions:
+        Returns a dict keyed by every ``Medication`` enum value.
+        Each value is a frozen ``InteractionPolicy``.
+        Raises ``InteractionDataError`` on any schema violation.
+
+    Invariants:
+        Result is identical across calls (cached, YAML is immutable at runtime).
+    """
+    path = _DATA_DIR / "interactions.yaml"
+    if not path.exists():
+        raise InteractionDataError(f"interactions.yaml not found at {path}")
+
+    with open(path, encoding="utf-8") as fh:
+        raw = yaml.safe_load(fh)
+
+    if not isinstance(raw, dict):
+        raise InteractionDataError(
+            f"interactions.yaml: root must be a mapping, got {type(raw).__name__}"
+        )
+
+    result: dict[str, InteractionPolicy] = {}
+
+    for key, entry in raw.items():
+        if key not in _MEDICATION_VALUES:
+            raise InteractionDataError(f"interactions.yaml: unknown Medication key '{key}'")
+        if not isinstance(entry, dict):
+            raise InteractionDataError(
+                f"interactions.yaml: {key} must be a mapping, got {type(entry).__name__}"
+            )
+
+        hard_raw = entry.get("hard", [])
+        flag_raw = entry.get("flag", [])
+        note = entry.get("note", "")
+
+        hard = _coerce_tags(hard_raw, "hard", key)
+        flag = _coerce_tags(flag_raw, "flag", key)
+
+        overlap = hard & flag
+        if overlap:
+            tag_names = ", ".join(sorted(t.value for t in overlap))
+            raise InteractionDataError(
+                f"interactions.yaml: {key} has tags in both hard and flag: {tag_names}"
+            )
+
+        if not isinstance(note, str):
+            raise InteractionDataError(
+                f"interactions.yaml: {key}.note must be a string, got {type(note).__name__}"
+            )
+
+        result[key] = InteractionPolicy(medication=key, hard=hard, flag=flag, note=note)
+
+    missing = _MEDICATION_VALUES - set(result.keys())
+    if missing:
+        raise InteractionDataError(
+            f"interactions.yaml: missing entries for Medication members: {sorted(missing)}"
+        )
+
+    return result
+
+
+def get_interaction_policies(
+    medications: List[str],
+) -> Tuple[Dict[str, InteractionPolicy], List[str]]:
+    """Look up interaction policies for a profile's medication list.
+
+    Preconditions:
+        ``medications`` is a list of strings (may contain unknown values).
+
+    Postconditions:
+        First element: dict of ``{medication_string: InteractionPolicy}``
+        for every medication that exists in ``interactions.yaml``.
+        Second element: list of medication strings that were not recognized
+        (for advisory downstream — never raises on unknowns).
+    """
+    interactions = load_interactions()
+    known: dict[str, InteractionPolicy] = {}
+    unknown: list[str] = []
+    for med in medications:
+        policy = interactions.get(med)
+        if policy is not None:
+            known[med] = policy
+        else:
+            unknown.append(med)
+    return known, unknown

--- a/backend/agents/nutrition_meal_planning_team/guardrail/interactions.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/interactions.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
-from typing import Dict, List, Tuple
+from types import MappingProxyType
+from typing import Dict, List, Mapping, Tuple
 
 import yaml
 
@@ -68,6 +69,10 @@ def _coerce_tags(raw: list, field_name: str, medication: str) -> frozenset[Inter
         )
     tags: list[InteractionTag] = []
     for item in raw:
+        if not isinstance(item, str):
+            raise InteractionDataError(
+                f"interactions.yaml: {medication}.{field_name} contains non-string entry: {item!r}"
+            )
         if item not in _INTERACTION_TAG_VALUES:
             raise InteractionDataError(
                 f"interactions.yaml: unknown InteractionTag '{item}' in {medication}.{field_name}"
@@ -77,14 +82,14 @@ def _coerce_tags(raw: list, field_name: str, medication: str) -> frozenset[Inter
 
 
 @lru_cache(maxsize=1)
-def load_interactions() -> Dict[str, InteractionPolicy]:
+def load_interactions() -> Mapping[str, InteractionPolicy]:
     """Load and validate ``interactions.yaml``.
 
     Preconditions:
         ``data/interactions.yaml`` exists and is valid YAML.
 
     Postconditions:
-        Returns a dict keyed by every ``Medication`` enum value.
+        Returns an immutable mapping keyed by every ``Medication`` enum value.
         Each value is a frozen ``InteractionPolicy``.
         Raises ``InteractionDataError`` on any schema violation.
 
@@ -140,7 +145,7 @@ def load_interactions() -> Dict[str, InteractionPolicy]:
             f"interactions.yaml: missing entries for Medication members: {sorted(missing)}"
         )
 
-    return result
+    return MappingProxyType(result)
 
 
 def get_interaction_policies(

--- a/backend/agents/nutrition_meal_planning_team/guardrail/tests/test_interactions_load.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/tests/test_interactions_load.py
@@ -9,6 +9,7 @@ correctly.
 from __future__ import annotations
 
 import dataclasses
+from collections.abc import Mapping
 
 import pytest
 from agents.nutrition_meal_planning_team.clinical_taxonomy import Medication
@@ -22,10 +23,12 @@ from agents.nutrition_meal_planning_team.ingredient_kb.taxonomy import Interacti
 
 
 class TestLoadInteractions:
-    def test_returns_dict(self) -> None:
+    def test_returns_immutable_mapping(self) -> None:
         result = load_interactions()
-        assert isinstance(result, dict)
+        assert isinstance(result, Mapping)
         assert len(result) > 0
+        with pytest.raises(TypeError):
+            result["warfarin"] = None  # type: ignore[index]
 
     def test_every_medication_has_policy(self) -> None:
         result = load_interactions()

--- a/backend/agents/nutrition_meal_planning_team/guardrail/tests/test_interactions_load.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/tests/test_interactions_load.py
@@ -1,0 +1,139 @@
+"""SPEC-007 W3 — interactions.yaml loader behavior tests.
+
+Validates that ``load_interactions`` returns well-shaped, frozen
+``InteractionPolicy`` entries for every medication class, and that
+``get_interaction_policies`` handles known/unknown medication strings
+correctly.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+from agents.nutrition_meal_planning_team.clinical_taxonomy import Medication
+from agents.nutrition_meal_planning_team.guardrail.interactions import (
+    EMPTY_POLICY,
+    InteractionPolicy,
+    get_interaction_policies,
+    load_interactions,
+)
+from agents.nutrition_meal_planning_team.ingredient_kb.taxonomy import InteractionTag
+
+
+class TestLoadInteractions:
+    def test_returns_dict(self) -> None:
+        result = load_interactions()
+        assert isinstance(result, dict)
+        assert len(result) > 0
+
+    def test_every_medication_has_policy(self) -> None:
+        result = load_interactions()
+        for med in Medication:
+            assert med.value in result, f"missing policy for {med.value}"
+
+    def test_no_extra_keys(self) -> None:
+        result = load_interactions()
+        med_values = {m.value for m in Medication}
+        assert set(result.keys()) == med_values
+
+    def test_policy_is_frozen_dataclass(self) -> None:
+        result = load_interactions()
+        policy = result["warfarin"]
+        assert isinstance(policy, InteractionPolicy)
+        assert dataclasses.is_dataclass(policy)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            policy.note = "mutated"  # type: ignore[misc]
+
+    def test_hard_and_flag_are_frozensets(self) -> None:
+        result = load_interactions()
+        for med, policy in result.items():
+            assert isinstance(policy.hard, frozenset), f"{med}.hard is not frozenset"
+            assert isinstance(policy.flag, frozenset), f"{med}.flag is not frozenset"
+
+    def test_hard_and_flag_disjoint(self) -> None:
+        result = load_interactions()
+        for med, policy in result.items():
+            overlap = policy.hard & policy.flag
+            assert not overlap, f"{med} has tags in both hard and flag: {overlap}"
+
+    def test_medication_field_matches_key(self) -> None:
+        result = load_interactions()
+        for med, policy in result.items():
+            assert policy.medication == med
+
+
+class TestPinnedPolicies:
+    def test_warfarin_policy(self) -> None:
+        policy = load_interactions()["warfarin"]
+        assert policy.hard == frozenset()
+        assert policy.flag == frozenset({InteractionTag.vitamin_k_high})
+        assert "vitamin K" in policy.note
+
+    def test_maoi_hard_rejects_tyramine(self) -> None:
+        policy = load_interactions()["maoi"]
+        assert InteractionTag.tyramine_high in policy.hard
+        assert policy.flag == frozenset()
+
+    def test_maoi_is_the_only_hard_rejection(self) -> None:
+        result = load_interactions()
+        hard_meds = [med for med, p in result.items() if p.hard]
+        assert hard_meds == ["maoi"]
+
+    def test_statin_flags_grapefruit(self) -> None:
+        policy = load_interactions()["statin"]
+        assert InteractionTag.grapefruit in policy.flag
+
+    def test_ssri_flags_st_johns_wort(self) -> None:
+        policy = load_interactions()["ssri"]
+        assert InteractionTag.st_johns_wort in policy.flag
+
+    def test_acei_arb_flags_potassium(self) -> None:
+        policy = load_interactions()["acei_arb"]
+        assert InteractionTag.potassium_high in policy.flag
+
+    def test_glp1_flags_very_high_fat(self) -> None:
+        policy = load_interactions()["glp1"]
+        assert InteractionTag.very_high_fat in policy.flag
+
+    def test_metformin_has_no_tags(self) -> None:
+        policy = load_interactions()["metformin"]
+        assert policy.hard == frozenset()
+        assert policy.flag == frozenset()
+
+
+class TestGetInteractionPolicies:
+    def test_known_medications(self) -> None:
+        known, unknown = get_interaction_policies(["warfarin", "maoi"])
+        assert "warfarin" in known
+        assert "maoi" in known
+        assert unknown == []
+
+    def test_unknown_medication(self) -> None:
+        known, unknown = get_interaction_policies(["warfarin", "aspirin_unknown"])
+        assert "warfarin" in known
+        assert "aspirin_unknown" not in known
+        assert unknown == ["aspirin_unknown"]
+
+    def test_all_unknown(self) -> None:
+        known, unknown = get_interaction_policies(["aspirin_unknown"])
+        assert known == {}
+        assert unknown == ["aspirin_unknown"]
+
+    def test_empty_input(self) -> None:
+        known, unknown = get_interaction_policies([])
+        assert known == {}
+        assert unknown == []
+
+    def test_duplicate_medication(self) -> None:
+        known, unknown = get_interaction_policies(["warfarin", "warfarin"])
+        assert len(known) == 1
+        assert unknown == []
+
+
+class TestEmptyPolicy:
+    def test_sentinel_shape(self) -> None:
+        assert EMPTY_POLICY.medication == ""
+        assert EMPTY_POLICY.hard == frozenset()
+        assert EMPTY_POLICY.flag == frozenset()
+        assert EMPTY_POLICY.note == ""

--- a/backend/agents/nutrition_meal_planning_team/guardrail/tests/test_interactions_schema.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/tests/test_interactions_schema.py
@@ -1,0 +1,82 @@
+"""SPEC-007 W3 — raw YAML schema parity tests.
+
+Loads ``interactions.yaml`` directly (bypassing the loader cache) and
+validates structural invariants against the ``Medication`` and
+``InteractionTag`` enums. Catches drift the loader's ``lru_cache``
+might mask during development.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from agents.nutrition_meal_planning_team.clinical_taxonomy import Medication
+from agents.nutrition_meal_planning_team.ingredient_kb.taxonomy import InteractionTag
+
+_YAML_PATH = Path(__file__).resolve().parent.parent / "data" / "interactions.yaml"
+
+
+def _load_raw() -> dict:
+    with open(_YAML_PATH, encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+class TestYamlStructure:
+    def test_yaml_file_exists(self) -> None:
+        assert _YAML_PATH.exists(), f"interactions.yaml not found at {_YAML_PATH}"
+
+    def test_yaml_root_is_mapping(self) -> None:
+        raw = _load_raw()
+        assert isinstance(raw, dict)
+
+    def test_every_key_is_known_medication(self) -> None:
+        raw = _load_raw()
+        med_values = {m.value for m in Medication}
+        for key in raw:
+            assert key in med_values, f"unknown Medication key in YAML: '{key}'"
+
+    def test_every_medication_enum_has_yaml_entry(self) -> None:
+        raw = _load_raw()
+        for med in Medication:
+            assert med.value in raw, f"Medication.{med.value} missing from interactions.yaml"
+
+
+class TestTagValidity:
+    def test_every_hard_tag_is_known_interaction_tag(self) -> None:
+        raw = _load_raw()
+        tag_values = {t.value for t in InteractionTag}
+        for med, entry in raw.items():
+            for tag in entry.get("hard", []):
+                assert tag in tag_values, f"unknown InteractionTag '{tag}' in {med}.hard"
+
+    def test_every_flag_tag_is_known_interaction_tag(self) -> None:
+        raw = _load_raw()
+        tag_values = {t.value for t in InteractionTag}
+        for med, entry in raw.items():
+            for tag in entry.get("flag", []):
+                assert tag in tag_values, f"unknown InteractionTag '{tag}' in {med}.flag"
+
+
+class TestFieldTypes:
+    def test_hard_and_flag_are_lists(self) -> None:
+        raw = _load_raw()
+        for med, entry in raw.items():
+            hard = entry.get("hard", [])
+            flag = entry.get("flag", [])
+            assert isinstance(hard, list), f"{med}.hard must be a list, got {type(hard).__name__}"
+            assert isinstance(flag, list), f"{med}.flag must be a list, got {type(flag).__name__}"
+
+    def test_note_is_string_or_absent(self) -> None:
+        raw = _load_raw()
+        for med, entry in raw.items():
+            if "note" in entry:
+                assert isinstance(entry["note"], str), f"{med}.note must be a string"
+
+    def test_hard_and_flag_disjoint(self) -> None:
+        raw = _load_raw()
+        for med, entry in raw.items():
+            hard = set(entry.get("hard", []))
+            flag = set(entry.get("flag", []))
+            overlap = hard & flag
+            assert not overlap, f"{med} has tags in both hard and flag: {overlap}"


### PR DESCRIPTION
## Summary

- Adds `interactions.yaml` mapping all 12 `Medication` enum classes to their forbidden `InteractionTag` sets with hard/flag severity split. Only `maoi × tyramine_high` is hard-reject in v1; all others are advisory flags.
- Adds `interactions.py` with `load_interactions()` (lru_cache, schema-validated), `get_interaction_policies()` (safe unknown-medication handling), `InteractionPolicy` frozen dataclass, and `EMPTY_POLICY` sentinel.
- Adds `InteractionDataError` to `errors.py` for schema validation failures.
- Exports new public API from `guardrail/__init__.py`.
- 30 new tests across two files: `test_interactions_load.py` (loader behavior, pinned policies, profile lookup) and `test_interactions_schema.py` (raw YAML parity against enums).
- Zero regressions: all 83 guardrail tests pass.

## Checklist

- [x] `load_interactions() → dict[str, InteractionPolicy]` implemented
- [x] Schema-validated on load (unknown tags fail loudly)
- [x] Unknown medication strings on a profile do not error; caller gets back empty policy + advisory
- [ ] Clinical reviewer has reviewed `interactions.yaml` entries and approved
- [x] `ruff check` + `ruff format --check` clean
- [x] All 83 guardrail tests pass (30 new + 53 existing)

## Test plan

- [x] Run `pytest agents/nutrition_meal_planning_team/guardrail/tests/ -v` — 83 passed
- [x] Verify lint: `ruff check` + `ruff format --check` clean
- [x] Verify no regressions in existing allergen, dietary, unresolved, determinism, red-team, and smoke tests

Closes #335

https://claude.ai/code/session_01FqvfiJMMYyzKHjqFFHBVfy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqvfiJMMYyzKHjqFFHBVfy)_