### PR TITLE
Add medication-interaction check to guardrail pipeline (SPEC-007 W4)

### DIFF
--- a/backend/agents/nutrition_meal_planning_team/guardrail/checker.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/checker.py
@@ -41,7 +41,9 @@ def check_recommendation(
     resolution = profile.restriction_resolution
     active_allergens = frozenset(resolution.active_allergen_tags())
     catalog = get_catalog()
-    all_meds = profile.clinical.medications + profile.clinical.medications_freetext
+    all_meds = list(
+        dict.fromkeys(profile.clinical.medications + profile.clinical.medications_freetext)
+    )
     med_policies, unknown_meds = get_interaction_policies(all_meds)
 
     parsed = tuple(parse_ingredient(raw) for raw in rec.ingredients)

--- a/backend/agents/nutrition_meal_planning_team/guardrail/checker.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/checker.py
@@ -41,7 +41,8 @@ def check_recommendation(
     resolution = profile.restriction_resolution
     active_allergens = frozenset(resolution.active_allergen_tags())
     catalog = get_catalog()
-    med_policies, unknown_meds = get_interaction_policies(profile.clinical.medications)
+    all_meds = profile.clinical.medications + profile.clinical.medications_freetext
+    med_policies, unknown_meds = get_interaction_policies(all_meds)
 
     parsed = tuple(parse_ingredient(raw) for raw in rec.ingredients)
 

--- a/backend/agents/nutrition_meal_planning_team/guardrail/checker.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/checker.py
@@ -1,18 +1,19 @@
 """SPEC-007 §4.4 deterministic guardrail checker.
 
-Implements steps 1, 2, 3, 5 of the check pipeline:
+Implements steps 1–5 of the check pipeline:
 
 1. Parse each ingredient via ``ingredient_kb.parse_ingredient``.
 2. Allergen check — intersect canonical food's ``allergen_tags`` with
    the profile's active allergen tags.
 3. Dietary check — intersect ``dietary_tags`` with the profile's
    ``dietary_tags_forbid`` set.
+4. Medication-interaction check — intersect ``interaction_tags`` with
+   the active medication policies from ``interactions.yaml``.
 5. Unknown-ingredient policy — fail closed:
    ``canonical_id is None`` and ``confidence < 0.85`` → hard reject;
    ``canonical_id is None`` and ``confidence >= 0.85`` → flag.
 
-Steps 4 (medication interactions) and 6 (condition-specific flags)
-land in W3/W4 and a later spec revision respectively.
+Step 6 (condition-specific flags) lands in a later spec revision.
 
 Pure function. No I/O, no LLM, no clock. Same ``(profile, rec)`` →
 byte-equal ``GuardrailResult``.
@@ -24,9 +25,10 @@ from typing import Iterable, Optional
 
 from ..ingredient_kb.catalog import get_catalog
 from ..ingredient_kb.parser import parse_ingredient
-from ..ingredient_kb.taxonomy import AllergenTag, DietaryTag
+from ..ingredient_kb.taxonomy import AllergenTag, DietaryTag, InteractionTag
 from ..ingredient_kb.types import CanonicalFood, ParsedIngredient
 from ..models import ClientProfile, MealRecommendation
+from .interactions import InteractionPolicy, get_interaction_policies
 from .violations import GuardrailResult, Severity, Violation, ViolationReason
 
 UNRESOLVED_CONFIDENCE_THRESHOLD = 0.85  # SPEC-007 §4.4 step 5
@@ -39,6 +41,7 @@ def check_recommendation(
     resolution = profile.restriction_resolution
     active_allergens = frozenset(resolution.active_allergen_tags())
     catalog = get_catalog()
+    med_policies, unknown_meds = get_interaction_policies(profile.clinical.medications)
 
     parsed = tuple(parse_ingredient(raw) for raw in rec.ingredients)
 
@@ -66,12 +69,22 @@ def check_recommendation(
             hard.append(_allergen(p, tag))
 
         # Per-food: a resolution's allergen exemption (e.g. pescatarian +
-        # fish, issue #351) drops its dietary forbid for this food only.
+        # fish) drops its dietary forbid for this food only.
         applicable_dietary = resolution.applicable_dietary_forbid(
             frozenset(canonical.allergen_tags)
         )
         for tag in _sorted_tags(canonical.dietary_tags & applicable_dietary):
             hard.append(_dietary(p, tag))
+
+        # Step 4: medication-interaction check
+        for policy in med_policies.values():
+            for tag in _sorted_tags(canonical.interaction_tags & policy.hard):
+                hard.append(_interaction_hard(p, tag, policy))
+            for tag in _sorted_tags(canonical.interaction_tags & policy.flag):
+                flags.append(_interaction_flag(p, tag, policy))
+
+    for med_name in sorted(unknown_meds):
+        flags.append(_unknown_medication(med_name))
 
     return GuardrailResult(
         passed=len(hard) == 0,
@@ -121,4 +134,41 @@ def _dietary(p: ParsedIngredient, tag: DietaryTag) -> Violation:
         tag=tag.value,
         detail=f"{p.raw} is forbidden by dietary rule '{tag.value}'",
         severity=Severity.hard_reject,
+    )
+
+
+def _interaction_hard(
+    p: ParsedIngredient, tag: InteractionTag, policy: InteractionPolicy
+) -> Violation:
+    return Violation(
+        reason=ViolationReason.interaction_hard,
+        ingredient_raw=p.raw,
+        canonical_id=p.canonical_id,
+        tag=tag.value,
+        detail=f"{p.raw} interacts with medication '{policy.medication}' (tag '{tag.value}')",
+        severity=Severity.hard_reject,
+    )
+
+
+def _interaction_flag(
+    p: ParsedIngredient, tag: InteractionTag, policy: InteractionPolicy
+) -> Violation:
+    return Violation(
+        reason=ViolationReason.interaction_flag,
+        ingredient_raw=p.raw,
+        canonical_id=p.canonical_id,
+        tag=tag.value,
+        detail=f"{p.raw} may interact with medication '{policy.medication}' (tag '{tag.value}')",
+        severity=Severity.flag,
+    )
+
+
+def _unknown_medication(med_name: str) -> Violation:
+    return Violation(
+        reason=ViolationReason.interaction_flag,
+        ingredient_raw="",
+        canonical_id=None,
+        tag=None,
+        detail=f"Medication '{med_name}' is not in the known interactions database; review with prescriber",
+        severity=Severity.flag,
     )

--- a/backend/agents/nutrition_meal_planning_team/guardrail/tests/_fixtures.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/tests/_fixtures.py
@@ -12,6 +12,7 @@ from agents.nutrition_meal_planning_team.ingredient_kb.taxonomy import (
 )
 from agents.nutrition_meal_planning_team.models import (
     ClientProfile,
+    ClinicalInfo,
     MealRecommendation,
     ResolvedRestriction,
     RestrictionResolution,
@@ -25,10 +26,20 @@ def profile_with(
     *,
     allergens: Iterable[AllergenTag] = (),
     dietary_forbid: Iterable[DietaryTag] = (),
+    medications: Iterable[str] = (),
     client_id: str = "test_client",
 ) -> ClientProfile:
     """Build a ClientProfile with the given active tags via SPEC-006
-    ``RestrictionResolution.resolved`` entries."""
+    ``RestrictionResolution.resolved`` entries.
+
+    Preconditions:
+        ``medications`` contains recognised ``Medication`` enum values
+        or free-text strings (unknown meds produce advisory flags).
+
+    Postconditions:
+        Returned profile has the specified allergens, dietary forbid tags,
+        and medications set on ``clinical.medications``.
+    """
     resolved: list[ResolvedRestriction] = []
     for tag in allergens:
         resolved.append(
@@ -44,9 +55,11 @@ def profile_with(
                 dietary_tags_forbid=[tag],
             )
         )
+    med_list = list(medications)
     return ClientProfile(
         client_id=client_id,
         restriction_resolution=RestrictionResolution(resolved=resolved),
+        clinical=ClinicalInfo(medications=med_list) if med_list else ClinicalInfo(),
     )
 
 

--- a/backend/agents/nutrition_meal_planning_team/guardrail/tests/_fixtures.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/tests/_fixtures.py
@@ -27,18 +27,20 @@ def profile_with(
     allergens: Iterable[AllergenTag] = (),
     dietary_forbid: Iterable[DietaryTag] = (),
     medications: Iterable[str] = (),
+    medications_freetext: Iterable[str] = (),
     client_id: str = "test_client",
 ) -> ClientProfile:
     """Build a ClientProfile with the given active tags via SPEC-006
     ``RestrictionResolution.resolved`` entries.
 
     Preconditions:
-        ``medications`` contains recognised ``Medication`` enum values
-        or free-text strings (unknown meds produce advisory flags).
+        ``medications`` contains recognised ``Medication`` enum values.
+        ``medications_freetext`` contains unrecognised medication strings
+        (mirrors the real write path in ``patch_clinical``).
 
     Postconditions:
         Returned profile has the specified allergens, dietary forbid tags,
-        and medications set on ``clinical.medications``.
+        and medications set on ``clinical.medications`` / ``medications_freetext``.
     """
     resolved: list[ResolvedRestriction] = []
     for tag in allergens:
@@ -56,10 +58,12 @@ def profile_with(
             )
         )
     med_list = list(medications)
+    med_freetext_list = list(medications_freetext)
+    clinical = ClinicalInfo(medications=med_list, medications_freetext=med_freetext_list)
     return ClientProfile(
         client_id=client_id,
         restriction_resolution=RestrictionResolution(resolved=resolved),
-        clinical=ClinicalInfo(medications=med_list) if med_list else ClinicalInfo(),
+        clinical=clinical,
     )
 
 

--- a/backend/agents/nutrition_meal_planning_team/guardrail/tests/red_team/test_red_team_fixtures.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/tests/red_team/test_red_team_fixtures.py
@@ -92,6 +92,12 @@ CASES: list[RedTeamCase] = [
         ingredient="honey",
         why="Honey forbidden under vegan dietary rules.",
     ),
+    RedTeamCase(
+        name="aged_cheddar_maoi",
+        profile=profile_with(medications=["maoi"]),
+        ingredient="aged cheddar",
+        why="Aged cheddar → ambiguous parse (confidence 0.5) → fail-closed hard reject.",
+    ),
 ]
 
 
