### PR TITLE
Strategy Lab: spec/code drift observability — revision histories

### DIFF
--- a/backend/agents/investment_team/models.py
+++ b/backend/agents/investment_team/models.py
@@ -915,6 +915,81 @@ class PaperTradingVerdict(str, Enum):
     NOT_PERFORMANT = "not_performant"
 
 
+# ---------------------------------------------------------------------------
+# Drift-observability models (spec/code revision ledger, gate timeline,
+# rule-implementation coverage)
+# ---------------------------------------------------------------------------
+
+StrategyLabPhase = Literal["design", "design_review", "synthesis", "verification"]
+
+
+class SpecRevision(BaseModel):
+    """One mutation of the strategy spec during a lab cycle.
+
+    Preconditions:
+      - ``before_hash`` / ``after_hash`` are 64-char hex SHA-256 digests
+        produced by ``phases.hash_spec``.
+      - ``before_hash != after_hash`` (no-op mutations are not recorded).
+    Postconditions:
+      - ``diff`` is a unified-diff string of the spec's sorted-key
+        pretty-printed JSON, suitable for human review.
+    """
+
+    phase: StrategyLabPhase
+    agent: str
+    timestamp: str
+    before_hash: str = Field(..., min_length=64, max_length=64)
+    after_hash: str = Field(..., min_length=64, max_length=64)
+    diff: str
+    reason: str
+    gate_failures: List[str] = Field(default_factory=list)
+
+
+class CodeRevision(BaseModel):
+    """One mutation of the strategy code during a lab cycle.
+
+    Preconditions:
+      - ``before_hash`` / ``after_hash`` are 64-char hex SHA-256 digests
+        produced by ``phases.hash_code``.
+      - ``before_hash != after_hash`` (no-op mutations are not recorded).
+    Postconditions:
+      - ``diff`` is a unified-diff string of the raw code text.
+    """
+
+    phase: StrategyLabPhase
+    agent: str
+    timestamp: str
+    before_hash: str = Field(..., min_length=64, max_length=64)
+    after_hash: str = Field(..., min_length=64, max_length=64)
+    diff: str
+    reason: str
+    gate_failures: List[str] = Field(default_factory=list)
+
+
+class GateEvent(BaseModel):
+    """Chronological record of a quality-gate evaluation."""
+
+    phase: str
+    gate_name: str
+    passed: bool
+    severity: Literal["info", "warning", "critical"]
+    details: str
+    timestamp: str
+
+
+class RuleImplementationMap(BaseModel):
+    """Per-rule trade coverage: how many trades exercised each spec rule.
+
+    ``code_line_refs`` is best-effort AST analysis — empty when the
+    generated code cannot be parsed or the rule cannot be located.
+    Each inner list is ``[start_line, end_line]``.
+    """
+
+    rule_id: str
+    code_line_refs: List[List[int]] = Field(default_factory=list)
+    traded_count: int = 0
+
+
 class StrategyLabRecord(BaseModel):
     """Result of one strategy ideation + backtest + analysis (+ optional paper trading) cycle.
 
@@ -996,6 +1071,11 @@ class StrategyLabRecord(BaseModel):
     )
     paper_trading_error: Optional[str] = None
     paper_trading_verdict: Optional[PaperTradingVerdict] = None
+    # Drift-observability ledgers
+    spec_history: List[SpecRevision] = Field(default_factory=list)
+    code_history: List[CodeRevision] = Field(default_factory=list)
+    gate_timeline: List[GateEvent] = Field(default_factory=list)
+    rule_implementation_map: List[RuleImplementationMap] = Field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/scripts/show_drift.py
+++ b/backend/agents/investment_team/scripts/show_drift.py
@@ -1,0 +1,123 @@
+"""Print the spec/code revision history for a Strategy Lab record.
+
+Reads a single ``StrategyLabRecord`` from the job service and displays
+the spec mutation ledger (``spec_history``), code mutation ledger
+(``code_history``), gate timeline summary, and rule-implementation
+coverage map.
+
+Run from ``backend/`` (same directory as ``Makefile``)::
+
+    PYTHONPATH=agents python3 -m investment_team.scripts.show_drift <lab_record_id>
+
+Requires ``JOB_SERVICE_URL`` to be set (same env var as the running API).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any, Dict, List, Optional
+
+
+def _print_spec_history(revisions: List[Dict[str, Any]]) -> None:
+    if not revisions:
+        print("\n  (no spec revisions)")
+        return
+    for i, rev in enumerate(revisions):
+        print(f"\n  [{i}] phase={rev.get('phase')}  agent={rev.get('agent')}")
+        print(f"      reason: {rev.get('reason', '')[:120]}")
+        print(f"      before: {rev.get('before_hash', '')[:16]}...")
+        print(f"      after:  {rev.get('after_hash', '')[:16]}...")
+        if rev.get("gate_failures"):
+            print(f"      gate_failures: {rev['gate_failures']}")
+        diff = rev.get("diff", "")
+        if diff:
+            for line in diff.splitlines()[:20]:
+                print(f"      {line}")
+            if len(diff.splitlines()) > 20:
+                print(f"      ... ({len(diff.splitlines()) - 20} more lines)")
+
+
+def _print_code_history(revisions: List[Dict[str, Any]]) -> None:
+    if not revisions:
+        print("\n  (no code revisions)")
+        return
+    for i, rev in enumerate(revisions):
+        print(f"\n  [{i}] phase={rev.get('phase')}  agent={rev.get('agent')}")
+        print(f"      reason: {rev.get('reason', '')[:120]}")
+        print(f"      before: {rev.get('before_hash', '')[:16]}...")
+        print(f"      after:  {rev.get('after_hash', '')[:16]}...")
+        diff = rev.get("diff", "")
+        if diff:
+            line_count = len(diff.splitlines())
+            print(f"      ({line_count} diff lines)")
+
+
+def _print_gate_timeline(events: List[Dict[str, Any]]) -> None:
+    if not events:
+        print("\n  (no gate events)")
+        return
+    passed = sum(1 for e in events if e.get("passed"))
+    failed = len(events) - passed
+    print(f"\n  {len(events)} gate events: {passed} passed, {failed} failed")
+    for e in events:
+        if not e.get("passed"):
+            mark = "FAIL"
+            print(f"    [{mark}] {e.get('gate_name')} ({e.get('severity')}) — {e.get('details', '')[:80]}")
+
+
+def _print_rule_map(rules: List[Dict[str, Any]]) -> None:
+    if not rules:
+        print("\n  (no rule implementation map)")
+        return
+    for r in rules:
+        traded = r.get("traded_count", 0)
+        refs = r.get("code_line_refs", [])
+        marker = " *** ZERO TRADES" if traded == 0 else ""
+        ref_str = f"  lines={refs}" if refs else ""
+        print(f"    {r.get('rule_id', '?'):30s}  traded={traded}{ref_str}{marker}")
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Show spec/code drift for a Strategy Lab record")
+    parser.add_argument("lab_record_id", help="lab-XXXXXXXX record identifier")
+    args = parser.parse_args(argv)
+
+    try:
+        from job_service_client import JobServiceClient
+    except ImportError:
+        print("ERROR: run from backend/ with PYTHONPATH=agents", file=sys.stderr)
+        sys.exit(1)
+
+    lab_client = JobServiceClient(team="investment_strategy_lab_records")
+    target = None
+    for job in lab_client.list_jobs() or []:
+        payload = job.get("data") or {}
+        if payload.get("lab_record_id") == args.lab_record_id:
+            target = payload
+            break
+
+    if target is None:
+        print(f"Record {args.lab_record_id!r} not found.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"=== Drift Report: {args.lab_record_id} ===")
+    print(f"    strategy_id: {target.get('strategy', {}).get('strategy_id', '?')}")
+    print(f"    is_winning:  {target.get('is_winning')}")
+    print(f"    created_at:  {target.get('created_at')}")
+
+    print("\n── Spec Revisions ──")
+    _print_spec_history(target.get("spec_history", []))
+
+    print("\n── Code Revisions ──")
+    _print_code_history(target.get("code_history", []))
+
+    print("\n── Gate Timeline ──")
+    _print_gate_timeline(target.get("gate_timeline", []))
+
+    print("\n── Rule Implementation Map ──")
+    _print_rule_map(target.get("rule_implementation_map", []))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
+++ b/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
@@ -183,6 +183,236 @@ class _DesignPersistContext:
 
 
 @dataclass
+class _DriftCollector:
+    """Mutable accumulator for spec/code revision history and gate events.
+
+    Threaded through the orchestrator pipeline alongside
+    ``_DesignPersistContext``. Each mutation site calls one of the
+    ``record_*`` helpers; the orchestrator drains the lists into the
+    final ``StrategyLabRecord`` at record-build time.
+
+    Invariants:
+      - ``record_spec_change`` is a no-op when before/after hashes match
+        (no-op mutation). Same for ``record_code_change``.
+    """
+
+    spec_history: list = field(default_factory=list)
+    code_history: list = field(default_factory=list)
+    gate_timeline: list = field(default_factory=list)
+
+    def record_spec_change(
+        self,
+        *,
+        phase: str,
+        agent: str,
+        before_spec: "StrategySpec",
+        after_spec: "StrategySpec",
+        reason: str,
+        gate_failures: Optional[List[str]] = None,
+    ) -> None:
+        """Append a ``SpecRevision`` if the spec actually changed.
+
+        Preconditions:
+          - Both specs are constructed ``StrategySpec`` instances.
+        Postconditions:
+          - If ``hash_spec(before) == hash_spec(after)``, no entry is appended.
+          - Otherwise exactly one ``SpecRevision`` is appended.
+        """
+        from ..models import SpecRevision
+        from .phases import hash_spec
+
+        before_hash = hash_spec(before_spec)
+        after_hash = hash_spec(after_spec)
+        if before_hash == after_hash:
+            return
+
+        diff = _unified_diff_json(before_spec, after_spec)
+        self.spec_history.append(
+            SpecRevision(
+                phase=phase,
+                agent=agent,
+                timestamp=_now_iso(),
+                before_hash=before_hash,
+                after_hash=after_hash,
+                diff=diff,
+                reason=reason,
+                gate_failures=list(gate_failures or []),
+            )
+        )
+
+    def record_code_change(
+        self,
+        *,
+        phase: str,
+        agent: str,
+        before_code: str,
+        after_code: str,
+        reason: str,
+        gate_failures: Optional[List[str]] = None,
+    ) -> None:
+        """Append a ``CodeRevision`` if the code actually changed.
+
+        Preconditions:
+          - ``before_code`` and ``after_code`` are strings (possibly empty).
+        Postconditions:
+          - If ``hash_code(before) == hash_code(after)``, no entry is appended.
+          - Otherwise exactly one ``CodeRevision`` is appended.
+        """
+        from ..models import CodeRevision
+        from .phases import hash_code
+
+        before_hash = hash_code(before_code)
+        after_hash = hash_code(after_code)
+        if before_hash == after_hash:
+            return
+
+        diff = _unified_diff_code(before_code, after_code)
+        self.code_history.append(
+            CodeRevision(
+                phase=phase,
+                agent=agent,
+                timestamp=_now_iso(),
+                before_hash=before_hash,
+                after_hash=after_hash,
+                diff=diff,
+                reason=reason,
+                gate_failures=list(gate_failures or []),
+            )
+        )
+
+    def record_gate(
+        self,
+        *,
+        phase: str,
+        gate_name: str,
+        passed: bool,
+        severity: str,
+        details: str,
+    ) -> None:
+        from ..models import GateEvent
+
+        self.gate_timeline.append(
+            GateEvent(
+                phase=phase,
+                gate_name=gate_name,
+                passed=passed,
+                severity=severity,
+                details=details,
+                timestamp=_now_iso(),
+            )
+        )
+
+
+def _now_iso() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _unified_diff_json(before_spec: "StrategySpec", after_spec: "StrategySpec") -> str:
+    """Unified diff of sorted-key pretty-printed JSON of two specs."""
+    import difflib
+
+    def _canon(spec: "StrategySpec") -> str:
+        d = spec.model_dump(mode="json")
+        d.pop("strategy_code", None)
+        return json.dumps(d, sort_keys=True, indent=2, default=str)
+
+    a = _canon(before_spec).splitlines(keepends=True)
+    b = _canon(after_spec).splitlines(keepends=True)
+    return "".join(difflib.unified_diff(a, b, fromfile="before", tofile="after"))
+
+
+def _unified_diff_code(before: str, after: str) -> str:
+    """Unified diff of raw code strings."""
+    import difflib
+
+    a = (before or "").splitlines(keepends=True)
+    b = (after or "").splitlines(keepends=True)
+    return "".join(difflib.unified_diff(a, b, fromfile="before", tofile="after"))
+
+
+def _build_rule_implementation_map(
+    spec: "StrategySpec",
+    findings: List[Any],
+    code: str,
+) -> list:
+    """Build per-rule trade coverage from alignment findings.
+
+    Preconditions:
+      - ``findings`` is a list of ``AlignmentFinding`` instances (or empty).
+      - ``spec`` has ``entry_rules``, ``exit_rules`` attributes.
+    Postconditions:
+      - Returns a list of ``RuleImplementationMap`` instances, one per
+        known rule ID derived from the spec plus ``"sizing"``.
+      - ``traded_count`` counts distinct trades where ``passed=True``
+        for that ``rule_id``.
+      - ``code_line_refs`` is best-effort AST; empty on parse failure.
+    """
+    from collections import defaultdict
+
+    from ..models import RuleImplementationMap
+
+    rule_ids: List[str] = []
+    for i, _ in enumerate(getattr(spec, "entry_rules", None) or []):
+        rule_ids.append(f"entry[{i}]")
+    for er in getattr(spec, "exit_rules", None) or []:
+        if hasattr(er, "rule_type"):
+            rule_ids.append(f"exit:{er.rule_type}")
+        else:
+            rule_ids.append(f"exit[{len([r for r in rule_ids if r.startswith('exit')])}]")
+    rule_ids.append("sizing")
+
+    passed_counts: Dict[str, int] = defaultdict(int)
+    for f in findings:
+        if f.rule_id and f.passed:
+            passed_counts[f.rule_id] += 1
+
+    all_rule_ids = list(dict.fromkeys(rule_ids))
+    for f in findings:
+        if f.rule_id and f.rule_id not in all_rule_ids:
+            all_rule_ids.append(f.rule_id)
+
+    code_refs = _extract_code_line_refs(code, all_rule_ids)
+
+    return [
+        RuleImplementationMap(
+            rule_id=rid,
+            code_line_refs=code_refs.get(rid, []),
+            traded_count=passed_counts.get(rid, 0),
+        )
+        for rid in all_rule_ids
+    ]
+
+
+def _extract_code_line_refs(code: str, rule_ids: List[str]) -> Dict[str, List[List[int]]]:
+    """Best-effort AST analysis to find code regions matching rule IDs."""
+    import ast
+    import re
+
+    if not code or not code.strip():
+        return {}
+
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return {}
+
+    refs: Dict[str, List[List[int]]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        name_lower = node.name.lower()
+        start = node.lineno
+        end = node.end_lineno or start
+        for rid in rule_ids:
+            tag = rid.replace("[", "").replace("]", "").replace(":", "_").lower()
+            if tag in name_lower or re.search(re.escape(tag), name_lower):
+                refs.setdefault(rid, []).append([start, end])
+    return refs
+
+
+@dataclass
 class _DesignLoopOutcome:
     """Bundle returned by ``_run_design_loop``.
 

--- a/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
+++ b/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
@@ -17,6 +17,7 @@ import json
 import logging
 import math
 import os
+import re
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
@@ -357,21 +358,44 @@ def _build_rule_implementation_map(
     for i, _ in enumerate(getattr(spec, "entry_rules", None) or []):
         rule_ids.append(f"entry[{i}]")
     for er in getattr(spec, "exit_rules", None) or []:
-        if hasattr(er, "rule_type"):
-            rule_ids.append(f"exit:{er.rule_type}")
+        if hasattr(er, "kind"):
+            rule_ids.append(f"exit:{er.kind}")
         else:
             rule_ids.append(f"exit[{len([r for r in rule_ids if r.startswith('exit')])}]")
     rule_ids.append("sizing")
 
+    # Alignment findings use indexed/suffixed rule IDs (e.g.
+    # "exit:signal_exit[0]", "exit:stop_loss:trailing") while the spec
+    # seeds canonical keys ("exit:signal_exit", "exit:stop_loss").
+    # Normalise finding IDs to their canonical form before counting.
+    canonical_set = set(rule_ids)
+
+    def _normalise(rid: str) -> str:
+        if rid in canonical_set:
+            return rid
+        # Strip trailing "[N]" index → "exit:signal_exit[0]" → "exit:signal_exit"
+        base = re.sub(r"\[\d+\]$", "", rid)
+        if base in canonical_set:
+            return base
+        # Strip ":suffix" after the rule type → "exit:stop_loss:trailing" → "exit:stop_loss"
+        parts = base.split(":")
+        if len(parts) >= 3:
+            candidate = ":".join(parts[:2])
+            if candidate in canonical_set:
+                return candidate
+        return rid
+
     passed_counts: Dict[str, int] = defaultdict(int)
     for f in findings:
         if f.rule_id and f.passed:
-            passed_counts[f.rule_id] += 1
+            passed_counts[_normalise(f.rule_id)] += 1
 
     all_rule_ids = list(dict.fromkeys(rule_ids))
     for f in findings:
-        if f.rule_id and f.rule_id not in all_rule_ids:
-            all_rule_ids.append(f.rule_id)
+        if f.rule_id:
+            norm = _normalise(f.rule_id)
+            if norm not in all_rule_ids and f.rule_id not in all_rule_ids:
+                all_rule_ids.append(f.rule_id)
 
     code_refs = _extract_code_line_refs(code, all_rule_ids)
 

--- a/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
+++ b/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
@@ -372,16 +372,14 @@ def _build_rule_implementation_map(
     # ("exit:stop_loss") or suffixed ("exit:stop_loss:trailing") IDs.
     # Normalise to the canonical form before counting.
     canonical_set = set(rule_ids)
-    # Map unindexed kind to [0] instance when only one exists.
-    _kind_to_sole: Dict[str, str] = {}
+    # Map unindexed kind → first ([0]) canonical instance.
+    _kind_to_first: Dict[str, str] = {}
     for rid in rule_ids:
         m = re.match(r"^(exit:\w+)\[(\d+)\]$", rid)
         if m:
             base_kind = m.group(1)
-            if base_kind not in _kind_to_sole:
-                _kind_to_sole[base_kind] = rid
-            else:
-                _kind_to_sole[base_kind] = ""  # multiple — no sole target
+            if base_kind not in _kind_to_first:
+                _kind_to_first[base_kind] = rid
 
     def _normalise(rid: str) -> str:
         if rid in canonical_set:
@@ -396,10 +394,10 @@ def _build_rule_implementation_map(
         indexed = re.sub(r"\[\d+\]$", "", rid)
         if indexed != rid and indexed in canonical_set:
             return indexed
-        # Unindexed form with a single spec instance → sole canonical key
-        sole = _kind_to_sole.get(rid)
-        if sole:
-            return sole
+        # Unindexed form → first ([0]) canonical instance as best-effort
+        first = _kind_to_first.get(rid)
+        if first:
+            return first
         return rid
 
     passed_trades: Dict[str, set] = defaultdict(set)

--- a/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
+++ b/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
@@ -358,11 +358,18 @@ def _build_rule_implementation_map(
     for i, _ in enumerate(getattr(spec, "entry_rules", None) or []):
         rule_ids.append(f"entry[{i}]")
     kind_counts: Dict[str, int] = defaultdict(int)
+    # Map suffixed finding IDs to the specific rule instance based on
+    # distinguishing attributes (e.g. StopLossRule.basis).
+    _suffix_to_instance: Dict[str, str] = {}
     for er in getattr(spec, "exit_rules", None) or []:
         if hasattr(er, "kind"):
             idx = kind_counts[er.kind]
             kind_counts[er.kind] += 1
-            rule_ids.append(f"exit:{er.kind}[{idx}]")
+            canonical = f"exit:{er.kind}[{idx}]"
+            rule_ids.append(canonical)
+            basis = getattr(er, "basis", None)
+            if basis:
+                _suffix_to_instance[f"exit:{er.kind}:{basis}"] = canonical
         else:
             rule_ids.append(f"exit[{len([r for r in rule_ids if r.startswith('exit')])}]")
     rule_ids.append("sizing")
@@ -384,18 +391,23 @@ def _build_rule_implementation_map(
     def _normalise(rid: str) -> str:
         if rid in canonical_set:
             return rid
-        # Strip ":suffix" first → "exit:stop_loss:trailing" → "exit:stop_loss"
+        # Suffixed form with a known instance mapping
+        # e.g. "exit:stop_loss:trailing_high" → "exit:stop_loss[1]"
+        if rid in _suffix_to_instance:
+            return _suffix_to_instance[rid]
+        # Strip ":suffix" → "exit:stop_loss:trailing" → "exit:stop_loss"
         parts = rid.split(":")
+        base = rid
         if len(parts) >= 3:
-            rid = ":".join(parts[:2])
-            if rid in canonical_set:
-                return rid
-        # Try appending "[N]" index → "exit:stop_loss" → "exit:stop_loss[0]"
-        indexed = re.sub(r"\[\d+\]$", "", rid)
-        if indexed != rid and indexed in canonical_set:
-            return indexed
+            base = ":".join(parts[:2])
+            if base in canonical_set:
+                return base
+        # Try stripping "[N]" index → already-indexed non-canonical
+        stripped = re.sub(r"\[\d+\]$", "", rid)
+        if stripped != rid and stripped in canonical_set:
+            return stripped
         # Unindexed form → first ([0]) canonical instance as best-effort
-        first = _kind_to_first.get(rid)
+        first = _kind_to_first.get(base)
         if first:
             return first
         return rid

--- a/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
+++ b/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
@@ -357,37 +357,54 @@ def _build_rule_implementation_map(
     rule_ids: List[str] = []
     for i, _ in enumerate(getattr(spec, "entry_rules", None) or []):
         rule_ids.append(f"entry[{i}]")
+    kind_counts: Dict[str, int] = defaultdict(int)
     for er in getattr(spec, "exit_rules", None) or []:
         if hasattr(er, "kind"):
-            rule_ids.append(f"exit:{er.kind}")
+            idx = kind_counts[er.kind]
+            kind_counts[er.kind] += 1
+            rule_ids.append(f"exit:{er.kind}[{idx}]")
         else:
             rule_ids.append(f"exit[{len([r for r in rule_ids if r.startswith('exit')])}]")
     rule_ids.append("sizing")
 
-    # Alignment findings use indexed/suffixed rule IDs (e.g.
-    # "exit:signal_exit[0]", "exit:stop_loss:trailing") while the spec
-    # seeds canonical keys ("exit:signal_exit", "exit:stop_loss").
-    # Normalise finding IDs to their canonical form before counting.
+    # Canonical keys are now per-instance (e.g. "exit:stop_loss[0]",
+    # "exit:signal_exit[1]"). Alignment findings may use unindexed
+    # ("exit:stop_loss") or suffixed ("exit:stop_loss:trailing") IDs.
+    # Normalise to the canonical form before counting.
     canonical_set = set(rule_ids)
+    # Map unindexed kind to [0] instance when only one exists.
+    _kind_to_sole: Dict[str, str] = {}
+    for rid in rule_ids:
+        m = re.match(r"^(exit:\w+)\[(\d+)\]$", rid)
+        if m:
+            base_kind = m.group(1)
+            if base_kind not in _kind_to_sole:
+                _kind_to_sole[base_kind] = rid
+            else:
+                _kind_to_sole[base_kind] = ""  # multiple — no sole target
 
     def _normalise(rid: str) -> str:
         if rid in canonical_set:
             return rid
-        # Strip trailing "[N]" index → "exit:signal_exit[0]" → "exit:signal_exit"
-        base = re.sub(r"\[\d+\]$", "", rid)
-        if base in canonical_set:
-            return base
-        # Strip ":suffix" after the rule type → "exit:stop_loss:trailing" → "exit:stop_loss"
-        parts = base.split(":")
+        # Strip ":suffix" first → "exit:stop_loss:trailing" → "exit:stop_loss"
+        parts = rid.split(":")
         if len(parts) >= 3:
-            candidate = ":".join(parts[:2])
-            if candidate in canonical_set:
-                return candidate
+            rid = ":".join(parts[:2])
+            if rid in canonical_set:
+                return rid
+        # Try appending "[N]" index → "exit:stop_loss" → "exit:stop_loss[0]"
+        indexed = re.sub(r"\[\d+\]$", "", rid)
+        if indexed != rid and indexed in canonical_set:
+            return indexed
+        # Unindexed form with a single spec instance → sole canonical key
+        sole = _kind_to_sole.get(rid)
+        if sole:
+            return sole
         return rid
 
     passed_trades: Dict[str, set] = defaultdict(set)
     for f in findings:
-        if f.rule_id and f.passed:
+        if f.rule_id and f.passed and f.computed_value is not None:
             passed_trades[_normalise(f.rule_id)].add(f.trade_num)
 
     all_rule_ids = list(dict.fromkeys(rule_ids))

--- a/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
+++ b/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
@@ -385,17 +385,12 @@ def _build_rule_implementation_map(
                 return candidate
         return rid
 
-    passed_counts: Dict[str, int] = defaultdict(int)
+    passed_trades: Dict[str, set] = defaultdict(set)
     for f in findings:
         if f.rule_id and f.passed:
-            passed_counts[_normalise(f.rule_id)] += 1
+            passed_trades[_normalise(f.rule_id)].add(f.trade_num)
 
     all_rule_ids = list(dict.fromkeys(rule_ids))
-    for f in findings:
-        if f.rule_id:
-            norm = _normalise(f.rule_id)
-            if norm not in all_rule_ids and f.rule_id not in all_rule_ids:
-                all_rule_ids.append(f.rule_id)
 
     code_refs = _extract_code_line_refs(code, all_rule_ids)
 
@@ -403,7 +398,7 @@ def _build_rule_implementation_map(
         RuleImplementationMap(
             rule_id=rid,
             code_line_refs=code_refs.get(rid, []),
-            traded_count=passed_counts.get(rid, 0),
+            traded_count=len(passed_trades.get(rid, set())),
         )
         for rid in all_rule_ids
     ]

--- a/backend/agents/investment_team/strategy_lab/exceptions.py
+++ b/backend/agents/investment_team/strategy_lab/exceptions.py
@@ -7,7 +7,7 @@ other in via a circular import.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
     from ..models import StrategySpec
@@ -27,6 +27,10 @@ class SpecImplementabilityError(Exception):
     re-entry exhaustion without re-running ideation. Raisers MUST set
     both — ``run_cycle`` relies on them when building the
     ``failed: spec_unimplementable`` record.
+
+    ``drift_collector`` (optional) carries the accumulated spec/code
+    revision history so the short-circuit record preserves drift
+    observability even on failure paths.
     """
 
     def __init__(
@@ -36,9 +40,11 @@ class SpecImplementabilityError(Exception):
         failure_phase: Optional[str],
         last_spec: "StrategySpec",
         last_code: str,
+        drift_collector: Optional[Any] = None,
     ) -> None:
         super().__init__(evidence)
         self.evidence = evidence
         self.failure_phase = failure_phase
         self.last_spec = last_spec
         self.last_code = last_code
+        self.drift_collector = drift_collector

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -595,6 +595,7 @@ class StrategyLabOrchestrator:
         # multiple-testing burden that DSR deflation corrects for.
         phase_back_count: int = 0
         drift_collector = _DriftCollector()
+        cumulative_gate_results: List[QualityGateResult] = []
         for design_attempt in range(MAX_DESIGN_REENTRIES + 1):
             try:
                 return self._run_design_attempt(
@@ -607,6 +608,7 @@ class StrategyLabOrchestrator:
                     design_attempt=design_attempt,
                     phase_back_count=phase_back_count,
                     drift_collector=drift_collector,
+                    cumulative_gate_results=cumulative_gate_results,
                 )
             except SpecImplementabilityError as exc:
                 last_evidence = exc.evidence
@@ -649,7 +651,7 @@ class StrategyLabOrchestrator:
             original_spec=last_spec,
             original_code=last_code,
             rationale="",
-            all_gate_results=[],
+            all_gate_results=cumulative_gate_results,
             refinement_attempts=[],
             short_circuit_status="failed: spec_unimplementable",
             short_circuit_reason=(
@@ -2348,6 +2350,7 @@ class StrategyLabOrchestrator:
         design_attempt: int = 0,
         phase_back_count: int = 0,
         drift_collector: Optional[_DriftCollector] = None,
+        cumulative_gate_results: Optional[List[QualityGateResult]] = None,
     ) -> StrategyLabRecord:
         """One design + refinement attempt. May raise
         ``SpecImplementabilityError`` to signal a need to re-enter the
@@ -2366,7 +2369,7 @@ class StrategyLabOrchestrator:
         # Reset per-attempt counters so a re-entry starts fresh.
         self._consecutive_spec_mutation_rounds = {}
 
-        all_gate_results: List[QualityGateResult] = []
+        all_gate_results: List[QualityGateResult] = cumulative_gate_results if cumulative_gate_results is not None else []
         refinement_attempts: List[str] = []
         zero_trade_attempts: List[str] = []
         if drift_collector is None:

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -594,6 +594,7 @@ class StrategyLabOrchestrator:
         # work on the same evaluation window and so contributes to the
         # multiple-testing burden that DSR deflation corrects for.
         phase_back_count: int = 0
+        last_drift_collector: Optional[_DriftCollector] = None
         for design_attempt in range(MAX_DESIGN_REENTRIES + 1):
             try:
                 return self._run_design_attempt(
@@ -611,6 +612,7 @@ class StrategyLabOrchestrator:
                 last_spec = exc.last_spec
                 last_code = exc.last_code
                 last_failure_phase = exc.failure_phase
+                last_drift_collector = exc.drift_collector
                 phase_back_count += 1
                 self.convergence_tracker.increment_trials(1)
                 if design_attempt >= MAX_DESIGN_REENTRIES:
@@ -656,6 +658,7 @@ class StrategyLabOrchestrator:
             ),
             emit=emit,
             phase_back_count=phase_back_count,
+            drift_collector=last_drift_collector,
         )
 
     def _run_design_loop(
@@ -1612,7 +1615,11 @@ class StrategyLabOrchestrator:
             },
         )
         proposed_code = report.proposed_code
-        proposed_spec = self._apply_updates(spec, {}, proposed_code)
+        try:
+            proposed_spec = self._apply_updates(spec, {}, proposed_code)
+        except SpecImplementabilityError as exc:
+            exc.drift_collector = drift_collector
+            raise
         change_summary = report.changes_made or "alignment fix"
 
         # Re-validate code safety on the proposed code — alignment runs
@@ -2803,7 +2810,11 @@ class StrategyLabOrchestrator:
             metrics,
             refinement_attempts,
         )
-        new_spec = self._apply_updates(spec, updates, new_code, failure_phase=failure_phase)
+        try:
+            new_spec = self._apply_updates(spec, updates, new_code, failure_phase=failure_phase)
+        except SpecImplementabilityError as exc:
+            exc.drift_collector = drift_collector
+            raise
         changes = updates.get("changes_made", default_change_label)
         refinement_attempts.append(changes)
         if drift_collector is not None:

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -2282,7 +2282,7 @@ class StrategyLabOrchestrator:
                 passed=g.passed,
                 severity=g.severity,
                 details=g.details,
-                timestamp=now_iso,
+                timestamp=g.evaluated_at,
             )
             for g in all_gate_results
         ]
@@ -3084,7 +3084,7 @@ class StrategyLabOrchestrator:
                 passed=g.passed,
                 severity=g.severity,
                 details=g.details,
-                timestamp=now_iso,
+                timestamp=g.evaluated_at,
             )
             for g in all_gate_results
         ]

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -37,6 +37,7 @@ from ..models import (
     BacktestRecord,
     BacktestResult,
     DataProvenance,
+    GateEvent,
     StrategyLabRecord,
     StrategySpec,
     TradeRecord,
@@ -668,6 +669,7 @@ class StrategyLabOrchestrator:
         all_gate_results: List[QualityGateResult],
         emit: PhaseCallback,
         design_attempt: int = 0,
+        drift_collector: Optional[_DriftCollector] = None,
     ) -> _DesignLoopOutcome:
         """Drive the bounded design ↔ design-review loop.
 
@@ -794,10 +796,19 @@ class StrategyLabOrchestrator:
                 # will short-circuit using the existing critique history.
                 break
 
+            prev_spec = spec.model_copy(deep=True)
             strategy_dict, rationale = self.design_agent.revise(
                 spec, critique, prior_critiques=critique_history
             )
             spec = self._build_spec_from_dict(strategy_dict, strategy_id=strategy_id)
+            if drift_collector is not None:
+                drift_collector.record_spec_change(
+                    phase="design_review",
+                    agent="DesignAgent",
+                    before_spec=prev_spec,
+                    after_spec=spec,
+                    reason=critique.rationale if hasattr(critique, "rationale") else str(critique),
+                )
 
         return _DesignLoopOutcome(
             spec=spec,
@@ -853,6 +864,7 @@ class StrategyLabOrchestrator:
         refinement_attempts: List[Dict[str, Any]],
         emit: PhaseCallback,
         phase_back_count: int = 0,
+        drift_collector: Optional[_DriftCollector] = None,
     ) -> Optional[StrategyLabRecord]:
         """Run spec validation before the refinement loop.
 
@@ -915,6 +927,7 @@ class StrategyLabOrchestrator:
             ),
             emit=emit,
             phase_back_count=phase_back_count,
+            drift_collector=drift_collector,
         )
 
     def _run_synthesis_loop(
@@ -927,6 +940,7 @@ class StrategyLabOrchestrator:
         refinement_attempts: List[str],
         zero_trade_attempts: List[str],
         emit: PhaseCallback,
+        drift_collector: Optional[_DriftCollector] = None,
     ) -> _SynthesisLoopOutcome:
         """Run up to ``MAX_CODE_REFINEMENT_ROUNDS`` of (validate → fetch →
         execute → trade-collect → evaluate), refining ``spec``/``code``
@@ -1031,6 +1045,7 @@ class StrategyLabOrchestrator:
                     round_num=round_num,
                     default_change_label="validation fix",
                     emit=emit,
+                    drift_collector=drift_collector,
                 )
                 if exhausted:
                     max_rounds_exhausted = True
@@ -1111,6 +1126,7 @@ class StrategyLabOrchestrator:
                     round_num=round_num,
                     default_change_label="execution fix",
                     emit=emit,
+                    drift_collector=drift_collector,
                 )
                 if exhausted:
                     max_rounds_exhausted = True
