### PR TITLE
Move secondary actions into overflow menu in jobs dashboard

### DIFF
--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.html
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.html
@@ -202,28 +202,34 @@
                   <button mat-icon-button
                           class="resume-button"
                           (click)="resumeJob($event, job)"
-                          matTooltip="Resume job (continue from where it left off, e.g. after server restart)"
+                          matTooltip="Resume job"
                           [attr.aria-label]="getActionAriaLabel(job, 'Resume')">
                     <mat-icon>play_arrow</mat-icon>
                   </button>
                 }
-                @if (canRestartJob(job)) {
+                @if (hasOverflowActions(job)) {
                   <button mat-icon-button
-                          class="restart-button"
-                          (click)="restartJob($event, job)"
-                          matTooltip="Restart from scratch (same job, workflow runs again from the start)"
-                          [attr.aria-label]="getActionAriaLabel(job, 'Restart')">
-                    <mat-icon>replay</mat-icon>
+                          class="overflow-button"
+                          [matMenuTriggerFor]="overflowMenu"
+                          (click)="$event.stopPropagation()"
+                          matTooltip="More actions"
+                          [attr.aria-label]="getActionAriaLabel(job, 'More actions')">
+                    <mat-icon>more_vert</mat-icon>
                   </button>
-                }
-                @if (canDeleteJob(job)) {
-                  <button mat-icon-button
-                          class="delete-button"
-                          (click)="deleteJob($event, job)"
-                          matTooltip="Delete job"
-                          [attr.aria-label]="getActionAriaLabel(job, 'Delete')">
-                    <mat-icon>delete</mat-icon>
-                  </button>
+                  <mat-menu #overflowMenu="matMenu" xPosition="before">
+                    @if (canRestartJob(job)) {
+                      <button mat-menu-item (click)="restartJob($event, job)">
+                        <mat-icon>replay</mat-icon>
+                        <span>Restart</span>
+                      </button>
+                    }
+                    @if (canDeleteJob(job)) {
+                      <button mat-menu-item (click)="deleteJob($event, job)">
+                        <mat-icon>delete</mat-icon>
+                        <span>Delete</span>
+                      </button>
+                    }
+                  </mat-menu>
                 }
               </td>
             </tr>

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
@@ -631,14 +631,9 @@ tbody .col-actions {
   &:hover { background: var(--kh-accent-subtle) !important; }
 }
 
-.restart-button {
-  color: #c084fc !important;
-  &:hover { background: rgba(168, 85, 247, 0.12) !important; }
-}
-
-.delete-button {
+.overflow-button {
   color: var(--kh-text-muted) !important;
-  &:hover { background: var(--kh-error-subtle) !important; color: var(--kh-error) !important; }
+  &:hover { background: var(--kh-glass) !important; }
 }
 
 // ── Animation ───────────────────────────────────────────────────────────────

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { of } from 'rxjs';
@@ -102,7 +103,7 @@ describe('JobsDashboardComponent', () => {
     };
 
     await TestBed.configureTestingModule({
-      imports: [JobsDashboardComponent],
+      imports: [JobsDashboardComponent, NoopAnimationsModule],
       providers: [
         provideHttpClient(),
         provideHttpClientTesting(),
@@ -428,11 +429,9 @@ describe('JobsDashboardComponent', () => {
       fixture.detectChanges();
 
       const host = fixture.nativeElement as HTMLElement;
-      // status 'completed' → restart + delete are visible, stop + resume are not.
-      const restart = host.querySelector('button.restart-button');
-      const del = host.querySelector('button.delete-button');
-      expect(restart?.getAttribute('aria-label')).toBe('Restart Blogging Blog pipeline job for Sample Post');
-      expect(del?.getAttribute('aria-label')).toBe('Delete Blogging Blog pipeline job for Sample Post');
+      // status 'completed' → overflow trigger visible, stop + resume are not.
+      const overflow = host.querySelector('button.overflow-button');
+      expect(overflow?.getAttribute('aria-label')).toBe('More actions Blogging Blog pipeline job for Sample Post');
     });
   });
 
@@ -1209,6 +1208,149 @@ describe('JobsDashboardComponent', () => {
     }
     expect(host.querySelectorAll('.progress-na').length).toBe(0);
     expect(host.querySelectorAll('.agents-na').length).toBe(0);
+  });
+
+  describe('hasOverflowActions', () => {
+    const makeJob = (status: string): any => ({
+      unified: { source: 'blogging', jobId: 'j1', status },
+      seDetail: undefined,
+    });
+
+    it('returns true for terminal statuses (restart or delete available)', () => {
+      expect(component.hasOverflowActions(makeJob('completed'))).toBe(true);
+      expect(component.hasOverflowActions(makeJob('failed'))).toBe(true);
+      expect(component.hasOverflowActions(makeJob('cancelled'))).toBe(true);
+      expect(component.hasOverflowActions(makeJob('interrupted'))).toBe(true);
+      expect(component.hasOverflowActions(makeJob('agent_crash'))).toBe(true);
+    });
+
+    it('returns false for running/pending (no restart or delete)', () => {
+      expect(component.hasOverflowActions(makeJob('running'))).toBe(false);
+      expect(component.hasOverflowActions(makeJob('pending'))).toBe(false);
+    });
+  });
+
+  describe('overflow menu', () => {
+    const makeRow = (status: string, source = 'blogging'): any => ({
+      unified: {
+        source,
+        jobId: 'j1',
+        status,
+        label: 'Test Job',
+        createdAt: new Date().toISOString(),
+      },
+      seDetail: undefined,
+    });
+
+    it('renders overflow trigger for completed status', () => {
+      component.jobs = [makeRow('completed')];
+      fixture.detectChanges();
+      const host = fixture.nativeElement as HTMLElement;
+      expect(host.querySelector('.overflow-button')).toBeTruthy();
+    });
+
+    it('renders overflow trigger for failed status', () => {
+      component.jobs = [makeRow('failed')];
+      fixture.detectChanges();
+      const host = fixture.nativeElement as HTMLElement;
+      expect(host.querySelector('.overflow-button')).toBeTruthy();
+    });
+
+    it('does not render overflow trigger for running jobs', () => {
+      component.jobs = [makeRow('running')];
+      fixture.detectChanges();
+      const host = fixture.nativeElement as HTMLElement;
+      expect(host.querySelector('.overflow-button')).toBeNull();
+    });
+
+    it('does not render overflow trigger for pending jobs', () => {
+      component.jobs = [makeRow('pending')];
+      fixture.detectChanges();
+      const host = fixture.nativeElement as HTMLElement;
+      expect(host.querySelector('.overflow-button')).toBeNull();
+    });
+
+    it('running jobs show only Stop inline, no overflow', () => {
+      component.jobs = [makeRow('running')];
+      fixture.detectChanges();
+      const actions = fixture.nativeElement.querySelector('td.col-actions');
+      expect(actions?.querySelectorAll('button.stop-button').length).toBe(1);
+      expect(actions?.querySelectorAll('button.resume-button').length).toBe(0);
+      expect(actions?.querySelectorAll('button.overflow-button').length).toBe(0);
+    });
+
+    it('failed jobs show Resume inline plus overflow', () => {
+      component.jobs = [makeRow('failed')];
+      fixture.detectChanges();
+      const actions = fixture.nativeElement.querySelector('td.col-actions');
+      expect(actions?.querySelectorAll('button.stop-button').length).toBe(0);
+      expect(actions?.querySelectorAll('button.resume-button').length).toBe(1);
+      expect(actions?.querySelectorAll('button.overflow-button').length).toBe(1);
+    });
+
+    it('completed jobs show only overflow trigger, no inline primary action', () => {
+      component.jobs = [makeRow('completed')];
+      fixture.detectChanges();
+      const actions = fixture.nativeElement.querySelector('td.col-actions');
+      expect(actions?.querySelectorAll('button.stop-button').length).toBe(0);
+      expect(actions?.querySelectorAll('button.resume-button').length).toBe(0);
+      expect(actions?.querySelectorAll('button.overflow-button').length).toBe(1);
+    });
+
+    it('overflow trigger click stops event propagation', () => {
+      component.jobs = [makeRow('completed')];
+      fixture.detectChanges();
+      const overflowBtn = fixture.nativeElement.querySelector('.overflow-button') as HTMLElement;
+      const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+      const stopSpy = vi.spyOn(clickEvent, 'stopPropagation');
+      overflowBtn.dispatchEvent(clickEvent);
+      expect(stopSpy).toHaveBeenCalled();
+    });
+
+    it('overflow menu contains Restart and Delete items for completed status', () => {
+      component.jobs = [makeRow('completed')];
+      fixture.detectChanges();
+      const overflowBtn = fixture.nativeElement.querySelector('.overflow-button') as HTMLElement;
+      overflowBtn.click();
+      fixture.detectChanges();
+      const overlay = document.querySelector('.cdk-overlay-container');
+      const items = Array.from(overlay?.querySelectorAll('[mat-menu-item]') ?? []);
+      const spans = items.map((el) => el.querySelector('span')?.textContent?.trim());
+      expect(spans).toContain('Restart');
+      expect(spans).toContain('Delete');
+    });
+
+    it('clicking Restart menu item triggers restartJob with confirmation dialog', () => {
+      dialogSpy.open.mockReturnValue({ afterClosed: () => of(true) });
+      component.jobs = [makeRow('failed', 'software_engineering')];
+      fixture.detectChanges();
+      const overflowBtn = fixture.nativeElement.querySelector('.overflow-button') as HTMLElement;
+      overflowBtn.click();
+      fixture.detectChanges();
+      const overlay = document.querySelector('.cdk-overlay-container');
+      const items = Array.from(overlay?.querySelectorAll('[mat-menu-item]') ?? []);
+      const restartItem = items.find((el) => el.querySelector('span')?.textContent?.trim() === 'Restart') as HTMLElement;
+      restartItem?.click();
+      fixture.detectChanges();
+      expect(dialogSpy.open).toHaveBeenCalled();
+      expect(jobActionsSpy.restart).toHaveBeenCalledWith('software_engineering', 'j1');
+    });
+
+    it('clicking Delete menu item triggers deleteJob with confirmation dialog', () => {
+      dialogSpy.open.mockReturnValue({ afterClosed: () => of(true) });
+      component.jobs = [makeRow('completed')];
+      fixture.detectChanges();
+      const overflowBtn = fixture.nativeElement.querySelector('.overflow-button') as HTMLElement;
+      overflowBtn.click();
+      fixture.detectChanges();
+      const overlay = document.querySelector('.cdk-overlay-container');
+      const items = Array.from(overlay?.querySelectorAll('[mat-menu-item]') ?? []);
+      const deleteItem = items.find((el) => el.querySelector('span')?.textContent?.trim() === 'Delete') as HTMLElement;
+      deleteItem?.click();
+      fixture.detectChanges();
+      expect(dialogSpy.open).toHaveBeenCalled();
+      expect(jobActionsSpy.delete).toHaveBeenCalledWith('blogging', 'j1');
+    });
   });
 
   describe('live-refresh indicator', () => {

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
@@ -6,6 +6,7 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatMenuModule } from '@angular/material/menu';
 import { MatDialog } from '@angular/material/dialog';
 import { Subscription, forkJoin, of, timer } from 'rxjs';
 import { switchMap, catchError, map } from 'rxjs/operators';
@@ -147,6 +148,7 @@ interface PersistedFilters {
     MatIconModule,
     MatButtonModule,
     MatTooltipModule,
+    MatMenuModule,
   ],
   templateUrl: './jobs-dashboard.component.html',
   styleUrl: './jobs-dashboard.component.scss',
@@ -731,7 +733,7 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
     return parts.join(', ');
   }
 
-  getActionAriaLabel(job: DashboardRow, action: 'Stop' | 'Resume' | 'Restart' | 'Delete'): string {
+  getActionAriaLabel(job: DashboardRow, action: 'Stop' | 'Resume' | 'Restart' | 'Delete' | 'More actions'): string {
     const team = SOURCE_DISPLAY[job.unified.source]?.label ?? job.unified.source;
     const type = this.getJobTypeInfo(job).label;
     const subject =
@@ -820,6 +822,10 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
 
   canDeleteJob(job: DashboardRow): boolean {
     return job.unified.status !== 'running' && job.unified.status !== 'pending';
+  }
+
+  hasOverflowActions(job: DashboardRow): boolean {
+    return this.canRestartJob(job) || this.canDeleteJob(job);
   }
 
   trackByJobId(_index: number, job: DashboardRow): string {


### PR DESCRIPTION
## Summary

- Moves Restart and Delete actions behind a `more_vert` overflow menu (`MatMenuModule`)
- Keeps only the primary contextual action inline: Stop for running/pending, Resume for failed/interrupted/cancelled/agent_crash
- Narrows the Actions column and reduces visual clutter per row

## Changes

| Status | Inline button | Overflow items |
|--------|--------------|----------------|
| running / pending | Stop | _(none)_ |
| failed / interrupted / cancelled / agent_crash | Resume | Restart, Delete |
| completed | _(none)_ | Restart, Delete |

## Test plan

- [x] All 95 jobs-dashboard tests pass (including 12 new overflow menu tests)
- [x] Full frontend suite passes (1661 tests, 139 files)
- [x] Production build succeeds
- [ ] Visual verification: action column narrower, one inline button max, overflow shows Restart/Delete

Closes #491

https://claude.ai/code/session_01BJqq29qvL9aErbQFga2Mzj