@@ -109,5 +115,5 @@ def test_red_team_case_hard_rejects(case: RedTeamCase) -> None:
 
 def test_red_team_suite_is_complete() -> None:
     """Lock the suite size so deletions don't slip past review."""
-    assert len(CASES) == 9
-    assert len({c.name for c in CASES}) == 9
+    assert len(CASES) == 10
+    assert len({c.name for c in CASES}) == 10

--- a/backend/agents/nutrition_meal_planning_team/guardrail/tests/test_interactions_maoi_tyramine.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/tests/test_interactions_maoi_tyramine.py
@@ -1,0 +1,85 @@
+"""SPEC-007 §4.4 step 4 — MAOI × tyramine_high hard-reject tests."""
+
+from __future__ import annotations
+
+import pytest
+from agents.nutrition_meal_planning_team.guardrail import (
+    GuardrailResult,
+    Severity,
+    ViolationReason,
+    check_recommendation,
+)
+
+from ._fixtures import profile_with, recipe
+
+MAOI_PROFILE = profile_with(medications=["maoi"])
+
+TYRAMINE_FOODS = [
+    pytest.param("miso paste", id="miso_paste"),
+    pytest.param("red wine", id="wine_red"),
+]
+
+
+@pytest.mark.parametrize("ingredient", TYRAMINE_FOODS)
+def test_maoi_tyramine_hard_rejects(ingredient: str) -> None:
+    result: GuardrailResult = check_recommendation(MAOI_PROFILE, recipe(ingredient))
+
+    assert result.passed is False
+    interaction_violations = [
+        v for v in result.violations if v.reason is ViolationReason.interaction_hard
+    ]
+    assert len(interaction_violations) >= 1
+    assert all(v.severity is Severity.hard_reject for v in interaction_violations)
+    assert any(v.tag == "tyramine_high" for v in interaction_violations)
+
+
+@pytest.mark.parametrize("ingredient", TYRAMINE_FOODS)
+def test_no_medication_no_interaction_violation(ingredient: str) -> None:
+    result: GuardrailResult = check_recommendation(profile_with(), recipe(ingredient))
+
+    interaction_violations = [
+        v
+        for v in result.violations
+        if v.reason in (ViolationReason.interaction_hard, ViolationReason.interaction_flag)
+    ]
+    interaction_flags = [
+        f
+        for f in result.flags
+        if f.reason in (ViolationReason.interaction_hard, ViolationReason.interaction_flag)
+    ]
+    assert interaction_violations == []
+    assert interaction_flags == []
+
+
+@pytest.mark.parametrize("ingredient", TYRAMINE_FOODS)
+def test_different_medication_no_tyramine_rejection(ingredient: str) -> None:
+    warfarin_profile = profile_with(medications=["warfarin"])
+    result: GuardrailResult = check_recommendation(warfarin_profile, recipe(ingredient))
+
+    interaction_hard = [
+        v for v in result.violations if v.reason is ViolationReason.interaction_hard
+    ]
+    assert interaction_hard == []
+
+
+def test_maoi_tyramine_violation_fields() -> None:
+    result: GuardrailResult = check_recommendation(MAOI_PROFILE, recipe("miso paste"))
+
+    v = next(v for v in result.violations if v.reason is ViolationReason.interaction_hard)
+    assert v.ingredient_raw == "miso paste"
+    assert v.canonical_id == "miso_paste"
+    assert v.tag == "tyramine_high"
+    assert "maoi" in v.detail
+    assert v.severity is Severity.hard_reject
+
+
+def test_maoi_multiple_tyramine_ingredients() -> None:
+    result: GuardrailResult = check_recommendation(MAOI_PROFILE, recipe("miso paste", "red wine"))
+
+    assert result.passed is False
+    tyramine_violations = [
+        v
+        for v in result.violations
+        if v.reason is ViolationReason.interaction_hard and v.tag == "tyramine_high"
+    ]
+    assert len(tyramine_violations) == 2