@@ -1180,6 +1196,7 @@ class StrategyLabOrchestrator:
                     zero_trade_attempts=zero_trade_attempts,
                     round_num=round_num,
                     emit=emit,
+                    drift_collector=drift_collector,
                 )
                 spec, code = recovery.spec, recovery.code
                 trades, metrics = recovery.trades, recovery.metrics
@@ -1234,6 +1251,7 @@ class StrategyLabOrchestrator:
         zero_trade_attempts: List[str],
         round_num: int,
         emit: PhaseCallback,
+        drift_collector: Optional[_DriftCollector] = None,
     ) -> _AnomalyRecoveryOutcome:
         """Recover from critical backtest anomalies in the evaluation phase.
 
@@ -1295,6 +1313,22 @@ class StrategyLabOrchestrator:
                     if zt_outcome.changes_made
                     else "zero-trade repair"
                 )
+                if drift_collector is not None:
+                    zt_reason = zt_outcome.changes_made or "zero-trade repair"
+                    drift_collector.record_spec_change(
+                        phase="verification",
+                        agent="ZeroTradeRepairer",
+                        before_spec=spec,
+                        after_spec=zt_outcome.new_spec,
+                        reason=zt_reason,
+                    )
+                    drift_collector.record_code_change(
+                        phase="verification",
+                        agent="ZeroTradeRepairer",
+                        before_code=code,
+                        after_code=zt_outcome.new_code,
+                        reason=zt_reason,
+                    )
                 emit(
                     "coding",
                     {
@@ -1325,6 +1359,7 @@ class StrategyLabOrchestrator:
             round_num=round_num,
             default_change_label="anomaly fix",
             emit=emit,
+            drift_collector=drift_collector,
         )
         return _AnomalyRecoveryOutcome(
             spec=new_spec,
@@ -1347,6 +1382,7 @@ class StrategyLabOrchestrator:
         execution_succeeded: bool,
         all_gate_results: List[QualityGateResult],
         emit: PhaseCallback,
+        drift_collector: Optional[_DriftCollector] = None,
     ) -> _AlignmentLoopOutcome:
         """Run the trade-alignment audit loop after the synthesis loop settles.
 
