### PR TITLE
Add hover/focus chevron affordance to jobs-dashboard rows

### DIFF
--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
@@ -338,6 +338,33 @@
         padding: var(--kh-space-2) var(--kh-space-3);
         vertical-align: middle;
       }
+
+      td.col-actions {
+        position: relative;
+        padding-right: calc(var(--kh-space-3) + 22px);
+
+        &::after {
+          content: 'chevron_right';
+          font-family: 'Material Icons';
+          font-feature-settings: 'liga';
+          -webkit-font-smoothing: antialiased;
+          position: absolute;
+          right: var(--kh-space-2);
+          top: 50%;
+          transform: translateY(-50%);
+          font-size: 18px;
+          line-height: 1;
+          color: var(--kh-text-muted);
+          opacity: 0;
+          transition: opacity var(--kh-transition);
+          pointer-events: none;
+        }
+      }
+
+      &:hover td.col-actions::after,
+      &:focus-visible td.col-actions::after {
+        opacity: 1;
+      }
     }
   }
 }
@@ -370,6 +397,7 @@
   .stuck-indicator   { animation: none; opacity: 1; }
   .live-dot          { animation: none; opacity: 1; }
   .table-refresh-bar { display: none; }
+  .jobs-table tbody tr.job-row td.col-actions::after { transition: none; }
 }
 
 // ── Column Widths ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary\n\n- Adds a subtle `chevron_right` icon that fades in on the right edge of job rows on hover and keyboard focus, signaling that rows are clickable/drillable.\n- Pure SCSS change using a `::after` pseudo-element with Material Icons ligature rendering — no HTML or TypeScript modifications.\n- Respects `prefers-reduced-motion` by disabling the opacity transition.\n\n## Implementation details\n\n- Chevron is positioned absolutely inside `td.col-actions` with reserved `padding-right` so it never overlaps action buttons.\n- Appears on both `:hover` and `:focus-visible` (keyboard accessibility).\n- Uses `--kh-text-muted` color for subtlety.\n\n## Test plan\n\n- [x] `npm run build` passes\n- [x] All 1665 vitest tests pass\n- [ ] Visual: hover a job row — chevron fades in on right edge\n- [ ] Visual: tab to a row — chevron appears on focus\n- [ ] Verify chevron doesn't overlap stop/resume/more action buttons\n- [ ] Verify completed rows (no action buttons) show chevron alone\n\nCloses #493\n\nhttps://claude.ai/code/session_01CfgzaeNAMi8W9WqgLM29Ye

---
_Generated by [Claude Code](https://claude.ai/code/session_01CfgzaeNAMi8W9WqgLM29Ye)_