--- a/backend/agents/nutrition_meal_planning_team/guardrail/tests/test_interactions_unknown_med.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/tests/test_interactions_unknown_med.py
@@ -1,0 +1,63 @@
+"""SPEC-007 §4.4 step 4 — unknown medication advisory flag tests."""
+
+from __future__ import annotations
+
+from agents.nutrition_meal_planning_team.guardrail import (
+    GuardrailResult,
+    Severity,
+    ViolationReason,
+    check_recommendation,
+)
+
+from ._fixtures import profile_with, recipe
+
+
+def test_unknown_medication_advisory_flag() -> None:
+    profile = profile_with(medications=["experimental_drug_xyz"])
+    result: GuardrailResult = check_recommendation(profile, recipe("chicken breast"))
+
+    assert result.passed is True
+    advisory = [f for f in result.flags if f.reason is ViolationReason.interaction_flag]
+    assert len(advisory) == 1
+    assert "experimental_drug_xyz" in advisory[0].detail
+    assert advisory[0].severity is Severity.flag
+    assert advisory[0].ingredient_raw == ""
+    assert advisory[0].canonical_id is None
+    assert advisory[0].tag is None
+
+
+def test_multiple_unknown_medications_each_flagged() -> None:
+    profile = profile_with(medications=["drug_a", "drug_b"])
+    result: GuardrailResult = check_recommendation(profile, recipe("chicken breast"))
+
+    assert result.passed is True
+    advisory = [f for f in result.flags if f.reason is ViolationReason.interaction_flag]
+    assert len(advisory) == 2
+    flagged_meds = {f.detail for f in advisory}
+    assert any("drug_a" in d for d in flagged_meds)
+    assert any("drug_b" in d for d in flagged_meds)
+
+
+def test_known_plus_unknown_medication() -> None:
+    profile = profile_with(medications=["maoi", "unknown_med"])
+    result: GuardrailResult = check_recommendation(profile, recipe("miso paste"))
+
+    assert result.passed is False
+    hard = [v for v in result.violations if v.reason is ViolationReason.interaction_hard]
+    assert len(hard) >= 1
+    assert any(v.tag == "tyramine_high" for v in hard)
+
+    advisory = [f for f in result.flags if "unknown_med" in f.detail]
+    assert len(advisory) == 1
+    assert advisory[0].severity is Severity.flag
+
+
+def test_no_medications_no_advisory() -> None:
+    result: GuardrailResult = check_recommendation(profile_with(), recipe("chicken breast"))
+
+    advisory = [
+        f
+        for f in result.flags
+        if f.reason in (ViolationReason.interaction_hard, ViolationReason.interaction_flag)
+    ]
+    assert advisory == []