@@ -1401,6 +1437,7 @@ class StrategyLabOrchestrator:
                 alignment_attempts=alignment_attempts,
                 alignment_reports=alignment_reports,
                 emit=emit,
+                drift_collector=drift_collector,
             )
             spec, code = round_outcome.spec, round_outcome.code
             trades, metrics = round_outcome.trades, round_outcome.metrics
@@ -1431,6 +1468,7 @@ class StrategyLabOrchestrator:
         alignment_attempts: List[str],
         alignment_reports: List[TradeAlignmentReport],
         emit: PhaseCallback,
+        drift_collector: Optional[_DriftCollector] = None,
     ) -> _AlignmentRoundOutcome:
         """One iteration of ``_run_trade_alignment_loop``.
 
@@ -1693,6 +1731,21 @@ class StrategyLabOrchestrator:
 
         # All gates passed — commit the proposal as the new known-good state.
         alignment_attempts.append(change_summary)
+        if drift_collector is not None:
+            drift_collector.record_code_change(
+                phase="verification",
+                agent="TradeAlignmentAgent",
+                before_code=code,
+                after_code=proposed_code,
+                reason=change_summary,
+            )
+            drift_collector.record_spec_change(
+                phase="verification",
+                agent="TradeAlignmentAgent",
+                before_spec=spec,
+                after_spec=proposed_spec,
+                reason=change_summary,
+            )
         emit(
             "aligning",
             {
@@ -2156,6 +2209,7 @@ class StrategyLabOrchestrator:
         design_context: Optional[_DesignPersistContext] = None,
         alignment_findings: Optional[List[AlignmentFinding]] = None,
         phase_back_count: int = 0,
+        drift_collector: Optional[_DriftCollector] = None,
     ) -> StrategyLabRecord:
         """Build the final ``StrategyLabRecord`` from a settled cycle.
 
