### PR TITLE
blogging: convert integration-marked tests to unit tests using fake_job_client

### DIFF
--- a/backend/agents/blogging/tests/test_blogging_api.py
+++ b/backend/agents/blogging/tests/test_blogging_api.py
@@ -1,8 +1,7 @@
 """Tests for blogging API artifact endpoints.
 
-Calls the real ``create_blog_job`` / ``update_blog_job`` helpers, which
-hit the central job service.  Marked integration pending a follow-up
-that replaces the storage calls with the in-memory fake.
+Backed by an in-memory FakeJobServiceClient — no Postgres or live job service
+required.
 """
 
 import importlib.util
@@ -12,8 +11,6 @@ from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
-
-pytestmark = [pytest.mark.integration]
 
 _blogging_root = Path(__file__).resolve().parent.parent
 if str(_blogging_root) not in sys.path:
@@ -28,24 +25,17 @@ _spec.loader.exec_module(_api_main)
 app = _api_main.app
 
 
+@pytest.fixture(autouse=True)
+def _patched_blog_client(monkeypatch, fake_job_client):
+    from shared import blog_job_store as bjs
+
+    monkeypatch.setattr(bjs, "_client", lambda *a, **kw: fake_job_client)
+    return fake_job_client
+
+
 @pytest.fixture
 def client() -> TestClient:
     return TestClient(app)
-
-
-def test_health_includes_brand_spec_configured(client: TestClient) -> None:
-    """GET /health returns brand_spec_configured when the blogging package has a substantive brand spec file."""
-    r = client.get("/health")
-    assert r.status_code == 200
-    data = r.json()
-    assert data.get("status") == "ok"
-    assert "brand_spec_configured" in data
-    assert isinstance(data["brand_spec_configured"], bool)
-
-
-@pytest.fixture
-def cache_dir(tmp_path: Path):
-    return tmp_path
 
 
 @pytest.fixture
@@ -58,28 +48,28 @@ def artifacts_dir(tmp_path: Path) -> Path:
     return d
 
 
+def test_health_includes_brand_spec_configured(client: TestClient) -> None:
+    """GET /health returns brand_spec_configured when the blogging package has a substantive brand spec file."""
+    r = client.get("/health")
+    assert r.status_code == 200
+    data = r.json()
+    assert data.get("status") == "ok"
+    assert "brand_spec_configured" in data
+    assert isinstance(data["brand_spec_configured"], bool)
+
+
 def test_list_job_artifacts_404_when_job_missing(client: TestClient) -> None:
     """GET /job/{id}/artifacts returns 404 when job_id does not exist."""
     r = client.get(f"/job/{uuid.uuid4()}/artifacts")
     assert r.status_code == 404
 
 