--- a/backend/agents/nutrition_meal_planning_team/guardrail/tests/test_interactions_unknown_med.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/tests/test_interactions_unknown_med.py
@@ -52,6 +52,29 @@ def test_known_plus_unknown_medication() -> None:
     assert advisory[0].severity is Severity.flag
 
 
+def test_freetext_medication_produces_advisory_flag() -> None:
+    profile = profile_with(medications_freetext=["my_custom_supplement"])
+    result: GuardrailResult = check_recommendation(profile, recipe("chicken breast"))
+
+    assert result.passed is True
+    advisory = [f for f in result.flags if f.reason is ViolationReason.interaction_flag]
+    assert len(advisory) == 1
+    assert "my_custom_supplement" in advisory[0].detail
+    assert advisory[0].severity is Severity.flag
+
+
+def test_freetext_plus_recognized_medication() -> None:
+    profile = profile_with(medications=["maoi"], medications_freetext=["aspirin_custom"])
+    result: GuardrailResult = check_recommendation(profile, recipe("miso paste"))
+
+    assert result.passed is False
+    hard = [v for v in result.violations if v.reason is ViolationReason.interaction_hard]
+    assert any(v.tag == "tyramine_high" for v in hard)
+
+    advisory = [f for f in result.flags if "aspirin_custom" in f.detail]
+    assert len(advisory) == 1
+
+
 def test_no_medications_no_advisory() -> None:
     result: GuardrailResult = check_recommendation(profile_with(), recipe("chicken breast"))
 

