### PR TITLE
investment_team: final golden-parity sweep + close Trading 5/5

### DIFF
--- a/backend/agents/investment_team/tests/test_bar_safety.py
+++ b/backend/agents/investment_team/tests/test_bar_safety.py
@@ -1,6 +1,6 @@
 """Regression tests for the engine-side look-ahead guard (Phase 2).
 
-Covers two surfaces:
+Covers three surfaces:
 
 * ``BarSafetyAssertion.check_fill`` — direct behavior check (enabled /
   disabled, equal / later / earlier bar timestamps).
@@ -8,6 +8,10 @@ Covers two surfaces:
   ``OrderBook`` seeded with an order whose ``submitted_at`` equals the bar
   the simulator is about to fill against must raise ``LookAheadError`` and
   flip ``TradingServiceResult.lookahead_violation``.
+* Requeue + submitted_at refresh — a partial fill with
+  ``REQUEUE_NEXT_BAR`` advances ``submitted_at`` to the fill bar's
+  timestamp, allowing the continuation fill on the next bar without
+  tripping the look-ahead guard.
 """
 
 from __future__ import annotations
@@ -24,7 +28,9 @@ from investment_team.models import BacktestConfig, StrategySpec
 from investment_team.trading_service.data_stream.historical_replay import (
     HistoricalReplayStream,
 )
+from investment_team.trading_service.engine.execution_model import RealisticExecutionModel
 from investment_team.trading_service.engine.fill_simulator import (
+    FillKind,
     FillSimulator,
     FillSimulatorConfig,
 )
@@ -38,6 +44,7 @@ from investment_team.trading_service.strategy.contract import (
     OrderSide,
     OrderType,
     TimeInForce,
+    UnfilledPolicy,
 )
 
 # ---------------------------------------------------------------------------
@@ -351,3 +358,71 @@ def test_trading_service_surfaces_lookahead_violation_from_engine() -> None:
     assert outcome.lookahead_violation
     assert outcome.error is not None
     assert "fill must be strictly after submission" in outcome.error
+
+
+# ---------------------------------------------------------------------------
+# Requeue refreshes submitted_at on partial fill
+# ---------------------------------------------------------------------------
+
+
+def test_requeue_on_partial_fill_refreshes_submitted_at() -> None:
+    """A partial fill with ``REQUEUE_NEXT_BAR`` must advance
+    ``submitted_at`` to the fill bar's timestamp so the continuation fill
+    on the *next* bar passes the look-ahead guard.
+
+    Preconditions: order submitted at ``2024-01-01`` with
+    ``unfilled_policy=REQUEUE_NEXT_BAR``, qty large enough to trigger
+    the participation cap on a thin-volume bar.
+
+    Postconditions:
+    - Bar ``2024-01-02``: partial fill emitted with ``FillKind.PARTIAL``;
+      requeued order has ``submitted_at == "2024-01-02"``.
+    - Bar ``2024-01-03``: continuation fill succeeds (no ``LookAheadError``)
+      because ``submitted_at`` was refreshed to ``"2024-01-02"`` (strictly
+      before ``"2024-01-03"``).
+    """
+    portfolio = Portfolio(initial_capital=100_000.0)
+    order_book = OrderBook()
+    risk = RiskFilter(RiskLimits())
+    sim = FillSimulator(
+        portfolio=portfolio,
+        order_book=order_book,
+        risk_filter=risk,
+        config=FillSimulatorConfig(slippage_bps=0.0, transaction_cost_bps=0.0),
+        execution_model=RealisticExecutionModel(participation_cap=0.10),
+        bar_safety=BarSafetyAssertion(enabled=True),
+    )
+
+    req = OrderRequest(
+        client_order_id="c1",
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=200,
+        order_type=OrderType.MARKET,
+        tif=TimeInForce.DAY,
+        unfilled_policy=UnfilledPolicy.REQUEUE_NEXT_BAR,
+    )
+    order_book.submit(req, submitted_at="2024-01-01", submitted_equity=100_000.0)
+
+    # Bar 1: thin volume triggers participation cap → partial fill + requeue
+    bar1 = Bar(
+        symbol="AAA", timestamp="2024-01-02",
+        open=100.0, high=101.0, low=99.0, close=100.0, volume=1_000.0,
+    )
+    outcome1 = sim.process_bar(bar1)
+
+    assert len(outcome1.entry_fills) == 1
+    assert outcome1.entry_fills[0].fill_kind == FillKind.PARTIAL
+
+    pending = order_book.all_pending()
+    assert len(pending) == 1
+    assert pending[0].submitted_at.startswith("2024-01-02")
+
+    # Bar 2: the requeued order fills on the next bar without tripping the
+    # look-ahead guard (submitted_at="2024-01-02" < fill_bar="2024-01-03").
+    bar2 = Bar(
+        symbol="AAA", timestamp="2024-01-03",
+        open=100.0, high=101.0, low=99.0, close=100.0, volume=1_000_000.0,
+    )
+    outcome2 = sim.process_bar(bar2)
+    assert len(outcome2.entry_fills) >= 1