@@ -2220,6 +2274,21 @@ class StrategyLabOrchestrator:
         )
 
         design_context = design_context or _DesignPersistContext()
+        dc = drift_collector or _DriftCollector()
+        gate_timeline = dc.gate_timeline + [
+            GateEvent(
+                phase=g.phase,
+                gate_name=g.gate_name,
+                passed=g.passed,
+                severity=g.severity,
+                details=g.details,
+                timestamp=now_iso,
+            )
+            for g in all_gate_results
+        ]
+        rule_impl_map = _build_rule_implementation_map(
+            spec, list(alignment_findings or []), code
+        )
         lab_record_id = f"lab-{uuid.uuid4().hex[:8]}"
         record = StrategyLabRecord(
             lab_record_id=lab_record_id,
@@ -2237,6 +2306,10 @@ class StrategyLabOrchestrator:
             original_spec=original_spec,
             original_code=original_code,
             spec_implementability_phase_backs=phase_back_count,
+            spec_history=list(dc.spec_history),
+            code_history=list(dc.code_history),
+            gate_timeline=gate_timeline,
+            rule_implementation_map=rule_impl_map,
         )
 
         self.convergence_tracker.record(spec, all_gate_results)
@@ -2288,6 +2361,7 @@ class StrategyLabOrchestrator:
         all_gate_results: List[QualityGateResult] = []
         refinement_attempts: List[str] = []
         zero_trade_attempts: List[str] = []
+        drift_collector = _DriftCollector()
 
         # ── Phase 1: DESIGN + REVIEW LOOP ──────────────────────────────
         design_outcome = self._run_design_loop(
@@ -2299,6 +2373,7 @@ class StrategyLabOrchestrator:
             all_gate_results=all_gate_results,
             emit=emit,
             design_attempt=design_attempt,
+            drift_collector=drift_collector,
         )
         spec = design_outcome.spec
         rationale = design_outcome.rationale
@@ -2332,6 +2407,7 @@ class StrategyLabOrchestrator:
                 emit=emit,
                 design_context=design_context,
                 phase_back_count=phase_back_count,
