### PR TITLE
Convert agent_provisioning_team integration tests to unit tests

### DIFF
--- a/backend/agents/agent_provisioning_team/tests/conftest.py
+++ b/backend/agents/agent_provisioning_team/tests/conftest.py
@@ -1,6 +1,17 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture(autouse=True)
+def _patched_job_store(monkeypatch, fake_job_client):
+    """Route the team's job_store ``_client`` through the in-memory fake."""
+    from agent_provisioning_team.shared import job_store as js
+
+    monkeypatch.setattr(js, "_client", lambda *a, **kw: fake_job_client)
+    return fake_job_client

--- a/backend/agents/agent_provisioning_team/tests/test_api.py
+++ b/backend/agents/agent_provisioning_team/tests/test_api.py
@@ -1,20 +1,13 @@
-"""Tests for agent_provisioning_team API endpoints.
-
-MIXED file: most tests mock the job store; a few exercise real timing /
-concurrency.  Marked integration pending a split.
-"""
+"""Tests for agent_provisioning_team API endpoints."""
 
 import threading
 import time
 from unittest.mock import MagicMock, patch
 
-import pytest
 from fastapi.testclient import TestClient
 
-pytestmark = [pytest.mark.integration]
-
-from agent_provisioning_team.api import main as api_main  # noqa: E402
-from agent_provisioning_team.api.main import app  # noqa: E402
+from agent_provisioning_team.api import main as api_main
+from agent_provisioning_team.api.main import app
 
 client = TestClient(app)
 

--- a/backend/agents/agent_provisioning_team/tests/test_job_store.py
+++ b/backend/agents/agent_provisioning_team/tests/test_job_store.py
@@ -1,15 +1,10 @@
 """Tests for agent_provisioning_team job store.
 
-Exercises the team's job_store helpers directly; relied on the file
-fallback that is now removed.  Marked integration until follow-up
-conversion to the in-memory fake.
+Exercises the team's job_store helpers directly via the in-memory
+FakeJobServiceClient (autouse fixture in conftest.py).
 """
 
