### PR TITLE
Bump status badge and agent chip font size to 0.7rem

### DIFF
--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
@@ -393,7 +393,7 @@ tbody .col-actions {
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  font-size: 0.65rem;
+  font-size: 0.7rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -556,7 +556,7 @@ tbody .col-actions {
   gap: 3px;
   padding: 2px 7px 2px 5px;
   border-radius: var(--kh-radius-full);
-  font-size: 0.65rem;
+  font-size: 0.7rem;
   font-weight: 500;
   white-space: nowrap;
   background: var(--kh-accent-subtle);


### PR DESCRIPTION
## Summary

- Bumps `.status-badge` and `.agent-chip` font-size from `0.65rem` (~10.4px) to `0.7rem` (~11.2px) for improved legibility on dense dashboard rows.
- No layout impact — chip widths are dominated by padding + icon + max-width on the phase span.

## Test plan

- [x] `npm run build` passes
- [x] All 1647 Vitest tests pass
- [ ] Visual check: table fits within 1440px CSS pixels
- [ ] No row-height regression beyond ~1px

Closes #485