+                drift_collector=drift_collector,
             )
 
         # ═══ Phase 2 → 3 transition: DESIGN_REVIEW → CODE_SYNTHESIS ═══
@@ -2394,7 +2470,16 @@ class StrategyLabOrchestrator:
                     emit=emit,
                     design_context=design_context,
                     phase_back_count=phase_back_count,
+                    drift_collector=drift_collector,
                 )
+
+        drift_collector.record_code_change(
+            phase="synthesis",
+            agent="compiler" if not spec.requires_custom_code else "CodeSynthesisAgent",
+            before_code="",
+            after_code=code,
+            reason="initial code synthesis",
+        )
 
         spec.strategy_code = code
         # ``original_spec`` / ``original_code`` are snapshotted after the
@@ -2451,6 +2536,7 @@ class StrategyLabOrchestrator:
             refinement_attempts=refinement_attempts,
             emit=emit,
             phase_back_count=phase_back_count,
+            drift_collector=drift_collector,
         )
         if pre_synthesis is not None:
             return pre_synthesis
@@ -2471,6 +2557,7 @@ class StrategyLabOrchestrator:
             refinement_attempts=refinement_attempts,
             zero_trade_attempts=zero_trade_attempts,
             emit=emit,
+            drift_collector=drift_collector,
         )
         spec = synthesis.spec
         code = synthesis.code
@@ -2514,6 +2601,7 @@ class StrategyLabOrchestrator:
             execution_succeeded=execution_succeeded,
             all_gate_results=all_gate_results,
             emit=emit,
+            drift_collector=drift_collector,
         )
         spec = alignment_outcome.spec
         code = alignment_outcome.code
@@ -2626,6 +2714,7 @@ class StrategyLabOrchestrator:
             design_context=design_context,
             alignment_findings=alignment_findings,
             phase_back_count=phase_back_count,
+            drift_collector=drift_collector,
         )
 
     # ------------------------------------------------------------------
@@ -2668,6 +2757,7 @@ class StrategyLabOrchestrator:
         default_change_label: str,
         emit: PhaseCallback,
         refine_label: Optional[str] = None,
+        drift_collector: Optional[_DriftCollector] = None,
     ) -> tuple[StrategySpec, str, bool]:
         """Apply one refinement attempt or exhaust the round budget.
 
@@ -2716,6 +2806,21 @@ class StrategyLabOrchestrator:
         new_spec = self._apply_updates(spec, updates, new_code, failure_phase=failure_phase)
         changes = updates.get("changes_made", default_change_label)
         refinement_attempts.append(changes)
+        if drift_collector is not None:
+            drift_collector.record_code_change(
+                phase="synthesis",
+                agent="RefinementAgent",
+                before_code=code,
+                after_code=new_code,
+                reason=changes,
+            )
+            drift_collector.record_spec_change(
+                phase="synthesis",
+                agent="RefinementAgent",
+                before_spec=spec,
+                after_spec=new_spec,
+                reason=changes,
+            )
         emit(
             "coding",
             {
@@ -2937,23 +3042,18 @@ class StrategyLabOrchestrator:
         emit: PhaseCallback,
         design_context: Optional[_DesignPersistContext] = None,
         phase_back_count: int = 0,
+        drift_collector: Optional[_DriftCollector] = None,
     ) -> StrategyLabRecord:
         """Persist a failed cycle that exited before code execution.
 
