### PR TITLE
Soften jobs-dashboard column-header typography

### DIFF
--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
@@ -291,8 +291,6 @@
       text-align: left;
       font-weight: 600;
       font-size: var(--kh-text-xs);
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
       color: var(--kh-text-secondary);
       white-space: nowrap;
     }


### PR DESCRIPTION
## Summary

- Remove `text-transform: uppercase` and `letter-spacing: 0.06em` from `thead th` in the jobs dashboard
- Headers now display in their natural sentence case (e.g. "Repository / Context", "Active Agents") with a calmer, less "shouty" look
- No HTML or test changes needed — the markup already used sentence case

## Test plan

- [x] All 82 jobs-dashboard component tests pass
- [ ] Visually verify header hierarchy and rhythm vs. row content

Closes #486

https://claude.ai/code/session_01BSVWYmxQQBJBqAt2rkdT1u

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSVWYmxQQBJBqAt2rkdT1u)_