### PR TITLE
jobs-dashboard: consolidate empty-cell em-dashes

### DIFF
--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.html
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.html
@@ -158,7 +158,7 @@
                   } @else if (getShowIndeterminate(job)) {
                     <mat-progress-bar mode="indeterminate"></mat-progress-bar>
                   } @else {
-                    <span class="progress-na">—</span>
+                    <span class="cell-empty">·</span>
                   }
                 </div>
               </td>
@@ -174,7 +174,7 @@
                     }
                   </div>
                 } @else {
-                  <span class="agents-na">—</span>
+                  <span class="cell-empty">·</span>
                 }
               </td>
               <td class="col-time">

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
@@ -530,9 +530,10 @@ tbody .col-actions {
   }
 }
 
-.progress-na,
-.agents-na {
-  color: var(--kh-text-secondary);
+.cell-empty {
+  color: var(--kh-text-muted);
+  opacity: 0.5;
+  user-select: none;
 }
 
 .time-ago {

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
@@ -1186,6 +1186,31 @@ describe('JobsDashboardComponent', () => {
     });
   });
 
+  it('renders muted middle-dot in both progress and agents cells when data is absent', () => {
+    component.jobs = [
+      {
+        unified: {
+          source: 'blogging',
+          jobId: 'empty-1',
+          status: 'pending',
+          createdAt: new Date().toISOString(),
+          label: 'Draft post',
+        },
+        seDetail: undefined,
+      } as any,
+    ];
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const empties = host.querySelectorAll('.cell-empty');
+    expect(empties.length).toBe(2);
+    for (const el of Array.from(empties)) {
+      expect(el.textContent?.trim()).toBe('·');
+    }
+    expect(host.querySelectorAll('.progress-na').length).toBe(0);
+    expect(host.querySelectorAll('.agents-na').length).toBe(0);
+  });
+
   describe('live-refresh indicator', () => {
     it('renders a pulsing live-dot next to the timestamp once lastUpdated is set', () => {
       component.lastUpdated = new Date();


### PR DESCRIPTION
## Summary

- Replace two separate em-dash (`—`) placeholders (`.progress-na`, `.agents-na`) with a single `.cell-empty` class rendering a muted middle-dot (`·`) at 50% opacity
- Visually quieter rows when both Progress and Active Agents cells lack data — one consistent pattern instead of two identical dashes competing for attention
- Added test verifying both empty cells render the new `.cell-empty` span

## Test plan

- [x] `npx vitest run src/app/components/jobs-dashboard/` — 84 tests passing (including new empty-cell test)
- [x] `npx ng build --configuration development` — clean build
- [ ] Visual check: rows with missing progress/agents show a quiet `·` instead of bold `—`

Closes #484

https://claude.ai/code/session_01MsGJGKM55s9VVfzSQyt3us

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsGJGKM55s9VVfzSQyt3us)_