-        Used by the pre-synthesis spec gate (#547 item 1) so that
-        critical spec failures short-circuit without ever running
-        ``run_strategy_code`` or fetching market data. The record still
-        flows through ``convergence_tracker`` so failed specs influence
-        diversity directives on the next cycle.
+        Used by the pre-synthesis spec gate so that critical spec failures
+        short-circuit without ever running ``run_strategy_code`` or
+        fetching market data. The record still flows through
+        ``convergence_tracker`` so failed specs influence diversity
+        directives on the next cycle.
         """
         now_iso = datetime.now(timezone.utc).isoformat()
 
-        # Mirror the short-circuit cause onto ``acceptance_reason`` so the
-        # persisted record self-documents — consistent with the Gap 4/8/7/9
-        # audit-trail messages set on the main publication path (#529).
-        # ``short_circuit_status`` carries a ``"failed: <cause>"`` prefix at
-        # every current call site; strip it so the resulting field reads
-        # ``"publication_disabled: <cause>"``.
         short_circuit_metrics = compute_metrics(
             [], config.initial_capital, config.start_date, config.end_date
         )
@@ -2976,6 +3076,18 @@ class StrategyLabOrchestrator:
         )
 
         design_context = design_context or _DesignPersistContext()
+        dc = drift_collector or _DriftCollector()
+        gate_timeline = dc.gate_timeline + [
+            GateEvent(
+                phase=g.phase,
+                gate_name=g.gate_name,
+                passed=g.passed,
+                severity=g.severity,
+                details=g.details,
+                timestamp=now_iso,
+            )
+            for g in all_gate_results
+        ]
         lab_record_id = f"lab-{uuid.uuid4().hex[:8]}"
         record = StrategyLabRecord(
             lab_record_id=lab_record_id,
@@ -2993,6 +3105,9 @@ class StrategyLabOrchestrator:
             original_spec=original_spec,
             original_code=original_code,
             spec_implementability_phase_backs=phase_back_count,
+            spec_history=list(dc.spec_history),
+            code_history=list(dc.code_history),
+            gate_timeline=gate_timeline,
         )
 
         self.convergence_tracker.record(spec, all_gate_results)
@@ -3323,10 +3438,12 @@ from ._orchestrator_helpers import (  # noqa: E402  — keep at file end
     _AlignmentRoundOutcome,
     _AnomalyRecoveryOutcome,
     _apply_veto_to_acceptance_reason,
+    _build_rule_implementation_map,
     _closes_to_equity,
     _daily_returns_from_trades,
     _DesignLoopOutcome,
     _DesignPersistContext,
+    _DriftCollector,
     _equity_to_returns,
     _format_execution_diagnostics,
     _MarketDataFetch,

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -594,7 +594,7 @@ class StrategyLabOrchestrator:
         # work on the same evaluation window and so contributes to the
         # multiple-testing burden that DSR deflation corrects for.
         phase_back_count: int = 0
-        last_drift_collector: Optional[_DriftCollector] = None
+        drift_collector = _DriftCollector()
         for design_attempt in range(MAX_DESIGN_REENTRIES + 1):
             try:
                 return self._run_design_attempt(
@@ -606,13 +606,13 @@ class StrategyLabOrchestrator:
                     directives=directives,
                     design_attempt=design_attempt,
                     phase_back_count=phase_back_count,
+                    drift_collector=drift_collector,
                 )
             except SpecImplementabilityError as exc:
                 last_evidence = exc.evidence
                 last_spec = exc.last_spec
                 last_code = exc.last_code
                 last_failure_phase = exc.failure_phase
-                last_drift_collector = exc.drift_collector
                 phase_back_count += 1
                 self.convergence_tracker.increment_trials(1)
                 if design_attempt >= MAX_DESIGN_REENTRIES:
@@ -658,7 +658,7 @@ class StrategyLabOrchestrator:
             ),
             emit=emit,
             phase_back_count=phase_back_count,
-            drift_collector=last_drift_collector,
+            drift_collector=drift_collector,
         )
 
     def _run_design_loop(
@@ -2347,6 +2347,7 @@ class StrategyLabOrchestrator:
         directives: List[str],
         design_attempt: int = 0,
         phase_back_count: int = 0,
+        drift_collector: Optional[_DriftCollector] = None,
     ) -> StrategyLabRecord:
         """One design + refinement attempt. May raise
         ``SpecImplementabilityError`` to signal a need to re-enter the
@@ -2368,7 +2369,8 @@ class StrategyLabOrchestrator:
         all_gate_results: List[QualityGateResult] = []
         refinement_attempts: List[str] = []
         zero_trade_attempts: List[str] = []
-        drift_collector = _DriftCollector()
+        if drift_collector is None:
+            drift_collector = _DriftCollector()
 
         # ── Phase 1: DESIGN + REVIEW LOOP ──────────────────────────────
         design_outcome = self._run_design_loop(

--- a/backend/agents/investment_team/strategy_lab/quality_gates/models.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/models.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from typing import ClassVar, Iterator, Literal, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 StrategyLabPhase = Literal["design", "design_review", "synthesis", "verification"]
 
@@ -28,6 +29,7 @@ class QualityGateResult(BaseModel):
     phase: StrategyLabPhase
     refinement_round: int = 0
     rule_id: Optional[str] = None
+    evaluated_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
 
 
 class GateResultsMixin:

--- a/backend/agents/investment_team/tests/test_show_drift_script.py
+++ b/backend/agents/investment_team/tests/test_show_drift_script.py
@@ -1,0 +1,120 @@
+"""Tests for the show_drift CLI script."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+from unittest import mock
+
+import pytest
+
+
+def _synthetic_record() -> Dict[str, Any]:
+    return {
+        "lab_record_id": "lab-abc123",
+        "strategy": {"strategy_id": "strat-1"},
+        "is_winning": True,
+        "created_at": "2024-01-01T00:00:00+00:00",
+        "spec_history": [
+            {
+                "phase": "design_review",
+                "agent": "DesignAgent",
+                "timestamp": "2024-01-01T00:00:01+00:00",
+                "before_hash": "a" * 64,
+                "after_hash": "b" * 64,
+                "diff": "--- before\n+++ after\n-old\n+new\n",
+                "reason": "revised hypothesis",
+                "gate_failures": [],
+            },
+        ],
+        "code_history": [
+            {
+                "phase": "synthesis",
+                "agent": "compiler",
+                "timestamp": "2024-01-01T00:00:02+00:00",
+                "before_hash": "c" * 64,
+                "after_hash": "d" * 64,
+                "diff": "--- before\n+++ after\n",
+                "reason": "initial code synthesis",
+                "gate_failures": [],
+            },
+        ],
+        "gate_timeline": [
+            {
+                "phase": "design",
+                "gate_name": "spec_readiness",
+                "passed": True,
+                "severity": "info",
+                "details": "ok",
+                "timestamp": "2024-01-01T00:00:00+00:00",
+            },
+        ],
+        "rule_implementation_map": [
+            {"rule_id": "entry[0]", "code_line_refs": [], "traded_count": 5},
+            {"rule_id": "sizing", "code_line_refs": [], "traded_count": 0},
+        ],
+    }
+
+
+class TestShowDrift:
+    def test_prints_spec_diff(self, capsys: pytest.CaptureFixture[str]):
+        from investment_team.scripts.show_drift import (
+            _print_spec_history,
+        )
+
+        record = _synthetic_record()
+        _print_spec_history(record["spec_history"])
+        captured = capsys.readouterr().out
+        assert "DesignAgent" in captured
+        assert "revised hypothesis" in captured
+
+    def test_prints_zero_trade_marker(self, capsys: pytest.CaptureFixture[str]):
+        from investment_team.scripts.show_drift import _print_rule_map
+
+        record = _synthetic_record()
+        _print_rule_map(record["rule_implementation_map"])
+        captured = capsys.readouterr().out
+        assert "ZERO TRADES" in captured
+        assert "entry[0]" in captured
+
+    def test_main_record_not_found(self):
+        from investment_team.scripts.show_drift import main
+
+        mock_client = mock.MagicMock()
+        mock_client.list_jobs.return_value = []
+
+        with mock.patch("job_service_client.JobServiceClient", return_value=mock_client):
+            with pytest.raises(SystemExit) as exc_info:
+                main(["lab-nonexistent"])
+            assert exc_info.value.code == 1
+
+    def test_main_success(self, capsys: pytest.CaptureFixture[str]):
+        from investment_team.scripts.show_drift import main
+
+        mock_client = mock.MagicMock()
+        mock_client.list_jobs.return_value = [{"data": _synthetic_record()}]
+
+        with mock.patch("job_service_client.JobServiceClient", return_value=mock_client):
+            main(["lab-abc123"])
+
+        captured = capsys.readouterr().out
+        assert "Drift Report" in captured
+        assert "lab-abc123" in captured
+        assert "DesignAgent" in captured
+
+    def test_empty_histories(self, capsys: pytest.CaptureFixture[str]):
+        from investment_team.scripts.show_drift import (
+            _print_code_history,
+            _print_gate_timeline,
+            _print_rule_map,
+            _print_spec_history,
+        )
+
+        _print_spec_history([])
+        _print_code_history([])
+        _print_gate_timeline([])
+        _print_rule_map([])
+        captured = capsys.readouterr().out
+        assert "no spec revisions" in captured
+        assert "no code revisions" in captured
+        assert "no gate events" in captured
+        assert "no rule implementation map" in captured

--- a/backend/agents/investment_team/tests/test_strategy_compiler.py
+++ b/backend/agents/investment_team/tests/test_strategy_compiler.py
@@ -938,6 +938,7 @@ def test_compiled_code_flows_into_orchestrator_local_variable() -> None:
         refinement_attempts,
         emit,
         phase_back_count=0,
+        drift_collector=None,
     ):
         captured["code"] = code
         captured["original_code"] = original_code

--- a/backend/agents/investment_team/tests/test_strategy_lab_drift_observability.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_drift_observability.py
@@ -197,6 +197,7 @@ class TestGateTimeline:
                 details="ok",
                 severity="info",
                 phase="design",
+                evaluated_at="2024-01-01T00:00:01+00:00",
             ),
             QualityGateResult(
                 gate_name="code_conformance",
@@ -204,9 +205,9 @@ class TestGateTimeline:
                 details="missing import",
                 severity="critical",
                 phase="synthesis",
+                evaluated_at="2024-01-01T00:00:05+00:00",
             ),
         ]
-        now_iso = "2024-01-01T00:00:00+00:00"
         timeline = [
             GateEvent(
                 phase=g.phase,
@@ -214,7 +215,7 @@ class TestGateTimeline:
                 passed=g.passed,
                 severity=g.severity,
                 details=g.details,
-                timestamp=now_iso,
+                timestamp=g.evaluated_at,
             )
             for g in gates
         ]
@@ -222,6 +223,41 @@ class TestGateTimeline:
         assert timeline[0].passed is True
         assert timeline[1].passed is False
         assert timeline[1].gate_name == "code_conformance"
+
+    def test_per_gate_timestamps_preserved(self):
+        """Each gate event carries its own evaluation timestamp."""
+        gates = [
+            QualityGateResult(
+                gate_name="spec_readiness",
+                passed=True,
+                details="ok",
+                severity="info",
+                phase="design",
+                evaluated_at="2024-01-01T00:00:01+00:00",
+            ),
+            QualityGateResult(
+                gate_name="alignment",
+                passed=False,
+                details="misaligned",
+                severity="critical",
+                phase="verification",
+                evaluated_at="2024-01-01T00:05:00+00:00",
+            ),
+        ]
+        timeline = [
+            GateEvent(
+                phase=g.phase,
+                gate_name=g.gate_name,
+                passed=g.passed,
+                severity=g.severity,
+                details=g.details,
+                timestamp=g.evaluated_at,
+            )
+            for g in gates
+        ]
+        assert timeline[0].timestamp == "2024-01-01T00:00:01+00:00"
+        assert timeline[1].timestamp == "2024-01-01T00:05:00+00:00"
+        assert timeline[0].timestamp != timeline[1].timestamp
 
 
 # ---------------------------------------------------------------------------
@@ -275,6 +311,27 @@ def check_exit_stop_loss(data):
         result = _build_rule_implementation_map(_minimal_spec(), [], "def broken(")
         assert isinstance(result, list)
         assert all(r.code_line_refs == [] for r in result)
+
+    def test_indexed_signal_exit_ids_normalised(self):
+        """Indexed IDs like exit:signal_exit[0] count toward exit:signal_exit."""
+        spec = _minimal_spec()
+        findings = [
+            AlignmentFinding(trade_num=1, rule_id="exit:signal_exit[0]", check_name="signal_exit", passed=True),
+            AlignmentFinding(trade_num=2, rule_id="exit:signal_exit[1]", check_name="signal_exit", passed=True),
+        ]
+        result = _build_rule_implementation_map(spec, findings, "def run(): pass")
+        sig_map = next(r for r in result if r.rule_id == "exit:signal_exit")
+        assert sig_map.traded_count == 2
+
+    def test_suffixed_stop_loss_ids_normalised(self):
+        """Suffixed IDs like exit:stop_loss:trailing count toward exit:stop_loss."""
+        spec = _minimal_spec()
+        findings = [
+            AlignmentFinding(trade_num=1, rule_id="exit:stop_loss:trailing", check_name="stop_loss", passed=True),
+        ]
+        result = _build_rule_implementation_map(spec, findings, "def run(): pass")
+        sl_map = next(r for r in result if r.rule_id == "exit:stop_loss")
+        assert sl_map.traded_count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/tests/test_strategy_lab_drift_observability.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_drift_observability.py
@@ -1,0 +1,343 @@
+"""Tests for spec/code drift observability: revision histories on StrategyLabRecord.
+
+Covers the ``_DriftCollector`` accumulator, ``SpecRevision`` / ``CodeRevision``
+models, gate-timeline conversion, rule-implementation map, and the full
+end-to-end flow through ``run_cycle``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from investment_team.models import (
+    BacktestConfig,
+    CodeRevision,
+    GateEvent,
+    SpecRevision,
+    StrategyLabRecord,
+    StrategySpec,
+)
+from investment_team.strategy_lab._orchestrator_helpers import (
+    _build_rule_implementation_map,
+    _DriftCollector,
+)
+from investment_team.strategy_lab.alignment_findings import AlignmentFinding
+from investment_team.strategy_lab.phases import hash_spec
+from investment_team.strategy_lab.quality_gates.models import QualityGateResult
+from investment_team.strategy_lab.spec_dsl import (
+    EntryRule,
+    IndicatorRef,
+    Predicate,
+    SignalExitRule,
+    StopLossRule,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _minimal_spec(**overrides: Any) -> StrategySpec:
+    defaults: Dict[str, Any] = {
+        "strategy_id": "strat-test",
+        "authored_by": "test",
+        "asset_class": "stocks",
+        "hypothesis": "test hypothesis",
+        "signal_definition": "RSI(14)",
+        "timeframe": "1d",
+        "entry_rules": [
+            EntryRule(
+                side="long",
+                when=Predicate(
+                    lhs=IndicatorRef(name="rsi", params={"period": 14}),
+                    op="<",
+                    rhs=30,
+                ),
+            ),
+        ],
+        "exit_rules": [
+            StopLossRule(pct=0.02),
+            SignalExitRule(
+                when=Predicate(
+                    lhs=IndicatorRef(name="rsi", params={"period": 14}),
+                    op=">",
+                    rhs=70,
+                ),
+            ),
+        ],
+        "target_symbols": ["AAPL"],
+        "requires_custom_code": False,
+    }
+    defaults.update(overrides)
+    return StrategySpec(**defaults)
+
+
+def _config() -> BacktestConfig:
+    return BacktestConfig(
+        start_date="2023-01-01",
+        end_date="2023-12-31",
+        initial_capital=100_000.0,
+        benchmark_symbol="SPY",
+        transaction_cost_bps=5.0,
+        slippage_bps=2.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _DriftCollector unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestDriftCollector:
+    def test_record_spec_change_appends_revision(self):
+        collector = _DriftCollector()
+        before = _minimal_spec(hypothesis="before")
+        after = _minimal_spec(hypothesis="after")
+        collector.record_spec_change(
+            phase="design_review",
+            agent="DesignAgent",
+            before_spec=before,
+            after_spec=after,
+            reason="revised hypothesis",
+        )
+        assert len(collector.spec_history) == 1
+        rev = collector.spec_history[0]
+        assert isinstance(rev, SpecRevision)
+        assert rev.phase == "design_review"
+        assert rev.agent == "DesignAgent"
+        assert rev.before_hash != rev.after_hash
+        assert "before" in rev.diff or "after" in rev.diff
+        assert rev.reason == "revised hypothesis"
+
+    def test_record_spec_change_noop_skipped(self):
+        collector = _DriftCollector()
+        spec = _minimal_spec()
+        collector.record_spec_change(
+            phase="synthesis",
+            agent="RefinementAgent",
+            before_spec=spec,
+            after_spec=spec,
+            reason="should not appear",
+        )
+        assert len(collector.spec_history) == 0
+
+    def test_record_code_change_appends_revision(self):
+        collector = _DriftCollector()
+        collector.record_code_change(
+            phase="synthesis",
+            agent="RefinementAgent",
+            before_code="def run(): pass",
+            after_code="def run(): return 42",
+            reason="fixed return",
+        )
+        assert len(collector.code_history) == 1
+        rev = collector.code_history[0]
+        assert isinstance(rev, CodeRevision)
+        assert rev.before_hash != rev.after_hash
+        assert "42" in rev.diff
+
+    def test_record_code_change_noop_skipped(self):
+        collector = _DriftCollector()
+        collector.record_code_change(
+            phase="synthesis",
+            agent="RefinementAgent",
+            before_code="x = 1",
+            after_code="x = 1",
+            reason="should not appear",
+        )
+        assert len(collector.code_history) == 0
+
+    def test_record_gate_appends_event(self):
+        collector = _DriftCollector()
+        collector.record_gate(
+            phase="verification",
+            gate_name="acceptance",
+            passed=True,
+            severity="info",
+            details="accepted",
+        )
+        assert len(collector.gate_timeline) == 1
+        ev = collector.gate_timeline[0]
+        assert isinstance(ev, GateEvent)
+        assert ev.passed is True
+
+    def test_gate_failures_carried_on_revision(self):
+        collector = _DriftCollector()
+        before = _minimal_spec(hypothesis="before")
+        after = _minimal_spec(hypothesis="after")
+        collector.record_spec_change(
+            phase="synthesis",
+            agent="RefinementAgent",
+            before_spec=before,
+            after_spec=after,
+            reason="tightened limits",
+            gate_failures=["code_conformance: failed"],
+        )
+        assert collector.spec_history[0].gate_failures == ["code_conformance: failed"]
+
+    def test_hash_stability(self):
+        spec = _minimal_spec()
+        h1 = hash_spec(spec)
+        h2 = hash_spec(spec)
+        assert h1 == h2
+        assert len(h1) == 64
+
+
+# ---------------------------------------------------------------------------
+# Gate timeline conversion
+# ---------------------------------------------------------------------------
+
+
+class TestGateTimeline:
+    def test_gate_results_to_timeline(self):
+        gates = [
+            QualityGateResult(
+                gate_name="spec_readiness",
+                passed=True,
+                details="ok",
+                severity="info",
+                phase="design",
+            ),
+            QualityGateResult(
+                gate_name="code_conformance",
+                passed=False,
+                details="missing import",
+                severity="critical",
+                phase="synthesis",
+            ),
+        ]
+        now_iso = "2024-01-01T00:00:00+00:00"
+        timeline = [
+            GateEvent(
+                phase=g.phase,
+                gate_name=g.gate_name,
+                passed=g.passed,
+                severity=g.severity,
+                details=g.details,
+                timestamp=now_iso,
+            )
+            for g in gates
+        ]
+        assert len(timeline) == 2
+        assert timeline[0].passed is True
+        assert timeline[1].passed is False
+        assert timeline[1].gate_name == "code_conformance"
+
+
+# ---------------------------------------------------------------------------
+# Rule implementation map
+# ---------------------------------------------------------------------------
+
+
+class TestRuleImplementationMap:
+    def test_builds_from_findings(self):
+        spec = _minimal_spec()
+        findings = [
+            AlignmentFinding(trade_num=1, rule_id="entry[0]", check_name="entry_signal", passed=True),
+            AlignmentFinding(trade_num=2, rule_id="entry[0]", check_name="entry_signal", passed=True),
+            AlignmentFinding(trade_num=1, rule_id="exit:stop_loss", check_name="stop_loss", passed=False),
+            AlignmentFinding(trade_num=1, rule_id="sizing", check_name="sizing", passed=True),
+        ]
+        result = _build_rule_implementation_map(spec, findings, "def run(): pass")
+        assert isinstance(result, list)
+        rule_ids = {r.rule_id for r in result}
+        assert "entry[0]" in rule_ids
+        assert "exit:stop_loss" in rule_ids
+        assert "sizing" in rule_ids
+
+        entry_map = next(r for r in result if r.rule_id == "entry[0]")
+        assert entry_map.traded_count == 2
+
+        sizing_map = next(r for r in result if r.rule_id == "sizing")
+        assert sizing_map.traded_count == 1
+
+    def test_empty_findings(self):
+        spec = _minimal_spec()
+        result = _build_rule_implementation_map(spec, [], "")
+        assert isinstance(result, list)
+        assert all(r.traded_count == 0 for r in result)
+
+    def test_code_line_refs_best_effort(self):
+        code = """
+def check_entry0(data):
+    return data['rsi'] < 30
+
+def check_exit_stop_loss(data):
+    return data['loss'] > 2.0
+"""
+        spec = _minimal_spec()
+        result = _build_rule_implementation_map(spec, [], code)
+        entry_map = next((r for r in result if r.rule_id == "entry[0]"), None)
+        assert entry_map is not None
+        assert isinstance(entry_map.code_line_refs, list)
+
+    def test_unparseable_code(self):
+        result = _build_rule_implementation_map(_minimal_spec(), [], "def broken(")
+        assert isinstance(result, list)
+        assert all(r.code_line_refs == [] for r in result)
+
+
+# ---------------------------------------------------------------------------
+# StrategyLabRecord with drift fields
+# ---------------------------------------------------------------------------
+
+
+class TestStrategyLabRecordDriftFields:
+    @staticmethod
+    def _backtest():
+        from investment_team.models import BacktestRecord
+        from investment_team.trade_simulator import compute_metrics
+
+        cfg = _config()
+        result = compute_metrics([], cfg.initial_capital, cfg.start_date, cfg.end_date)
+        return BacktestRecord(
+            backtest_id="bt-test",
+            strategy_id="strat-test",
+            strategy=_minimal_spec(),
+            config=cfg,
+            submitted_by="test",
+            submitted_at="2024-01-01",
+            completed_at="2024-01-01",
+            status="completed",
+            result=result,
+            trades=[],
+        )
+
+    def test_empty_defaults(self):
+        record = StrategyLabRecord(
+            lab_record_id="lab-test",
+            strategy=_minimal_spec(),
+            backtest=self._backtest(),
+            is_winning=False,
+            strategy_rationale="test",
+            analysis_narrative="test",
+            created_at="2024-01-01",
+        )
+        assert record.spec_history == []
+        assert record.code_history == []
+        assert record.gate_timeline == []
+        assert record.rule_implementation_map == []
+
+    def test_populated_fields_serialize(self):
+        rev = SpecRevision(
+            phase="design_review",
+            agent="DesignAgent",
+            timestamp="2024-01-01T00:00:00+00:00",
+            before_hash="a" * 64,
+            after_hash="b" * 64,
+            diff="--- a\n+++ b\n",
+            reason="revised",
+        )
+        record = StrategyLabRecord(
+            lab_record_id="lab-test",
+            strategy=_minimal_spec(),
+            backtest=self._backtest(),
+            is_winning=False,
+            strategy_rationale="test",
+            analysis_narrative="test",
+            created_at="2024-01-01",
+            spec_history=[rev],
+        )
+        dumped = record.model_dump()
+        assert len(dumped["spec_history"]) == 1
+        assert dumped["spec_history"][0]["phase"] == "design_review"

--- a/backend/agents/investment_team/tests/test_strategy_lab_drift_observability.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_drift_observability.py
@@ -433,6 +433,30 @@ def check_exit_stop_loss(data):
         assert m0.traded_count == 1
         assert m1.traded_count == 0
 
+    def test_suffixed_ids_map_to_matching_instance(self):
+        """Suffixed IDs map to the instance with the matching basis attribute."""
+        spec = _minimal_spec(
+            exit_rules=[
+                StopLossRule(pct=0.02, basis="entry_price"),
+                StopLossRule(pct=0.05, basis="trailing_high"),
+            ],
+        )
+        findings = [
+            AlignmentFinding(
+                trade_num=1, rule_id="exit:stop_loss:trailing_high", check_name="stop_loss",
+                passed=True, computed_value=-3.0, expected_value=-5.0,
+            ),
+            AlignmentFinding(
+                trade_num=2, rule_id="exit:stop_loss:entry_price", check_name="stop_loss",
+                passed=True, computed_value=-1.5, expected_value=-2.0,
+            ),
+        ]
+        result = _build_rule_implementation_map(spec, findings, "def run(): pass")
+        m0 = next(r for r in result if r.rule_id == "exit:stop_loss[0]")
+        m1 = next(r for r in result if r.rule_id == "exit:stop_loss[1]")
+        assert m0.traded_count == 1  # entry_price finding → [0]
+        assert m1.traded_count == 1  # trailing_high finding → [1]
+
 
 # ---------------------------------------------------------------------------
 # StrategyLabRecord with drift fields

--- a/backend/agents/investment_team/tests/test_strategy_lab_drift_observability.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_drift_observability.py
@@ -269,16 +269,25 @@ class TestRuleImplementationMap:
     def test_builds_from_findings(self):
         spec = _minimal_spec()
         findings = [
-            AlignmentFinding(trade_num=1, rule_id="entry[0]", check_name="entry_signal", passed=True),
-            AlignmentFinding(trade_num=2, rule_id="entry[0]", check_name="entry_signal", passed=True),
-            AlignmentFinding(trade_num=1, rule_id="exit:stop_loss", check_name="stop_loss", passed=False),
-            AlignmentFinding(trade_num=1, rule_id="sizing", check_name="sizing", passed=True),
+            AlignmentFinding(
+                trade_num=1, rule_id="entry[0]", check_name="entry_signal",
+                passed=True, computed_value=25.0, expected_value=30.0,
+            ),
+            AlignmentFinding(
+                trade_num=2, rule_id="entry[0]", check_name="entry_signal",
+                passed=True, computed_value=22.0, expected_value=30.0,
+            ),
+            AlignmentFinding(trade_num=1, rule_id="exit:stop_loss[0]", check_name="stop_loss", passed=False),
+            AlignmentFinding(
+                trade_num=1, rule_id="sizing", check_name="sizing",
+                passed=True, computed_value=100.0, expected_value=100.0,
+            ),
         ]
         result = _build_rule_implementation_map(spec, findings, "def run(): pass")
         assert isinstance(result, list)
         rule_ids = {r.rule_id for r in result}
         assert "entry[0]" in rule_ids
-        assert "exit:stop_loss" in rule_ids
+        assert "exit:stop_loss[0]" in rule_ids
         assert "sizing" in rule_ids
 
         entry_map = next(r for r in result if r.rule_id == "entry[0]")
@@ -312,37 +321,55 @@ def check_exit_stop_loss(data):
         assert isinstance(result, list)
         assert all(r.code_line_refs == [] for r in result)
 
-    def test_indexed_signal_exit_ids_normalised(self):
-        """Indexed IDs like exit:signal_exit[0] count toward exit:signal_exit."""
+    def test_indexed_signal_exit_ids_match_directly(self):
+        """Indexed IDs like exit:signal_exit[0] match the per-instance canonical key."""
         spec = _minimal_spec()
         findings = [
-            AlignmentFinding(trade_num=1, rule_id="exit:signal_exit[0]", check_name="signal_exit", passed=True),
-            AlignmentFinding(trade_num=2, rule_id="exit:signal_exit[1]", check_name="signal_exit", passed=True),
+            AlignmentFinding(
+                trade_num=1, rule_id="exit:signal_exit[0]", check_name="signal_exit",
+                passed=True, severity="info", computed_value=75.0, expected_value=70.0,
+            ),
+            AlignmentFinding(
+                trade_num=2, rule_id="exit:signal_exit[0]", check_name="signal_exit",
+                passed=True, severity="info", computed_value=80.0, expected_value=70.0,
+            ),
         ]
         result = _build_rule_implementation_map(spec, findings, "def run(): pass")
-        sig_map = next(r for r in result if r.rule_id == "exit:signal_exit")
+        sig_map = next(r for r in result if r.rule_id == "exit:signal_exit[0]")
         assert sig_map.traded_count == 2
 
     def test_suffixed_stop_loss_ids_normalised(self):
-        """Suffixed IDs like exit:stop_loss:trailing count toward exit:stop_loss."""
+        """Suffixed IDs like exit:stop_loss:trailing normalise to exit:stop_loss[0]."""
         spec = _minimal_spec()
         findings = [
-            AlignmentFinding(trade_num=1, rule_id="exit:stop_loss:trailing", check_name="stop_loss", passed=True),
+            AlignmentFinding(
+                trade_num=1, rule_id="exit:stop_loss:trailing", check_name="stop_loss",
+                passed=True, computed_value=-1.5, expected_value=-2.0,
+            ),
         ]
         result = _build_rule_implementation_map(spec, findings, "def run(): pass")
-        sl_map = next(r for r in result if r.rule_id == "exit:stop_loss")
+        sl_map = next(r for r in result if r.rule_id == "exit:stop_loss[0]")
         assert sl_map.traded_count == 1
 
     def test_traded_count_is_distinct_trades(self):
         """Same trade with multiple suffixed findings counts once."""
         spec = _minimal_spec()
         findings = [
-            AlignmentFinding(trade_num=1, rule_id="exit:stop_loss:trailing_high", check_name="stop_loss", passed=True),
-            AlignmentFinding(trade_num=1, rule_id="exit:stop_loss:trailing_low", check_name="stop_loss", passed=True),
-            AlignmentFinding(trade_num=2, rule_id="exit:stop_loss:entry_price", check_name="stop_loss", passed=True),
+            AlignmentFinding(
+                trade_num=1, rule_id="exit:stop_loss:trailing_high", check_name="stop_loss",
+                passed=True, computed_value=-1.0, expected_value=-2.0,
+            ),
+            AlignmentFinding(
+                trade_num=1, rule_id="exit:stop_loss:trailing_low", check_name="stop_loss",
+                passed=True, computed_value=-0.5, expected_value=-2.0,
+            ),
+            AlignmentFinding(
+                trade_num=2, rule_id="exit:stop_loss:entry_price", check_name="stop_loss",
+                passed=True, computed_value=-1.8, expected_value=-2.0,
+            ),
         ]
         result = _build_rule_implementation_map(spec, findings, "def run(): pass")
-        sl_map = next(r for r in result if r.rule_id == "exit:stop_loss")
+        sl_map = next(r for r in result if r.rule_id == "exit:stop_loss[0]")
         assert sl_map.traded_count == 2
 
     def test_non_spec_finding_ids_excluded(self):
@@ -356,6 +383,55 @@ def check_exit_stop_loss(data):
         rule_ids = {r.rule_id for r in result}
         assert "universe" not in rule_ids
         assert "exit:time_stop" not in rule_ids
+
+    def test_info_skip_findings_not_counted(self):
+        """N/A skip findings (passed=True but no computed_value) don't inflate traded_count."""
+        spec = _minimal_spec()
+        findings = [
+            AlignmentFinding(
+                trade_num=1, rule_id="exit:signal_exit", check_name="signal_exit",
+                passed=True, severity="info",
+                details="Trade #1 closed via engine attribution; signal-exit check N/A.",
+            ),
+        ]
+        result = _build_rule_implementation_map(spec, findings, "def run(): pass")
+        sig_map = next(r for r in result if r.rule_id == "exit:signal_exit[0]")
+        assert sig_map.traded_count == 0
+
+    def test_per_instance_exit_rule_ids(self):
+        """Multiple exit rules of the same kind get separate map entries."""
+        spec = _minimal_spec(
+            exit_rules=[
+                SignalExitRule(
+                    when=Predicate(
+                        lhs=IndicatorRef(name="rsi", params={"period": 14}),
+                        op=">",
+                        rhs=70,
+                    ),
+                ),
+                SignalExitRule(
+                    when=Predicate(
+                        lhs=IndicatorRef(name="rsi", params={"period": 14}),
+                        op="<",
+                        rhs=20,
+                    ),
+                ),
+            ],
+        )
+        findings = [
+            AlignmentFinding(
+                trade_num=1, rule_id="exit:signal_exit[0]", check_name="signal_exit",
+                passed=True, severity="info", computed_value=75.0, expected_value=70.0,
+            ),
+        ]
+        result = _build_rule_implementation_map(spec, findings, "def run(): pass")
+        rule_ids = [r.rule_id for r in result]
+        assert "exit:signal_exit[0]" in rule_ids
+        assert "exit:signal_exit[1]" in rule_ids
+        m0 = next(r for r in result if r.rule_id == "exit:signal_exit[0]")
+        m1 = next(r for r in result if r.rule_id == "exit:signal_exit[1]")
+        assert m0.traded_count == 1
+        assert m1.traded_count == 0
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/tests/test_strategy_lab_drift_observability.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_drift_observability.py
@@ -333,6 +333,30 @@ def check_exit_stop_loss(data):
         sl_map = next(r for r in result if r.rule_id == "exit:stop_loss")
         assert sl_map.traded_count == 1
 
+    def test_traded_count_is_distinct_trades(self):
+        """Same trade with multiple suffixed findings counts once."""
+        spec = _minimal_spec()
+        findings = [
+            AlignmentFinding(trade_num=1, rule_id="exit:stop_loss:trailing_high", check_name="stop_loss", passed=True),
+            AlignmentFinding(trade_num=1, rule_id="exit:stop_loss:trailing_low", check_name="stop_loss", passed=True),
+            AlignmentFinding(trade_num=2, rule_id="exit:stop_loss:entry_price", check_name="stop_loss", passed=True),
+        ]
+        result = _build_rule_implementation_map(spec, findings, "def run(): pass")
+        sl_map = next(r for r in result if r.rule_id == "exit:stop_loss")
+        assert sl_map.traded_count == 2
+
+    def test_non_spec_finding_ids_excluded(self):
+        """Diagnostic finding IDs not in the spec are excluded from the map."""
+        spec = _minimal_spec()
+        findings = [
+            AlignmentFinding(trade_num=1, rule_id="universe", check_name="universe_check", passed=True),
+            AlignmentFinding(trade_num=1, rule_id="exit:time_stop", check_name="time_stop", passed=True),
+        ]
+        result = _build_rule_implementation_map(spec, findings, "def run(): pass")
+        rule_ids = {r.rule_id for r in result}
+        assert "universe" not in rule_ids
+        assert "exit:time_stop" not in rule_ids
+
 
 # ---------------------------------------------------------------------------
 # StrategyLabRecord with drift fields


### PR DESCRIPTION
## Summary

- Add four structured history fields to `StrategyLabRecord` (`spec_history`, `code_history`, `gate_timeline`, `rule_implementation_map`) that record every spec/code mutation with SHA-256 before/after hashes, unified diffs, agent attribution, and phase context
- Implement a `_DriftCollector` accumulator threaded through the orchestrator pipeline (design loop, synthesis, refinement, zero-trade repair, alignment audit) — no-op mutations are silently skipped
- Add `_build_rule_implementation_map()` helper that aggregates per-rule trade coverage from alignment findings with best-effort AST code-line refs
- Add CLI script `show_drift.py` for inspecting drift on persisted records
- 19 new tests covering the collector, models, gate timeline conversion, rule implementation map, and the CLI script; all 2526 existing tests pass with no regressions

## Test plan

- [x] `_DriftCollector.record_spec_change` appends a `SpecRevision` when spec hashes differ
- [x] `_DriftCollector.record_spec_change` is a no-op when hashes match
- [x] `_DriftCollector.record_code_change` appends a `CodeRevision` when code hashes differ
- [x] `_DriftCollector.record_code_change` is a no-op when hashes match
- [x] `_DriftCollector.record_gate` appends a `GateEvent`
- [x] Gate failures are carried on revision entries
- [x] `hash_spec` produces stable 64-char hex digests
- [x] Gate timeline conversion from `QualityGateResult` to `GateEvent`
- [x] `_build_rule_implementation_map` aggregates traded_count from alignment findings
- [x] Empty findings produce zero-traded rules
- [x] Best-effort AST code line refs
- [x] Unparseable code returns empty code_line_refs
- [x] `StrategyLabRecord` defaults new fields to empty lists
- [x] Populated fields serialize correctly via `model_dump()`
- [x] CLI script prints spec diffs and zero-trade markers
- [x] CLI script handles record-not-found
- [x] All 2526 existing investment team tests pass (0 regressions)

Closes #548

https://claude.ai/code/session_011cUZWTjVa1RSk5LEtU3y3h

---
_Generated by [Claude Code](https://claude.ai/code/session_011cUZWTjVa1RSk5LEtU3y3h)_