--- a/backend/agents/investment_team/tests/test_realistic_fill_model.py
+++ b/backend/agents/investment_team/tests/test_realistic_fill_model.py
@@ -1,4 +1,4 @@
-"""Unit tests for ``RealisticExecutionModel`` (issue #248).
+"""Unit tests for ``RealisticExecutionModel``.
 
 Covers the three fill-realism fixes:
 
@@ -12,24 +12,34 @@ Covers the three fill-realism fixes:
    ``participation_cap × bar_dollar_volume`` partially fill to the cap;
    remainder is dropped.
 
-Also covers the adverse-selection haircut on limit fills (``next_bar``-aware).
+Also covers the adverse-selection haircut on limit fills (``next_bar``-aware),
+and partial-fill emission through the ``FillSimulator`` integration layer.
 """
 
 from __future__ import annotations
 
 import pytest
 
+from investment_team.execution.risk_filter import RiskFilter, RiskLimits
 from investment_team.trading_service.engine.execution_model import (
     OptimisticExecutionModel,
     RealisticExecutionModel,
     build_execution_model,
 )
+from investment_team.trading_service.engine.fill_simulator import (
+    FillKind,
+    FillSimulator,
+    FillSimulatorConfig,
+)
+from investment_team.trading_service.engine.order_book import OrderBook
+from investment_team.trading_service.engine.portfolio import Portfolio
 from investment_team.trading_service.strategy.contract import (
     Bar,
     OrderRequest,
     OrderSide,
     OrderType,
     TimeInForce,
+    UnfilledPolicy,
 )
 
 
@@ -373,3 +383,136 @@ def test_optimistic_silenced_by_explicit_warn_false(caplog):
     caplog.set_level(logging.WARNING)
     OptimisticExecutionModel(warn=False)
     assert not any("OptimisticExecutionModel selected" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Partial-fill emission through FillSimulator
+# ---------------------------------------------------------------------------
+
+
+def _make_sim(*, participation_cap: float = 0.10) -> tuple:
+    """Build a FillSimulator with a RealisticExecutionModel.
+
+    Preconditions: participation_cap in (0, 1].
+    Postconditions: returns (simulator, order_book, portfolio) triple;
+    portfolio starts at $100k, zero slippage/cost.
+    """
+    portfolio = Portfolio(initial_capital=100_000.0)
+    order_book = OrderBook()
+    risk = RiskFilter(RiskLimits())
+    sim = FillSimulator(
+        portfolio=portfolio,
+        order_book=order_book,
+        risk_filter=risk,
+        config=FillSimulatorConfig(slippage_bps=0.0, transaction_cost_bps=0.0),
+        execution_model=RealisticExecutionModel(participation_cap=participation_cap),
+    )
+    return sim, order_book, portfolio
+
+
+def test_simulator_emits_partial_fill_when_cap_exceeded() -> None:
+    """When order notional exceeds the participation cap the FillSimulator
+    must emit a Fill with ``fill_kind=PARTIAL`` and a positive
+    ``unfilled_qty`` — not silently drop the remainder.
+
+    Preconditions: order qty × bar.open > participation_cap × bar_dollar_vol.
+    Postconditions: exactly one entry fill with PARTIAL kind, unfilled_qty
+    equal to the uncapped remainder, and the order removed (DROP policy).
+    """
+    sim, ob, _ = _make_sim(participation_cap=0.10)
+    # bar_dollar_volume = 100 * 1000 = 100k; 10% cap = 10k
+    # 200 shares @ $100 = $20k notional → qty_fraction = 0.5 → 100 filled
+    req = _req(side=OrderSide.LONG, order_type=OrderType.MARKET, qty=200)
+    ob.submit(req, submitted_at="2024-01-01", submitted_equity=100_000.0)
+
+    bar = _bar(o=100.0, h=101.0, l=99.0, c=100.0, volume=1_000.0)
+    outcome = sim.process_bar(bar)
+
+    assert len(outcome.entry_fills) == 1
+    fill = outcome.entry_fills[0]
+    assert fill.fill_kind == FillKind.PARTIAL
+    assert fill.qty == pytest.approx(100.0)
+    assert fill.unfilled_qty == pytest.approx(100.0)
+    assert len(ob.all_pending()) == 0
+
+
+def test_simulator_emits_full_fill_when_within_cap() -> None:
+    """When order notional fits within the cap the emitted Fill must have
+    ``fill_kind=FULL``.
+
+    Preconditions: order qty × bar.open <= participation_cap × bar_dollar_vol.
+    Postconditions: one entry fill with FULL kind; unfilled_qty is zero or None.
+    """
+    sim, ob, _ = _make_sim(participation_cap=0.10)
+    req = _req(side=OrderSide.LONG, order_type=OrderType.MARKET, qty=5)
+    ob.submit(req, submitted_at="2024-01-01", submitted_equity=100_000.0)
+
+    bar = _bar(o=100.0, h=101.0, l=99.0, c=100.0, volume=1_000_000.0)
+    outcome = sim.process_bar(bar)
+
+    assert len(outcome.entry_fills) == 1
+    fill = outcome.entry_fills[0]
+    assert fill.fill_kind == FillKind.FULL
+    assert (fill.unfilled_qty or 0.0) == pytest.approx(0.0)
+
+
+def test_partial_fill_with_drop_policy_removes_remainder() -> None:
+    """Under ``unfilled_policy=DROP`` (the default), a participation-capped
+    partial fill removes the order from the book after emitting the PARTIAL
+    Fill.
+
+    Preconditions: order with no explicit unfilled_policy (defaults to DROP).
+    Postconditions: order book is empty after the fill; the partial Fill is
+    still emitted so downstream analytics can see the partial.
+    """
+    sim, ob, _ = _make_sim(participation_cap=0.10)
+    req = OrderRequest(
+        client_order_id="c1",
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=200,
+        order_type=OrderType.MARKET,
+        tif=TimeInForce.DAY,
+    )
+    ob.submit(req, submitted_at="2024-01-01", submitted_equity=100_000.0)
+
+    bar = _bar(o=100.0, h=101.0, l=99.0, c=100.0, volume=1_000.0)
+    outcome = sim.process_bar(bar)
+
+    assert outcome.entry_fills[0].fill_kind == FillKind.PARTIAL
+    assert len(ob.all_pending()) == 0
+
+
+def test_partial_fill_with_requeue_policy_retains_order() -> None:
+    """Under ``unfilled_policy=REQUEUE_NEXT_BAR``, the order stays in the
+    book with updated ``remaining_qty`` and a refreshed ``submitted_at``
+    matching the fill bar's timestamp.
+
+    Preconditions: order with REQUEUE_NEXT_BAR policy, qty exceeding cap.
+    Postconditions: one entry fill (PARTIAL), order remains pending with
+    ``remaining_qty == unfilled_qty`` and ``submitted_at == bar.timestamp``.
+    """
+    sim, ob, _ = _make_sim(participation_cap=0.10)
+    req = OrderRequest(
+        client_order_id="c1",
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=200,
+        order_type=OrderType.MARKET,
+        tif=TimeInForce.DAY,
+        unfilled_policy=UnfilledPolicy.REQUEUE_NEXT_BAR,
+    )
+    ob.submit(req, submitted_at="2024-01-01", submitted_equity=100_000.0)
+
+    bar = _bar(o=100.0, h=101.0, l=99.0, c=100.0, volume=1_000.0)
+    outcome = sim.process_bar(bar)
+
+    assert len(outcome.entry_fills) == 1
+    assert outcome.entry_fills[0].fill_kind == FillKind.PARTIAL
+    assert outcome.entry_fills[0].unfilled_qty == pytest.approx(100.0)
+
+    pending = ob.all_pending()
+    assert len(pending) == 1
+    po = pending[0]
+    assert po.remaining_qty == pytest.approx(100.0)
+    assert po.submitted_at.startswith("2024-01-02")


### PR DESCRIPTION
## Summary

- Verified zero snapshot drift under `OptimisticExecutionModel + unfilled_policy=DROP + no attachments` across all 3 golden reference strategy snapshots and 4 Hypothesis-based invariant tests — no serialization fixes needed (new model fields all have `None` defaults and `_summarize_trades()` filters to a fixed field set)
- Converted `test_realistic_fill_model.py` from silent-drop assertions to partial-fill emission assertions: 4 new `FillSimulator`-level tests verify `FillKind.PARTIAL`/`FULL` emission, DROP policy removal, and `REQUEUE_NEXT_BAR` order retention with refreshed `submitted_at`
- Added `test_requeue_on_partial_fill_refreshes_submitted_at` to `test_bar_safety.py` proving that partial-fill continuation fills pass the look-ahead guard after requeue advances `submitted_at`
- Full investment_team test suite: **2511 passed**, 0 failed

## Test plan

- [x] All 3 golden snapshot tests pass without `UPDATE_GOLDEN_SNAPSHOTS`
- [x] All 4 Hypothesis-based invariant tests pass
- [x] New `test_realistic_fill_model.py` emission tests pass (4 new tests)
- [x] New `test_bar_safety.py` requeue refresh test passes
- [x] Full investment_team test suite passes (2511 tests)
- [x] Ruff lint clean

Closes #392
Closes #379

---
_Generated by [Claude Code](https://claude.ai/code/session_017FewmcZHj8xYQftSinPmAV)_