-def test_list_job_artifacts_404_when_no_work_dir(
-    client: TestClient, cache_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_list_job_artifacts_404_when_no_work_dir(client: TestClient) -> None:
     """GET /job/{id}/artifacts returns 404 when job exists but has no work_dir."""
-    from shared.blog_job_store import create_blog_job, get_blog_job
+    from shared.blog_job_store import create_blog_job
 
     job_id = str(uuid.uuid4())
-    create_blog_job(job_id, "Brief", cache_dir=cache_dir)
-    original = _api_main.get_blog_job
-
-    def get_job(jid):
-        if jid == job_id:
-            return get_blog_job(jid, cache_dir=cache_dir)
-        return original(jid)
-
-    monkeypatch.setattr(_api_main, "get_blog_job", get_job)
+    create_blog_job(job_id, "Brief")
     r = client.get(f"/job/{job_id}/artifacts")
     assert r.status_code == 404
     detail = r.json().get("detail", "").lower()
@@ -87,22 +77,14 @@ def test_list_job_artifacts_404_when_no_work_dir(
 
 
 def test_list_job_artifacts_200_when_artifacts_exist(
-    client: TestClient, cache_dir: Path, artifacts_dir: Path, monkeypatch: pytest.MonkeyPatch
+    client: TestClient, artifacts_dir: Path
 ) -> None:
     """GET /job/{id}/artifacts returns 200 with list of existing artifact names."""
-    from shared.blog_job_store import create_blog_job, get_blog_job, update_blog_job
+    from shared.blog_job_store import create_blog_job, update_blog_job
 
     job_id = str(uuid.uuid4())
-    create_blog_job(job_id, "Brief", cache_dir=cache_dir)
-    update_blog_job(job_id, work_dir=str(artifacts_dir), cache_dir=cache_dir)
-    original = _api_main.get_blog_job
-
-    def get_job(jid):
-        if jid == job_id:
-            return get_blog_job(jid, cache_dir=cache_dir)
-        return original(jid)
-
-    monkeypatch.setattr(_api_main, "get_blog_job", get_job)
+    create_blog_job(job_id, "Brief")
+    update_blog_job(job_id, work_dir=str(artifacts_dir))
     r = client.get(f"/job/{job_id}/artifacts")
     assert r.status_code == 200
     data = r.json()
@@ -113,52 +95,31 @@ def test_list_job_artifacts_200_when_artifacts_exist(
     assert "final.md" in names
     assert "outline.md" in names
     assert "compliance_report.json" in names
-    # Response includes producer metadata per artifact
     final_meta = next((a for a in artifacts if a["name"] == "final.md"), None)
     assert final_meta is not None
     assert "producer_phase" in final_meta or "producer_agent" in final_meta
 
 
-def test_get_job_artifact_content_404_invalid_name(
-    client: TestClient, cache_dir: Path, artifacts_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_get_job_artifact_content_404_invalid_name(client: TestClient, artifacts_dir: Path) -> None:
     """GET /job/{id}/artifacts/{name} returns 404 when artifact_name is not in ARTIFACT_NAMES."""
-    from shared.blog_job_store import create_blog_job, get_blog_job, update_blog_job
+    from shared.blog_job_store import create_blog_job, update_blog_job
 
     job_id = str(uuid.uuid4())
-    create_blog_job(job_id, "Brief", cache_dir=cache_dir)
-    update_blog_job(job_id, work_dir=str(artifacts_dir), cache_dir=cache_dir)
-    original = _api_main.get_blog_job
-
-    def get_job(jid):
-        if jid == job_id:
-            return get_blog_job(jid, cache_dir=cache_dir)
-        return original(jid)
-
-    monkeypatch.setattr(_api_main, "get_blog_job", get_job)
+    create_blog_job(job_id, "Brief")
+    update_blog_job(job_id, work_dir=str(artifacts_dir))
     r = client.get(f"/job/{job_id}/artifacts/../etc/passwd")
     assert r.status_code == 404
     r2 = client.get(f"/job/{job_id}/artifacts/unknown_file.txt")
     assert r2.status_code == 404
 
 
-def test_get_job_artifact_content_200(
-    client: TestClient, cache_dir: Path, artifacts_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_get_job_artifact_content_200(client: TestClient, artifacts_dir: Path) -> None:
     """GET /job/{id}/artifacts/{name} returns 200 with { name, content } for valid artifact."""
-    from shared.blog_job_store import create_blog_job, get_blog_job, update_blog_job
+    from shared.blog_job_store import create_blog_job, update_blog_job
 
     job_id = str(uuid.uuid4())
-    create_blog_job(job_id, "Brief", cache_dir=cache_dir)
-    update_blog_job(job_id, work_dir=str(artifacts_dir), cache_dir=cache_dir)
-    original = _api_main.get_blog_job
-
-    def get_job(jid):
-        if jid == job_id:
-            return get_blog_job(jid, cache_dir=cache_dir)
-        return original(jid)
-
-    monkeypatch.setattr(_api_main, "get_blog_job", get_job)
+    create_blog_job(job_id, "Brief")
+    update_blog_job(job_id, work_dir=str(artifacts_dir))
     r = client.get(f"/job/{job_id}/artifacts/final.md")
     assert r.status_code == 200
     data = r.json()
@@ -174,22 +135,14 @@ def test_get_job_artifact_content_200(
 
 
 def test_get_job_artifact_download_returns_attachment(
-    client: TestClient, cache_dir: Path, artifacts_dir: Path, monkeypatch: pytest.MonkeyPatch
+    client: TestClient, artifacts_dir: Path
 ) -> None:
     """GET /job/{id}/artifacts/{name}?download=true returns Content-Disposition attachment with filename."""
-    from shared.blog_job_store import create_blog_job, get_blog_job, update_blog_job
+    from shared.blog_job_store import create_blog_job, update_blog_job
 
     job_id = str(uuid.uuid4())
-    create_blog_job(job_id, "Brief", cache_dir=cache_dir)
-    update_blog_job(job_id, work_dir=str(artifacts_dir), cache_dir=cache_dir)
-    original = _api_main.get_blog_job
-
-    def get_job(jid):
-        if jid == job_id:
-            return get_blog_job(jid, cache_dir=cache_dir)
-        return original(jid)
-
-    monkeypatch.setattr(_api_main, "get_blog_job", get_job)
+    create_blog_job(job_id, "Brief")
+    update_blog_job(job_id, work_dir=str(artifacts_dir))
     r = client.get(f"/job/{job_id}/artifacts/final.md", params={"download": True})
     assert r.status_code == 200
     assert "content-disposition" in r.headers
@@ -197,52 +150,23 @@ def test_get_job_artifact_download_returns_attachment(
     assert "final.md" in r.headers["content-disposition"]
 
 
-def test_approve_job_400_when_not_terminal(
-    client: TestClient, cache_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_approve_job_400_when_not_terminal(client: TestClient) -> None:
     """POST /job/{id}/approve returns 400 when job status is not completed or needs_human_review."""
-    from shared.blog_job_store import create_blog_job, get_blog_job
+    from shared.blog_job_store import create_blog_job
 
     job_id = str(uuid.uuid4())
-    create_blog_job(job_id, "Brief", cache_dir=cache_dir)
-    original = _api_main.get_blog_job
-
-    def get_job(jid):
-        if jid == job_id:
-            return get_blog_job(jid, cache_dir=cache_dir)
-        return original(jid)
-
-    monkeypatch.setattr(_api_main, "get_blog_job", get_job)
+    create_blog_job(job_id, "Brief")
     r = client.post(f"/job/{job_id}/approve")
     assert r.status_code == 400
 
 
-def test_approve_job_200_and_includes_approved_at(
-    client: TestClient, cache_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_approve_job_200_and_includes_approved_at(client: TestClient) -> None:
     """POST /job/{id}/approve returns 200 and response includes approved_at when job is completed."""
-    from shared.blog_job_store import (
-        create_blog_job,
-        get_blog_job,
-        update_blog_job,
-    )
+    from shared.blog_job_store import create_blog_job, update_blog_job
 
     job_id = str(uuid.uuid4())
-    create_blog_job(job_id, "Brief", cache_dir=cache_dir)
-    update_blog_job(job_id, status="completed", cache_dir=cache_dir)
-    original_get = _api_main.get_blog_job
-    original_approve = _api_main.approve_blog_job
-
-    def get_job(jid):
-        if jid == job_id:
-            return get_blog_job(jid, cache_dir=cache_dir)
-        return original_get(jid)
-
-    def approve(jid):
-        return original_approve(jid, cache_dir=cache_dir)
-
-    monkeypatch.setattr(_api_main, "get_blog_job", get_job)
-    monkeypatch.setattr(_api_main, "approve_blog_job", approve)
+    create_blog_job(job_id, "Brief")
+    update_blog_job(job_id, status="completed")
     r = client.post(f"/job/{job_id}/approve")
     assert r.status_code == 200
     data = r.json()
@@ -250,34 +174,14 @@ def test_approve_job_200_and_includes_approved_at(
     assert data["approved_at"]
 
 
-def test_unapprove_job_200(
-    client: TestClient, cache_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_unapprove_job_200(client: TestClient) -> None:
     """POST /job/{id}/unapprove returns 200 and clears approved_at."""
-    from shared.blog_job_store import (
-        approve_blog_job,
-        create_blog_job,
-        get_blog_job,
-        update_blog_job,
-    )
+    from shared.blog_job_store import approve_blog_job, create_blog_job, update_blog_job
 
     job_id = str(uuid.uuid4())
-    create_blog_job(job_id, "Brief", cache_dir=cache_dir)
-    update_blog_job(job_id, status="completed", cache_dir=cache_dir)
-    approve_blog_job(job_id, cache_dir=cache_dir)
-    original_get = _api_main.get_blog_job
-    original_unapprove = _api_main.unapprove_blog_job
-
-    def get_job(jid):
-        if jid == job_id:
-            return get_blog_job(jid, cache_dir=cache_dir)
-        return original_get(jid)
-
-    def unapprove(jid):
-        return original_unapprove(jid, cache_dir=cache_dir)
-
-    monkeypatch.setattr(_api_main, "get_blog_job", get_job)
-    monkeypatch.setattr(_api_main, "unapprove_blog_job", unapprove)
+    create_blog_job(job_id, "Brief")
+    update_blog_job(job_id, status="completed")
+    approve_blog_job(job_id)
     r = client.post(f"/job/{job_id}/unapprove")
     assert r.status_code == 200
     data = r.json()

--- a/backend/agents/blogging/tests/test_medium_stats_api.py
+++ b/backend/agents/blogging/tests/test_medium_stats_api.py
@@ -1,7 +1,7 @@
 """API tests for Medium stats endpoints (agent mocked — no browser).
 
-MIXED file: one test polls a real async job loop; the other two could run
-on the in-memory fake.  Marked integration until we split it.
+Backed by an in-memory FakeJobServiceClient — no Postgres or live job service
+required.  The async tests still poll a real background thread for completion.
 """
 
 import importlib.util
@@ -11,8 +11,6 @@ from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
-
-pytestmark = [pytest.mark.integration]
 
 _blogging_root = Path(__file__).resolve().parent.parent
 if str(_blogging_root) not in sys.path:
@@ -27,54 +25,28 @@ _spec.loader.exec_module(_api_main)
 app = _api_main.app
 
 
-@pytest.fixture
-def client() -> TestClient:
-    return TestClient(app)
+@pytest.fixture(autouse=True)
+def _patched_blog_client(monkeypatch, fake_job_client):
+    from shared import blog_job_store as bjs
+
+    monkeypatch.setattr(bjs, "_client", lambda *a, **kw: fake_job_client)
+    return fake_job_client
 
 
-@pytest.fixture
-def cache_dir(tmp_path: Path) -> Path:
-    return tmp_path
-
-
-def _patch_job_store(cache_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.fixture(autouse=True)
+def _medium_stats_tmp_dir(monkeypatch, tmp_path):
     from shared import blog_job_store as bjs
 
     monkeypatch.setattr(
         _api_main,
-        "create_blog_job",
-        lambda jid, brief, **kw: bjs.create_blog_job(jid, brief, cache_dir=cache_dir, **kw),
-    )
-    monkeypatch.setattr(
-        _api_main,
-        "get_blog_job",
-        lambda jid: bjs.get_blog_job(jid, cache_dir=cache_dir),
-    )
-    monkeypatch.setattr(
-        _api_main,
-        "update_blog_job",
-        lambda jid, **kw: bjs.update_blog_job(jid, cache_dir=cache_dir, **kw),
-    )
-    monkeypatch.setattr(
-        _api_main,
-        "start_blog_job",
-        lambda jid: bjs.start_blog_job(jid, cache_dir=cache_dir),
-    )
-    monkeypatch.setattr(
-        _api_main,
-        "fail_blog_job",
-        lambda jid, **kw: bjs.fail_blog_job(jid, cache_dir=cache_dir, **kw),
-    )
-    monkeypatch.setattr(
-        _api_main,
-        "list_blog_jobs",
-        lambda **kw: bjs.list_blog_jobs(cache_dir=cache_dir, **kw),
-    )
-    monkeypatch.setattr(
-        _api_main,
         "medium_stats_run_dir",
-        lambda jid: bjs.medium_stats_run_dir(jid, cache_dir=cache_dir),
+        lambda jid, **kw: bjs.medium_stats_run_dir(jid, cache_dir=tmp_path),
     )
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
 
 
 def test_medium_stats_sync_returns_503_without_integration(client: TestClient) -> None:
@@ -87,7 +59,6 @@ def test_medium_stats_sync_returns_503_without_integration(client: TestClient) -
 
 def test_medium_stats_async_writes_artifact(
     client: TestClient,
-    cache_dir: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Async job completes and persists medium_stats_report.json when collect is mocked."""
@@ -108,7 +79,6 @@ def test_medium_stats_async_writes_artifact(
 
     monkeypatch.setattr(_api_main, "BlogMediumStatsAgent", FakeBlogMediumStatsAgent)
     monkeypatch.setattr(_api_main, "medium_stats_integration_eligible", lambda: (True, ""))
-    _patch_job_store(cache_dir, monkeypatch)
 
     r = client.post("/medium-stats-async", json={"headless": True})
     assert r.status_code == 200
@@ -141,7 +111,6 @@ def test_medium_stats_async_writes_artifact(
 
 def test_jobs_list_includes_job_type_for_medium_stats(
     client: TestClient,
-    cache_dir: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from blog_medium_stats_agent.models import MediumStatsReport
@@ -152,7 +121,6 @@ def test_jobs_list_includes_job_type_for_medium_stats(
 
     monkeypatch.setattr(_api_main, "BlogMediumStatsAgent", FakeBlogMediumStatsAgent)
     monkeypatch.setattr(_api_main, "medium_stats_integration_eligible", lambda: (True, ""))
-    _patch_job_store(cache_dir, monkeypatch)
 
     r = client.post("/medium-stats-async", json={})
     job_id = r.json()["job_id"]


### PR DESCRIPTION
## Summary

- Convert `test_blogging_api.py` and `test_medium_stats_api.py` from integration tests to unit tests by replacing real job service calls with the in-memory `FakeJobServiceClient`
- Remove `pytestmark = [pytest.mark.integration]` so tests run in the default CI unit-test pass
- Add autouse `_patched_blog_client` fixture (same pattern as `test_blog_job_store.py` from PR #360) that patches `blog_job_store._client` at the source
- Eliminate ~130 lines of per-test monkeypatch boilerplate (get_job closures, cache_dir threading, `_patch_job_store` helper)

## Test plan

- [x] All 13 tests pass without a running job service (`JOB_SERVICE_URL` points at placeholder)
- [x] Tests are collected normally (no `-m integration` flag needed)
- [x] Full blogging test suite (533 tests) passes with no regressions
- [x] `ruff check` and `ruff format --check` clean

Closes #362

https://claude.ai/code/session_01KHKmrr67J8auzyJXuNQFH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHKmrr67J8auzyJXuNQFH1)_