--- a/backend/agents/nutrition_meal_planning_team/guardrail/tests/test_interactions_unknown_med.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/tests/test_interactions_unknown_med.py
@@ -75,6 +75,24 @@ def test_freetext_plus_recognized_medication() -> None:
     assert len(advisory) == 1
 
 
+def test_duplicate_medication_across_lists_produces_single_flag() -> None:
+    profile = profile_with(medications=["unknown_x"], medications_freetext=["unknown_x"])
+    result: GuardrailResult = check_recommendation(profile, recipe("chicken breast"))
+
+    assert result.passed is True
+    advisory = [f for f in result.flags if "unknown_x" in f.detail]
+    assert len(advisory) == 1
+
+
+def test_duplicate_within_medications_produces_single_flag() -> None:
+    profile = profile_with(medications=["unknown_y", "unknown_y"])
+    result: GuardrailResult = check_recommendation(profile, recipe("chicken breast"))
+
+    assert result.passed is True
+    advisory = [f for f in result.flags if "unknown_y" in f.detail]
+    assert len(advisory) == 1
+
+
 def test_no_medications_no_advisory() -> None:
     result: GuardrailResult = check_recommendation(profile_with(), recipe("chicken breast"))
 

--- a/backend/agents/nutrition_meal_planning_team/guardrail/tests/test_interactions_warfarin_vitamin_k.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/tests/test_interactions_warfarin_vitamin_k.py
@@ -1,0 +1,68 @@
+"""SPEC-007 §4.4 step 4 — warfarin × vitamin_k_high flag (non-blocking) tests."""
+
+from __future__ import annotations
+
+import pytest
+from agents.nutrition_meal_planning_team.guardrail import (
+    GuardrailResult,
+    Severity,
+    ViolationReason,
+    check_recommendation,
+)
+
+from ._fixtures import profile_with, recipe
+
+WARFARIN_PROFILE = profile_with(medications=["warfarin"])
+
+VITAMIN_K_FOODS = [
+    pytest.param("kale", id="kale_raw"),
+    pytest.param("spinach", id="spinach_raw"),
+]
+
+
+@pytest.mark.parametrize("ingredient", VITAMIN_K_FOODS)
+def test_warfarin_vitamin_k_flags_not_rejects(ingredient: str) -> None:
+    result: GuardrailResult = check_recommendation(WARFARIN_PROFILE, recipe(ingredient))
+
+    assert result.passed is True
+    assert not any(v.reason is ViolationReason.interaction_hard for v in result.violations)
+
+    interaction_flags = [f for f in result.flags if f.reason is ViolationReason.interaction_flag]
+    assert len(interaction_flags) >= 1
+    assert any(f.tag == "vitamin_k_high" for f in interaction_flags)
+    assert all(f.severity is Severity.flag for f in interaction_flags)
+
+
+@pytest.mark.parametrize("ingredient", VITAMIN_K_FOODS)
+def test_no_medication_no_vitamin_k_flag(ingredient: str) -> None:
+    result: GuardrailResult = check_recommendation(profile_with(), recipe(ingredient))
+
+    interaction_flags = [
+        f
+        for f in result.flags
+        if f.reason in (ViolationReason.interaction_hard, ViolationReason.interaction_flag)
+    ]
+    assert interaction_flags == []
+
+
+def test_warfarin_vitamin_k_flag_fields() -> None:
+    result: GuardrailResult = check_recommendation(WARFARIN_PROFILE, recipe("kale"))
+
+    f = next(f for f in result.flags if f.reason is ViolationReason.interaction_flag)
+    assert f.ingredient_raw == "kale"
+    assert f.canonical_id == "kale_raw"
+    assert f.tag == "vitamin_k_high"
+    assert "warfarin" in f.detail
+    assert f.severity is Severity.flag
+
+
+def test_warfarin_safe_food_no_flag() -> None:
+    result: GuardrailResult = check_recommendation(WARFARIN_PROFILE, recipe("chicken breast"))
+
+    interaction_flags = [
+        f
+        for f in result.flags
+        if f.reason in (ViolationReason.interaction_hard, ViolationReason.interaction_flag)
+    ]
+    assert interaction_flags == []
+    assert result.passed is True


### PR DESCRIPTION
## Summary

- Integrate step 4 (medication-interaction check) into `checker.py`: intersect each resolved ingredient's `interaction_tags` with the active medication policies from `interactions.yaml`
- MAOI + tyramine_high is the only hard rejection in v1; all other medication-food interactions produce advisory flags
- Unknown medications emit one advisory flag per unrecognized name — never fail-closed
- Extend test fixture helper `profile_with()` with a `medications` parameter
- Add three new test files covering MAOI/tyramine hard-reject, warfarin/vitamin-K flag, and unknown-medication advisory paths
- Add aged-cheddar-on-MAOI red-team case (caught by fail-closed unresolved-ingredient policy)

## Test plan

- [x] All 102 guardrail tests pass (`pytest agents/nutrition_meal_planning_team/guardrail/tests/ -v`)
- [x] Ruff lint and format checks pass
- [x] Existing determinism tests still pass (interaction violations use `_sorted_tags` for stable ordering)
- [ ] Broader nutrition team test suite passes
- [ ] CI green

Closes #336

https://claude.ai/code/session_01KZDG7ozCZUAMz5tjMNfBfV

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZDG7ozCZUAMz5tjMNfBfV)_