### PR TITLE
jobs-dashboard: top-of-table progress bar during refresh

### DIFF
--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.html
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.html
@@ -97,6 +97,9 @@
     </div>
   } @else {
     <div class="jobs-table-container">
+      @if (loading) {
+        <mat-progress-bar class="table-refresh-bar" mode="indeterminate"></mat-progress-bar>
+      }
       <table class="jobs-table">
         <thead>
           <tr>

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
@@ -268,11 +268,21 @@
 // ── Table ───────────────────────────────────────────────────────────────────
 
 .jobs-table-container {
+  position: relative;
   background: var(--kh-surface-2);
   border-radius: var(--kh-radius-lg);
   border: 1px solid var(--kh-border);
   box-shadow: var(--kh-shadow-md);
   overflow: hidden;
+}
+
+.table-refresh-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  z-index: 1;
 }
 
 .jobs-table {
@@ -357,8 +367,9 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .stuck-indicator { animation: none; opacity: 1; }
-  .live-dot        { animation: none; opacity: 1; }
+  .stuck-indicator   { animation: none; opacity: 1; }
+  .live-dot          { animation: none; opacity: 1; }
+  .table-refresh-bar { display: none; }
 }
 
 // ── Column Widths ───────────────────────────────────────────────────────────

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
@@ -1385,4 +1385,65 @@ describe('JobsDashboardComponent', () => {
       expect(component.isPollingActive).toBe(false);
     });
   });
+
+  describe('table refresh progress bar', () => {
+    const row = (jobId: string) =>
+      ({
+        unified: {
+          source: 'software_engineering',
+          jobId,
+          status: 'running',
+          createdAt: new Date().toISOString(),
+          label: 'Run',
+          progress: 50,
+        },
+        seDetail: undefined,
+      }) as any;
+
+    it('renders an indeterminate progress bar at the top of the table when loading is true', () => {
+      component.jobs = [row('j1')];
+      component.loading = true;
+      fixture.detectChanges();
+
+      const host = fixture.nativeElement as HTMLElement;
+      const bar = host.querySelector('.jobs-table-container .table-refresh-bar');
+      expect(bar).toBeTruthy();
+      expect(bar?.getAttribute('mode')).toBe('indeterminate');
+      expect(bar?.getAttribute('role')).toBe('progressbar');
+    });
+
+    it('does not render the refresh bar when loading is false', () => {
+      component.jobs = [row('j1')];
+      component.loading = false;
+      fixture.detectChanges();
+
+      const bar = fixture.nativeElement.querySelector('.jobs-table-container .table-refresh-bar');
+      expect(bar).toBeNull();
+    });
+
+    it('bar disappears after loading flips from true to false', () => {
+      component.jobs = [row('j1')];
+      component.loading = true;
+      fixture.detectChanges();
+
+      const host = fixture.nativeElement as HTMLElement;
+      expect(host.querySelector('.table-refresh-bar')).toBeTruthy();
+
+      component.loading = false;
+      fixture.detectChanges();
+
+      expect(host.querySelector('.table-refresh-bar')).toBeNull();
+    });
+
+    it('does not render the refresh bar when no jobs exist', () => {
+      component.jobs = [];
+      component.loading = true;
+      fixture.detectChanges();
+
+      const host = fixture.nativeElement as HTMLElement;
+      expect(host.querySelector('.jobs-table-container')).toBeNull();
+      expect(host.querySelector('.table-refresh-bar')).toBeNull();
+      expect(host.querySelector('.loading-state')).toBeTruthy();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Pins a 2px indeterminate `mat-progress-bar` to the top edge of `.jobs-table-container` while `loading === true && jobs.length > 0`, giving users visual feedback that fresh data is incoming during refresh.
- Bar is absolutely positioned so it overlays inside the rounded container without pushing table rows down.
- Hidden under `prefers-reduced-motion: reduce` since it's decorative feedback.
- Adds 4 unit tests covering bar presence, absence, transition, and initial-load exclusion.

## Test plan

- [x] `npm test` — all 99 tests pass (4 new)
- [x] `ng build --configuration=production` — compiles cleanly
- [ ] Visual: start dev server, load jobs dashboard with existing jobs, click refresh — 2px bar appears at table top and vanishes when data arrives
- [ ] Verify no row jitter or layout shift during the bar's appearance/disappearance
- [ ] Check on narrow viewport (< 1024px) that bar stays pinned at visible top during horizontal scroll

Closes #490

https://claude.ai/code/session_01TrfBm37qPtLJzbnPTgjYVT