-import pytest
-
-pytestmark = [pytest.mark.integration]
-
-from agent_provisioning_team.shared.job_store import (  # noqa: E402
+from agent_provisioning_team.shared.job_store import (
     JOB_STATUS_CANCELLED,
     JOB_STATUS_COMPLETED,
     JOB_STATUS_FAILED,
@@ -26,87 +21,82 @@ from agent_provisioning_team.shared.job_store import (  # noqa: E402
 )
 
 
-@pytest.fixture()
-def cache_dir(tmp_path):
-    return tmp_path / "cache"
-
-
-def test_create_and_get_job(cache_dir):
-    create_job("j1", agent_id="agent-001", manifest_path="default.yaml", cache_dir=cache_dir)
-    data = get_job("j1", cache_dir=cache_dir)
+def test_create_and_get_job():
+    create_job("j1", agent_id="agent-001", manifest_path="default.yaml")
+    data = get_job("j1")
     assert data["job_id"] == "j1"
     assert data["agent_id"] == "agent-001"
     assert data["status"] == JOB_STATUS_PENDING
 
 
-def test_list_jobs_empty(cache_dir):
-    jobs = list_jobs(cache_dir=cache_dir)
+def test_list_jobs_empty():
+    jobs = list_jobs()
     assert jobs == []
 
 
-def test_list_jobs_all(cache_dir):
-    create_job("j1", "agent-1", "default.yaml", cache_dir=cache_dir)
-    create_job("j2", "agent-2", "custom.yaml", cache_dir=cache_dir)
-    jobs = list_jobs(cache_dir=cache_dir)
+def test_list_jobs_all():
+    create_job("j1", "agent-1", "default.yaml")
+    create_job("j2", "agent-2", "custom.yaml")
+    jobs = list_jobs()
     assert len(jobs) == 2
 
 
-def test_list_jobs_running_only(cache_dir):
-    create_job("j1", "agent-1", "default.yaml", cache_dir=cache_dir)
-    create_job("j2", "agent-2", "default.yaml", cache_dir=cache_dir)
-    mark_job_running("j1", cache_dir=cache_dir)
-    mark_job_failed("j2", error="failed", cache_dir=cache_dir)
+def test_list_jobs_running_only():
+    create_job("j1", "agent-1", "default.yaml")
+    create_job("j2", "agent-2", "default.yaml")
+    mark_job_running("j1")
+    mark_job_failed("j2", error="failed")
 
-    running = list_jobs(running_only=True, cache_dir=cache_dir)
+    running = list_jobs(running_only=True)
     assert len(running) == 1
     assert running[0]["job_id"] == "j1"
 
 
-def test_mark_job_running(cache_dir):
-    create_job("j1", "agent-1", "default.yaml", cache_dir=cache_dir)
-    mark_job_running("j1", cache_dir=cache_dir)
-    data = get_job("j1", cache_dir=cache_dir)
+def test_mark_job_running():
+    create_job("j1", "agent-1", "default.yaml")
+    mark_job_running("j1")
+    data = get_job("j1")
     assert data["status"] == JOB_STATUS_RUNNING
 
 
-def test_mark_job_completed(cache_dir):
-    create_job("j1", "agent-1", "default.yaml", cache_dir=cache_dir)
-    mark_job_completed("j1", result={"agent_id": "agent-1", "success": True}, cache_dir=cache_dir)
-    data = get_job("j1", cache_dir=cache_dir)
+def test_mark_job_completed():
+    create_job("j1", "agent-1", "default.yaml")
+    mark_job_completed("j1", result={"agent_id": "agent-1", "success": True})
+    data = get_job("j1")
     assert data["status"] == JOB_STATUS_COMPLETED
     assert data["progress"] == 100
     assert data["result"]["success"] is True
 
 
-def test_mark_job_failed(cache_dir):
-    create_job("j1", "agent-1", "default.yaml", cache_dir=cache_dir)
-    mark_job_failed("j1", error="Docker not available", cache_dir=cache_dir)
-    data = get_job("j1", cache_dir=cache_dir)
+def test_mark_job_failed():
+    create_job("j1", "agent-1", "default.yaml")
+    mark_job_failed("j1", error="Docker not available")
+    data = get_job("j1")
     assert data["status"] == JOB_STATUS_FAILED
     assert data["error"] == "Docker not available"
 
 
-def test_cancel_job(cache_dir):
-    create_job("j1", "agent-1", "default.yaml", cache_dir=cache_dir)
-    result = cancel_job("j1", cache_dir=cache_dir)
+def test_cancel_job():
+    create_job("j1", "agent-1", "default.yaml")
+    result = cancel_job("j1")
     assert result is True
-    data = get_job("j1", cache_dir=cache_dir)
+    data = get_job("j1")
     assert data["status"] == JOB_STATUS_CANCELLED
 
 
-def test_cancel_nonexistent_job(cache_dir):
-    result = cancel_job("no-such-job", cache_dir=cache_dir)
+def test_cancel_nonexistent_job():
+    result = cancel_job("no-such-job")
     assert result is False
 
 
-def test_delete_job(cache_dir):
-    create_job("j1", "agent-1", "default.yaml", cache_dir=cache_dir)
-    deleted = delete_job("j1", cache_dir=cache_dir)
+def test_delete_job():
+    create_job("j1", "agent-1", "default.yaml")
+    deleted = delete_job("j1")
     assert deleted is True
-    data = get_job("j1", cache_dir=cache_dir)
+    data = get_job("j1")
     assert data == {}
 
 
-def test_get_missing_job(cache_dir):
-    data = get_job("nonexistent", cache_dir=cache_dir)
+def test_get_missing_job():
+    data = get_job("nonexistent")
     assert data == {}

--- a/backend/agents/agent_provisioning_team/tests/test_temporal_integration.py
+++ b/backend/agents/agent_provisioning_team/tests/test_temporal_integration.py
@@ -1,4 +1,4 @@
-"""Temporal integration tests for the Agent Provisioning team.
+"""Temporal tests for the Agent Provisioning team.
 
 Covers routing, skip_phases/prior_results plumbing on /resume, the
 PROVISION_THREAD_FALLBACK escape hatch, progress writes from v2
@@ -11,15 +11,10 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 from fastapi.testclient import TestClient
 
 from agent_provisioning_team.api import main as api_main
 from agent_provisioning_team.api.main import app
-
-# Exercises real activity contracts that touch the job store.  Run via the
-# `test-integration` CI job.
-pytestmark = [pytest.mark.integration]
 
 client = TestClient(app)
 


### PR DESCRIPTION
## Summary

- Add autouse `_patched_job_store` fixture to `tests/conftest.py` that routes the team's `_client()` factory through the in-memory `FakeJobServiceClient`, matching the pattern established by blogging, ai_systems_team, and market_research_team
- Remove `@pytest.mark.integration` from `test_job_store.py`, `test_temporal_integration.py`, and `test_api.py` so all 27 tests run in the regular CI suite instead of being skipped
- Remove vestigial `cache_dir` fixture and arguments from `test_job_store.py` (the parameter was accepted but ignored by `_client()`)

## Test plan

- [x] All 27 tests across the three converted files pass (`pytest -v` — 27 passed in 0.95s)
- [x] Full team suite (`test_shared.py` etc.) unaffected — the autouse fixture coexists with `test_shared.py`'s own `mock_job_client` fixture (66 passed)
- [x] No `pytest.mark.integration` remains in the three files
- [ ] CI confirms these tests now run in the regular test job (previously skipped)

Closes #363

---
_Generated by [Claude Code](https://claude.ai/code/session_019VxNV7TZpqtuA8PTTU7tVH)_