### PR TITLE
Add meal_planning_agent.regenerate_single (SPEC-007 W5)

### DIFF
--- a/backend/agents/nutrition_meal_planning_team/agents/meal_planning_agent/__init__.py
+++ b/backend/agents/nutrition_meal_planning_team/agents/meal_planning_agent/__init__.py
@@ -2,10 +2,13 @@
 
 from .agent import MealPlanningAgent, _build_user_prompt, _summarize_history
 from .prompt_constraints import render_constraints_block
+from .regeneration_prompt import REGENERATION_SYSTEM_PROMPT, build_regeneration_prompt
 
 __all__ = [
     "MealPlanningAgent",
+    "REGENERATION_SYSTEM_PROMPT",
     "_build_user_prompt",
     "_summarize_history",
+    "build_regeneration_prompt",
     "render_constraints_block",
 ]

--- a/backend/agents/nutrition_meal_planning_team/agents/meal_planning_agent/agent.py
+++ b/backend/agents/nutrition_meal_planning_team/agents/meal_planning_agent/agent.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Sequence
 
 from strands import Agent
 
+from ...guardrail.violations import Violation
 from ...models import (
     ClientProfile,
     MealHistoryEntry,
@@ -16,6 +17,7 @@ from ...models import (
     NutritionPlan,
 )
 from .prompt_constraints import render_constraints_block
+from .regeneration_prompt import REGENERATION_SYSTEM_PROMPT, build_regeneration_prompt
 
 logger = logging.getLogger(__name__)
 
@@ -93,8 +95,10 @@ def _build_user_prompt(
 class MealPlanningAgent:
     """Suggests meals from profile, nutrition plan, and meal history. Caller records recommendations and passes history."""
 
-    def __init__(self, model: Any) -> None:
+    def __init__(self, model: Any, *, agent_key: str = "nutrition_meal_planning") -> None:
         self._agent = Agent(model=model, system_prompt=SYSTEM_PROMPT)
+        self._agent_key = agent_key
+        self._client: Any = None
 
     def run(
         self,
@@ -128,3 +132,50 @@ class MealPlanningAgent:
             if isinstance(s, dict):
                 result_list.append(MealRecommendation.model_validate(s))
         return result_list
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            from llm_service import get_client
+
+            self._client = get_client(self._agent_key)
+        return self._client
+
+    def regenerate_single(
+        self,
+        profile: ClientProfile,
+        original: MealRecommendation,
+        violations: Sequence[Violation],
+    ) -> Optional[MealRecommendation]:
+        """Generate a single replacement meal after a guardrail rejection.
+
+        Preconditions:
+            ``violations`` is non-empty — at least one hard-reject violation
+            triggered the regeneration request.
+            ``profile`` carries a valid ``restriction_resolution`` and ``clinical``.
+
+        Postconditions:
+            Returns a validated ``MealRecommendation`` on success, or ``None``
+            when the LLM fails to produce a valid response after built-in
+            self-correction retry.
+        """
+        from llm_service import LLMError, LLMPermanentError
+        from llm_service.structured import complete_validated
+
+        prompt = build_regeneration_prompt(profile, original, violations)
+        try:
+            client = self._get_client()
+            return complete_validated(
+                client,
+                prompt,
+                schema=MealRecommendation,
+                system_prompt=REGENERATION_SYSTEM_PROMPT,
+            )
+        except LLMPermanentError as e:
+            logger.warning("regenerate_single failed (permanent): %s", e)
+            return None
+        except LLMError as e:
+            logger.warning("regenerate_single failed (transient): %s", e)
+            return None
+        except Exception as e:
+            logger.exception("regenerate_single unexpected error: %s", e)
+            return None

--- a/backend/agents/nutrition_meal_planning_team/agents/meal_planning_agent/agent.py
+++ b/backend/agents/nutrition_meal_planning_team/agents/meal_planning_agent/agent.py
@@ -161,8 +161,8 @@ class MealPlanningAgent:
         from llm_service import LLMError, LLMPermanentError
         from llm_service.structured import complete_validated
 
-        prompt = build_regeneration_prompt(profile, original, violations)
         try:
+            prompt = build_regeneration_prompt(profile, original, violations)
             client = self._get_client()
             return complete_validated(
                 client,

--- a/backend/agents/nutrition_meal_planning_team/agents/meal_planning_agent/regeneration_prompt.py
+++ b/backend/agents/nutrition_meal_planning_team/agents/meal_planning_agent/regeneration_prompt.py
@@ -50,12 +50,9 @@ def build_regeneration_prompt(
 
     parts.append(_forbidden_section(violations))
 
-    try:
-        constraints = render_constraints_block(profile.restriction_resolution, profile.clinical)
-        if constraints:
-            parts.append(constraints)
-    except Exception:
-        pass
+    constraints = render_constraints_block(profile.restriction_resolution, profile.clinical)
+    if constraints:
+        parts.append(constraints)
 
     parts.append(_original_context(original))
     parts.append(_instruction(original))

--- a/backend/agents/nutrition_meal_planning_team/agents/meal_planning_agent/regeneration_prompt.py
+++ b/backend/agents/nutrition_meal_planning_team/agents/meal_planning_agent/regeneration_prompt.py
@@ -1,0 +1,103 @@
+"""SPEC-007 §4.5 / §4.6 — regeneration prompt for rejected meal suggestions.
+
+Pure function. No I/O, no LLM. Deterministic: identical inputs produce
+byte-identical output (violation entries sorted by ``(ingredient_raw, tag)``).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Sequence
+
+from ...guardrail.violations import Violation
+from ...models import ClientProfile, MealRecommendation
+from .prompt_constraints import render_constraints_block
+
+REGENERATION_SYSTEM_PROMPT = (
+    "You are a meal planning expert. A previous meal suggestion was rejected "
+    "by the safety guardrail because it contained forbidden ingredients.\n\n"
+    "Generate exactly ONE replacement meal suggestion as a JSON object.\n"
+    "You MUST NOT use any ingredient from the FORBIDDEN list.\n"
+    "You MUST obey every dietary constraint listed.\n"
+    "Output valid JSON matching the schema provided. "
+    "No markdown fences. No prose outside the JSON."
+)
+
+
+def build_regeneration_prompt(
+    profile: ClientProfile,
+    original: MealRecommendation,
+    violations: Sequence[Violation],
+) -> str:
+    """Build the user prompt for a single-meal regeneration request.
+
+    Preconditions:
+        ``violations`` is non-empty (caller checked the guardrail result).
+        ``profile`` carries a valid ``restriction_resolution`` and ``clinical``.
+
+    Postconditions:
+        Returns a deterministic multi-part prompt string containing:
+        - An explicit FORBIDDEN list derived from ``violations``
+        - The full profile constraints block (via ``render_constraints_block``)
+        - The original meal's slot context (name, meal_type, suggested_date)
+        - A JSON-output instruction with the ``MealRecommendation`` schema
+
+    Invariants:
+        Identical inputs produce byte-identical output. Violation entries
+        are deduplicated by ``(ingredient_raw, tag)`` and sorted.
+    """
+    parts: list[str] = []
+
+    parts.append(_forbidden_section(violations))
+
+    try:
+        constraints = render_constraints_block(profile.restriction_resolution, profile.clinical)
+        if constraints:
+            parts.append(constraints)
+    except Exception:
+        pass
+
+    parts.append(_original_context(original))
+    parts.append(_instruction(original))
+
+    return "\n\n".join(parts)
+
+
+def _forbidden_section(violations: Sequence[Violation]) -> str:
+    seen: set[tuple[str, str | None]] = set()
+    lines: list[str] = []
+    for v in violations:
+        key = (v.ingredient_raw, v.tag)
+        if key in seen:
+            continue
+        seen.add(key)
+        if v.tag:
+            lines.append(f"  - {v.ingredient_raw} (tag: {v.tag})")
+        else:
+            lines.append(f"  - {v.ingredient_raw}")
+    lines.sort()
+    body = "\n".join(lines)
+    return f"FORBIDDEN INGREDIENTS (do NOT use any of these, by any name or derivative):\n{body}"
+
+
+def _original_context(original: MealRecommendation) -> str:
+    date_str = original.suggested_date or "none"
+    return (
+        "Original meal (rejected — do NOT reuse its ingredients):\n"
+        f"  Name: {original.name}\n"
+        f"  Meal type: {original.meal_type}\n"
+        f"  Suggested date: {date_str}"
+    )
+
+
+def _instruction(original: MealRecommendation) -> str:
+    schema_json = json.dumps(MealRecommendation.model_json_schema(), separators=(",", ":"))
+    meal_type = original.meal_type or "meal"
+    return (
+        f"Generate exactly ONE replacement {meal_type} that:\n"
+        "1. Does NOT contain any FORBIDDEN ingredient listed above\n"
+        "2. Obeys ALL dietary constraints above\n"
+        "3. Is a reasonable, nutritious alternative to the rejected meal\n\n"
+        f"Output valid JSON matching this schema:\n{schema_json}\n\n"
+        "Output JSON only. No markdown fences. No prose outside the JSON."
+    )

--- a/backend/agents/nutrition_meal_planning_team/agents/meal_planning_agent/tests/test_regenerate_single.py
+++ b/backend/agents/nutrition_meal_planning_team/agents/meal_planning_agent/tests/test_regenerate_single.py
@@ -1,0 +1,244 @@
+"""Tests for MealPlanningAgent.regenerate_single (SPEC-007 W5).
+
+Uses a lightweight dummy LLM client injected via ``agent._client`` to
+control ``complete_json`` responses without touching the real LLM.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from agents.nutrition_meal_planning_team.agents.meal_planning_agent.agent import (
+    MealPlanningAgent,
+)
+from agents.nutrition_meal_planning_team.guardrail.tests._fixtures import (
+    profile_with,
+    recipe,
+)
+from agents.nutrition_meal_planning_team.guardrail.violations import (
+    Severity,
+    Violation,
+    ViolationReason,
+)
+from agents.nutrition_meal_planning_team.ingredient_kb.taxonomy import AllergenTag
+from agents.nutrition_meal_planning_team.models import MealRecommendation
+
+from llm_service.clients.dummy import DummyLLMClient
+from llm_service.interface import (
+    LLMError,
+    LLMJsonParseError,
+    LLMPermanentError,
+    LLMSchemaValidationError,
+)
+
+# ---------------------------------------------------------------------------
+# Test-only dummy client
+# ---------------------------------------------------------------------------
+
+
+class _RegenDummyClient:
+    """Minimal ``LLMClient``-compatible stub for regeneration tests."""
+
+    def __init__(
+        self,
+        response: Optional[Dict[str, Any]] = None,
+        error: Optional[Exception] = None,
+    ):
+        self._response = response
+        self._error = error
+        self.last_prompt: Optional[str] = None
+        self.last_kwargs: Dict[str, Any] = {}
+
+    def complete_json(self, prompt: str, **kwargs: Any) -> Dict[str, Any]:
+        self.last_prompt = prompt
+        self.last_kwargs = kwargs
+        if self._error is not None:
+            raise self._error
+        assert self._response is not None
+        return self._response
+
+
+_VALID_RESPONSE: Dict[str, Any] = {
+    "name": "Grilled Tofu Bowl",
+    "ingredients": ["tofu", "rice", "broccoli", "soy sauce"],
+    "portions_servings": "2",
+    "prep_time_minutes": 10,
+    "cook_time_minutes": 20,
+    "rationale": "Avoids tree nuts; high protein",
+    "meal_type": "dinner",
+    "suggested_date": None,
+}
+
+
+def _make_agent(client: _RegenDummyClient) -> MealPlanningAgent:
+    agent = MealPlanningAgent(DummyLLMClient())
+    agent._client = client
+    return agent
+
+
+def _violation(
+    ingredient: str = "almonds",
+    tag: str | None = "tree_nut",
+) -> Violation:
+    return Violation(
+        reason=ViolationReason.allergen,
+        ingredient_raw=ingredient,
+        canonical_id=None,
+        tag=tag,
+        detail=f"test: {ingredient}",
+        severity=Severity.hard_reject,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_returns_meal_recommendation(self):
+        client = _RegenDummyClient(response=_VALID_RESPONSE)
+        agent = _make_agent(client)
+        result = agent.regenerate_single(
+            profile_with(allergens=[AllergenTag.tree_nut]),
+            recipe("almonds", name="Almond Cake"),
+            [_violation("almonds", "tree_nut")],
+        )
+        assert isinstance(result, MealRecommendation)
+        assert result.name == "Grilled Tofu Bowl"
+        assert result.meal_type == "dinner"
+
+    def test_returned_meal_has_ingredients(self):
+        client = _RegenDummyClient(response=_VALID_RESPONSE)
+        agent = _make_agent(client)
+        result = agent.regenerate_single(
+            profile_with(),
+            recipe("item"),
+            [_violation("item", "tree_nut")],
+        )
+        assert result is not None
+        assert len(result.ingredients) > 0
+
+
+# ---------------------------------------------------------------------------
+# Returns None on errors
+# ---------------------------------------------------------------------------
+
+
+class TestReturnsNone:
+    def test_returns_none_on_json_parse_error(self):
+        client = _RegenDummyClient(error=LLMJsonParseError("bad json"))
+        agent = _make_agent(client)
+        result = agent.regenerate_single(
+            profile_with(),
+            recipe("item"),
+            [_violation()],
+        )
+        assert result is None
+
+    def test_returns_none_on_schema_validation_error(self):
+        client = _RegenDummyClient(error=LLMSchemaValidationError("bad schema"))
+        agent = _make_agent(client)
+        result = agent.regenerate_single(
+            profile_with(),
+            recipe("item"),
+            [_violation()],
+        )
+        assert result is None
+
+    def test_returns_none_on_permanent_error(self):
+        client = _RegenDummyClient(error=LLMPermanentError("4xx"))
+        agent = _make_agent(client)
+        result = agent.regenerate_single(
+            profile_with(),
+            recipe("item"),
+            [_violation()],
+        )
+        assert result is None
+
+    def test_returns_none_on_transient_error(self):
+        client = _RegenDummyClient(error=LLMError("timeout"))
+        agent = _make_agent(client)
+        result = agent.regenerate_single(
+            profile_with(),
+            recipe("item"),
+            [_violation()],
+        )
+        assert result is None
+
+    def test_returns_none_on_unexpected_exception(self):
+        client = _RegenDummyClient(error=RuntimeError("unexpected"))
+        agent = _make_agent(client)
+        result = agent.regenerate_single(
+            profile_with(),
+            recipe("item"),
+            [_violation()],
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Prompt wiring
+# ---------------------------------------------------------------------------
+
+
+class TestPromptWiring:
+    def test_forbidden_ingredients_in_prompt(self):
+        client = _RegenDummyClient(response=_VALID_RESPONSE)
+        agent = _make_agent(client)
+        agent.regenerate_single(
+            profile_with(allergens=[AllergenTag.tree_nut]),
+            recipe("walnuts", name="Walnut Salad"),
+            [_violation("walnuts", "tree_nut")],
+        )
+        assert client.last_prompt is not None
+        assert "walnuts (tag: tree_nut)" in client.last_prompt
+
+    def test_multiple_violations_all_in_prompt(self):
+        client = _RegenDummyClient(response=_VALID_RESPONSE)
+        agent = _make_agent(client)
+        agent.regenerate_single(
+            profile_with(allergens=[AllergenTag.tree_nut]),
+            recipe("walnuts", "milk"),
+            [
+                _violation("walnuts", "tree_nut"),
+                _violation("milk", "dairy"),
+            ],
+        )
+        assert client.last_prompt is not None
+        assert "walnuts (tag: tree_nut)" in client.last_prompt
+        assert "milk (tag: dairy)" in client.last_prompt
+
+    def test_system_prompt_passed(self):
+        client = _RegenDummyClient(response=_VALID_RESPONSE)
+        agent = _make_agent(client)
+        agent.regenerate_single(
+            profile_with(),
+            recipe("item"),
+            [_violation()],
+        )
+        from agents.nutrition_meal_planning_team.agents.meal_planning_agent.regeneration_prompt import (
+            REGENERATION_SYSTEM_PROMPT,
+        )
+
+        assert client.last_kwargs.get("system_prompt") == REGENERATION_SYSTEM_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# Schema contract
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaContract:
+    def test_schema_is_single_meal_recommendation(self):
+        """The prompt instructs the LLM to return a single object, not a list."""
+        client = _RegenDummyClient(response=_VALID_RESPONSE)
+        agent = _make_agent(client)
+        agent.regenerate_single(
+            profile_with(),
+            recipe("item"),
+            [_violation()],
+        )
+        assert client.last_prompt is not None
+        assert '"MealRecommendation"' in client.last_prompt
+        assert '"suggestions"' not in client.last_prompt

--- a/backend/agents/nutrition_meal_planning_team/agents/meal_planning_agent/tests/test_regeneration_prompt.py
+++ b/backend/agents/nutrition_meal_planning_team/agents/meal_planning_agent/tests/test_regeneration_prompt.py
@@ -1,0 +1,247 @@
+"""Tests for SPEC-007 §4.5/§4.6 regeneration prompt builder.
+
+Pure-function tests — no LLM mock needed. Validates prompt content,
+structure, determinism, and forbidden-list rendering.
+"""
+
+from __future__ import annotations
+
+from agents.nutrition_meal_planning_team.agents.meal_planning_agent.regeneration_prompt import (
+    REGENERATION_SYSTEM_PROMPT,
+    build_regeneration_prompt,
+)
+from agents.nutrition_meal_planning_team.guardrail.tests._fixtures import (
+    profile_from_resolver,
+    profile_with,
+    recipe,
+)
+from agents.nutrition_meal_planning_team.guardrail.violations import (
+    Severity,
+    Violation,
+    ViolationReason,
+)
+from agents.nutrition_meal_planning_team.ingredient_kb.taxonomy import AllergenTag
+from agents.nutrition_meal_planning_team.models import (
+    ClientProfile,
+    ClinicalInfo,
+    MealRecommendation,
+    RestrictionResolution,
+)
+
+
+def _violation(
+    ingredient: str = "almonds",
+    tag: str | None = "tree_nut",
+    reason: ViolationReason = ViolationReason.allergen,
+    severity: Severity = Severity.hard_reject,
+) -> Violation:
+    return Violation(
+        reason=reason,
+        ingredient_raw=ingredient,
+        canonical_id=None,
+        tag=tag,
+        detail=f"test: {ingredient}",
+        severity=severity,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Forbidden list rendering
+# ---------------------------------------------------------------------------
+
+
+class TestForbiddenList:
+    def test_single_violation_renders_forbidden(self):
+        v = _violation("almonds", "tree_nut")
+        prompt = build_regeneration_prompt(
+            profile_with(allergens=[AllergenTag.tree_nut]),
+            recipe("almonds", name="Almond Cake"),
+            [v],
+        )
+        assert "FORBIDDEN INGREDIENTS" in prompt
+        assert "almonds (tag: tree_nut)" in prompt
+
+    def test_multiple_violations_all_listed(self):
+        vs = [
+            _violation("almonds", "tree_nut"),
+            _violation("milk", "dairy"),
+        ]
+        prompt = build_regeneration_prompt(
+            profile_with(allergens=[AllergenTag.tree_nut]),
+            recipe("almonds", "milk"),
+            vs,
+        )
+        assert "almonds (tag: tree_nut)" in prompt
+        assert "milk (tag: dairy)" in prompt
+
+    def test_none_tag_renders_ingredient_only(self):
+        v = _violation(
+            "mystery spice",
+            None,
+            reason=ViolationReason.unresolved_ingredient,
+        )
+        prompt = build_regeneration_prompt(
+            profile_with(),
+            recipe("mystery spice"),
+            [v],
+        )
+        assert "  - mystery spice" in prompt
+        assert "(tag:" not in prompt.split("mystery spice")[1].split("\n")[0]
+
+    def test_duplicate_violations_deduplicated(self):
+        v = _violation("almonds", "tree_nut")
+        prompt = build_regeneration_prompt(
+            profile_with(allergens=[AllergenTag.tree_nut]),
+            recipe("almonds"),
+            [v, v],
+        )
+        count = prompt.count("almonds (tag: tree_nut)")
+        assert count == 1
+
+    def test_violations_sorted_deterministically(self):
+        vs_a = [
+            _violation("walnuts", "tree_nut"),
+            _violation("almonds", "tree_nut"),
+            _violation("milk", "dairy"),
+        ]
+        vs_b = [
+            _violation("milk", "dairy"),
+            _violation("almonds", "tree_nut"),
+            _violation("walnuts", "tree_nut"),
+        ]
+        profile = profile_with(allergens=[AllergenTag.tree_nut])
+        original = recipe("walnuts", "almonds", "milk")
+        prompt_a = build_regeneration_prompt(profile, original, vs_a)
+        prompt_b = build_regeneration_prompt(profile, original, vs_b)
+        assert prompt_a == prompt_b
+
+
+# ---------------------------------------------------------------------------
+# Constraints block
+# ---------------------------------------------------------------------------
+
+
+class TestConstraintsBlockIncluded:
+    def test_vegan_profile_includes_constraints(self):
+        profile = profile_from_resolver(dietary_needs=["vegan"])
+        prompt = build_regeneration_prompt(
+            profile,
+            recipe("chicken breast"),
+            [_violation("chicken breast", "animal", reason=ViolationReason.dietary_forbid)],
+        )
+        assert "=== DIETARY CONSTRAINTS (MUST OBEY) ===" in prompt
+
+    def test_empty_profile_omits_constraints(self):
+        profile = ClientProfile(
+            client_id="test",
+            restriction_resolution=RestrictionResolution(),
+            clinical=ClinicalInfo(),
+        )
+        prompt = build_regeneration_prompt(
+            profile,
+            recipe("item"),
+            [_violation("item", None, reason=ViolationReason.unresolved_ingredient)],
+        )
+        assert "=== DIETARY CONSTRAINTS" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# Original meal context
+# ---------------------------------------------------------------------------
+
+
+class TestOriginalMealContext:
+    def test_original_name_present(self):
+        original = MealRecommendation(
+            name="Almond Cake", meal_type="dessert", ingredients=["almonds", "sugar"]
+        )
+        prompt = build_regeneration_prompt(
+            profile_with(allergens=[AllergenTag.tree_nut]),
+            original,
+            [_violation("almonds", "tree_nut")],
+        )
+        assert "Almond Cake" in prompt
+
+    def test_original_meal_type_present(self):
+        original = MealRecommendation(name="Pasta", meal_type="dinner")
+        prompt = build_regeneration_prompt(
+            profile_with(),
+            original,
+            [_violation("cheese", "dairy")],
+        )
+        assert "dinner" in prompt
+
+    def test_original_ingredients_not_in_prompt(self):
+        original = MealRecommendation(
+            name="Nut Salad",
+            meal_type="lunch",
+            ingredients=["cashews", "walnuts", "lettuce"],
+        )
+        prompt = build_regeneration_prompt(
+            profile_with(allergens=[AllergenTag.tree_nut]),
+            original,
+            [_violation("cashews", "tree_nut")],
+        )
+        assert "lettuce" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    def test_100_iterations_byte_identical(self):
+        profile = profile_from_resolver(
+            allergies=["tree nuts"],
+            dietary_needs=["vegan"],
+        )
+        original = MealRecommendation(
+            name="Bad Meal",
+            meal_type="dinner",
+            ingredients=["walnuts", "cream"],
+        )
+        vs = [
+            _violation("walnuts", "tree_nut"),
+            _violation("cream", "dairy"),
+        ]
+        baseline = build_regeneration_prompt(profile, original, vs)
+        for _ in range(100):
+            assert build_regeneration_prompt(profile, original, vs) == baseline
+
+
+# ---------------------------------------------------------------------------
+# Prompt structure
+# ---------------------------------------------------------------------------
+
+
+class TestPromptStructure:
+    def test_json_schema_present(self):
+        prompt = build_regeneration_prompt(
+            profile_with(),
+            recipe("item"),
+            [_violation("item", "tree_nut")],
+        )
+        assert '"MealRecommendation"' in prompt
+
+    def test_json_instruction_present(self):
+        prompt = build_regeneration_prompt(
+            profile_with(),
+            recipe("item"),
+            [_violation("item", "tree_nut")],
+        )
+        assert "Output JSON only" in prompt
+
+    def test_forbidden_before_instruction(self):
+        prompt = build_regeneration_prompt(
+            profile_with(),
+            recipe("item"),
+            [_violation("item", "tree_nut")],
+        )
+        forbidden_pos = prompt.index("FORBIDDEN INGREDIENTS")
+        instruction_pos = prompt.index("Output JSON only")
+        assert forbidden_pos < instruction_pos
+
+    def test_system_prompt_is_nonempty_string(self):
+        assert isinstance(REGENERATION_SYSTEM_PROMPT, str)
+        assert len(REGENERATION_SYSTEM_PROMPT) > 0


### PR DESCRIPTION
## Summary

- Add `regenerate_single(profile, original, violations) → MealRecommendation | None` method to `MealPlanningAgent` for targeted single-meal regeneration when the guardrail pipeline rejects a suggestion
- Create `regeneration_prompt.py` — pure-function prompt builder that constructs a deterministic prompt with an explicit FORBIDDEN ingredient list from violations, the full profile constraints block, and the MealRecommendation JSON schema
- Use `llm_service.complete_validated` (NutritionistAgent pattern) for structured output with built-in self-correction retry; return `None` on any LLM failure
- 26 new tests across two files: prompt content/structure/determinism tests and method integration tests covering happy path, all error modes, prompt wiring, and schema contract

## Test plan

- [x] `test_regeneration_prompt.py` — 15 tests: forbidden list rendering (single, multiple, None tag, dedup, sort order), constraints block inclusion/omission, original meal context, 100-iteration determinism, prompt structure
- [x] `test_regenerate_single.py` — 11 tests: happy path returns `MealRecommendation`, returns `None` on each error type (`LLMJsonParseError`, `LLMSchemaValidationError`, `LLMPermanentError`, `LLMError`, `RuntimeError`), prompt wiring (forbidden ingredients present, system prompt passed), schema contract (single object, not list)
- [x] All 57 meal_planning_agent tests pass (31 existing + 26 new)
- [x] `ruff check` + `ruff format --check` clean

Closes #337

https://claude.ai/code/session_01KcA3GpNKCxJnDDJfdnS9Kg

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcA3GpNKCxJnDDJfdnS9Kg)_