### PR TITLE
Add GitHub integration: issue-to-PR workflow via coding team

### DIFF
--- a/backend/unified_api/integrations_store.py
+++ b/backend/unified_api/integrations_store.py
@@ -70,6 +70,7 @@ _BROWSER_SESSION_ROOT_LOGGED = False
 
 _SLACK_SERVICE = "slack"
 _MEDIUM_SERVICE = "medium"
+_GITHUB_SERVICE = "github"
 
 
 def _get_integrations_path() -> Path:
@@ -502,6 +503,9 @@ def get_integrations_list() -> list[dict[str, Any]]:
         data = _read_raw()
     slack = data.get("slack") or {}
     medium = data.get("medium") or {}
+    github = data.get("github") or {}
+    gh_owner = str(github.get("owner", "")).strip()
+    gh_repo = str(github.get("repo", "")).strip()
     return [
         {
             "id": "slack",
@@ -517,4 +521,75 @@ def get_integrations_list() -> list[dict[str, Any]]:
             or str(medium.get("oauth_provider", "")).strip()
             or None,
         },
+        {
+            "id": "github",
+            "type": "github",
+            "enabled": bool(github.get("enabled", False)),
+            "channel": f"{gh_owner}/{gh_repo}" if gh_owner and gh_repo else None,
+        },
     ]
+
+
+# ---------------------------------------------------------------------------
+# GitHub
+# ---------------------------------------------------------------------------
+
+
+def get_github_config() -> dict[str, Any]:
+    """Return GitHub integration config. PAT from encrypted DB; owner/repo from JSON."""
+    with _LOCK:
+        data = _read_raw()
+    github = data.get("github") or {}
+    token = get_credential(_GITHUB_SERVICE, "personal_access_token")
+    return {
+        "enabled": bool(github.get("enabled", False)),
+        "owner": str(github.get("owner", "")).strip(),
+        "repo": str(github.get("repo", "")).strip(),
+        "default_label": str(github.get("default_label", "")).strip(),
+        "repo_path": str(github.get("repo_path", "")).strip(),
+        "token_configured": bool(token),
+    }
+
+
+def set_github_config(
+    *,
+    enabled: bool,
+    owner: str = "",
+    repo: str = "",
+    personal_access_token: str = "",
+    default_label: str = "",
+    repo_path: str = "",
+) -> None:
+    """Persist GitHub config. PAT goes encrypted to Postgres; rest to JSON.
+
+    Preserves existing values when empty strings are passed for owner/repo/repo_path.
+    """
+    if personal_access_token.strip():
+        set_credential(_GITHUB_SERVICE, "personal_access_token", personal_access_token.strip())
+
+    with _LOCK:
+        data = _read_raw()
+        existing = data.get("github") or {}
+        data["github"] = {
+            "enabled": enabled,
+            "owner": owner.strip() or existing.get("owner", ""),
+            "repo": repo.strip() or existing.get("repo", ""),
+            "default_label": default_label.strip(),
+            "repo_path": repo_path.strip() or existing.get("repo_path", ""),
+        }
+        _write_raw(data)
+
+
+def clear_github_config() -> None:
+    """Remove GitHub PAT and reset config to disabled defaults."""
+    delete_credential(_GITHUB_SERVICE, "personal_access_token")
+    with _LOCK:
+        data = _read_raw()
+        data["github"] = {
+            "enabled": False,
+            "owner": "",
+            "repo": "",
+            "default_label": "",
+            "repo_path": "",
+        }
+        _write_raw(data)

--- a/backend/unified_api/routes/integrations.py
+++ b/backend/unified_api/routes/integrations.py
@@ -14,14 +14,18 @@ Endpoints:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
+import subprocess
 import urllib.error
 import urllib.parse
 import urllib.request
+from pathlib import Path
 from typing import Any, Literal
 
+import httpx
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel, Field
@@ -33,15 +37,19 @@ from unified_api.google_browser_login_credentials import (
     google_browser_login_storage_available,
     set_google_browser_login_credentials,
 )
+from unified_api.integration_credentials import get_credential
 from unified_api.integrations_store import (
+    clear_github_config,
     clear_medium_google_oauth_identity,
     clear_medium_session_storage,
     clear_slack_oauth,
     generate_medium_google_oauth_state,
     generate_oauth_state,
+    get_github_config,
     get_integrations_list,
     get_medium_config,
     get_slack_config,
+    set_github_config,
     set_medium_config,
     set_medium_google_oauth_identity,
     set_medium_session_storage_state_json,
@@ -866,3 +874,241 @@ async def medium_clear_session() -> MediumConfigResponse:
     """Remove stored Medium browser session."""
     clear_medium_session_storage()
     return _build_medium_config_response(get_medium_config())
+
+
+# ---------------------------------------------------------------------------
+# GitHub integration
+# ---------------------------------------------------------------------------
+
+_GITHUB_SERVICE = "github"
+_GITHUB_API_BASE = "https://api.github.com"
+
+
+class GitHubConfigResponse(BaseModel):
+    enabled: bool
+    token_configured: bool
+    owner: str
+    repo: str
+    default_label: str
+
+
+class GitHubConfigUpdate(BaseModel):
+    enabled: bool = True
+    token: str = Field(default="", description="Personal Access Token; empty preserves existing")
+    owner: str = ""
+    repo: str = ""
+    default_label: str = ""
+    repo_path: str = Field(default="", description="Operator override for local checkout path")
+
+
+class GitHubIssueItem(BaseModel):
+    number: int
+    title: str
+    body_preview: str
+    labels: list[str]
+    html_url: str
+
+
+class RunGitHubIssueRequest(BaseModel):
+    issue_number: int
+    base_branch: str | None = None
+
+
+class RunGitHubIssueResponse(BaseModel):
+    job_id: str
+    issue_number: int
+    issue_url: str
+    status: str = "pending"
+    message: str = "Job started. Poll GET /api/coding-team/status/{job_id} for progress."
+
+
+def _build_github_config_response(cfg: dict[str, Any]) -> GitHubConfigResponse:
+    return GitHubConfigResponse(
+        enabled=cfg["enabled"],
+        token_configured=cfg["token_configured"],
+        owner=cfg["owner"],
+        repo=cfg["repo"],
+        default_label=cfg["default_label"],
+    )
+
+
+@router.get("/github", response_model=GitHubConfigResponse)
+async def get_github() -> GitHubConfigResponse:
+    """Return GitHub integration config status."""
+    return _build_github_config_response(get_github_config())
+
+
+@router.put("/github", response_model=GitHubConfigResponse)
+async def update_github(body: GitHubConfigUpdate) -> GitHubConfigResponse:
+    """Save or update GitHub integration config (PAT stored encrypted)."""
+    set_github_config(
+        enabled=body.enabled,
+        owner=body.owner,
+        repo=body.repo,
+        personal_access_token=body.token,
+        default_label=body.default_label,
+        repo_path=body.repo_path,
+    )
+    return _build_github_config_response(get_github_config())
+
+
+@router.delete("/github", response_model=GitHubConfigResponse)
+async def delete_github() -> GitHubConfigResponse:
+    """Disconnect GitHub integration (removes PAT and resets config)."""
+    clear_github_config()
+    return _build_github_config_response(get_github_config())
+
+
+@router.get("/github/issues", response_model=list[GitHubIssueItem])
+async def list_github_issues(label: str | None = Query(default=None)) -> list[GitHubIssueItem]:
+    """List open issues from the configured GitHub repository."""
+    cfg = get_github_config()
+    if not cfg["enabled"]:
+        raise HTTPException(status_code=400, detail="GitHub integration is not enabled.")
+    token = get_credential(_GITHUB_SERVICE, "personal_access_token")
+    if not token:
+        raise HTTPException(status_code=400, detail="GitHub PAT not configured.")
+    owner = cfg["owner"]
+    repo = cfg["repo"]
+    if not owner or not repo:
+        raise HTTPException(status_code=400, detail="GitHub owner/repo not configured.")
+
+    params: dict[str, Any] = {"state": "open", "per_page": 30}
+    use_label = label or cfg["default_label"]
+    if use_label:
+        params["labels"] = use_label
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "khala-integrations",
+    }
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.get(
+            f"{_GITHUB_API_BASE}/repos/{owner}/{repo}/issues",
+            headers=headers,
+            params=params,
+        )
+
+    if resp.status_code == 401:
+        raise HTTPException(status_code=401, detail="GitHub token is invalid or expired.")
+    if resp.status_code == 404:
+        raise HTTPException(status_code=404, detail=f"Repository {owner}/{repo} not found.")
+    if resp.status_code != 200:
+        raise HTTPException(status_code=502, detail=f"GitHub API returned {resp.status_code}.")
+
+    items: list[GitHubIssueItem] = []
+    for raw in resp.json():
+        if "pull_request" in raw:
+            continue
+        body = (raw.get("body") or "")[:200]
+        labels = [lbl["name"] for lbl in (raw.get("labels") or []) if isinstance(lbl, dict) and lbl.get("name")]
+        items.append(
+            GitHubIssueItem(
+                number=raw["number"],
+                title=raw.get("title") or "",
+                body_preview=body,
+                labels=labels,
+                html_url=raw.get("html_url") or "",
+            )
+        )
+    return items
+
+
+def _resolve_repo_path(cfg: dict[str, Any]) -> str:
+    """Resolve the local checkout path for the coding team.
+
+    Priority: config override > SE_WORKSPACE_DIR env > WORKSPACE_ROOT env > AGENT_CACHE fallback.
+    """
+    override = cfg.get("repo_path", "").strip()
+    if override:
+        return override
+
+    for env_var in ("SE_WORKSPACE_DIR", "WORKSPACE_ROOT"):
+        val = os.environ.get(env_var, "").strip()
+        if val:
+            return str(Path(val) / f"{cfg['owner']}_{cfg['repo']}")
+
+    cache_dir = os.environ.get("AGENT_CACHE", ".agent_cache")
+    return str(Path(cache_dir) / "github_workspaces" / cfg["owner"] / cfg["repo"])
+
+
+def _ensure_repo_clone(repo_path: str, owner: str, repo: str, token: str) -> str | None:
+    """Clone or fetch the repository. Returns error string on failure, None on success."""
+    path = Path(repo_path)
+    if path.is_dir() and (path / ".git").is_dir():
+        result = subprocess.run(
+            ["git", "-C", repo_path, "fetch", "--all"],
+            capture_output=True, text=True, timeout=120,
+        )
+        if result.returncode != 0:
+            return f"git fetch failed: {result.stderr[:300]}"
+        return None
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    clone_url = f"https://x-access-token:{token}@github.com/{owner}/{repo}.git"
+    result = subprocess.run(
+        ["git", "clone", clone_url, repo_path],
+        capture_output=True, text=True, timeout=300,
+    )
+    if result.returncode != 0:
+        safe_err = result.stderr.replace(token, "***")[:300]
+        return f"git clone failed: {safe_err}"
+    return None
+
+
+@router.post("/github/run-issue", response_model=RunGitHubIssueResponse)
+async def run_github_issue(body: RunGitHubIssueRequest) -> RunGitHubIssueResponse:
+    """Start the coding team on a specific GitHub issue."""
+    cfg = get_github_config()
+    if not cfg["enabled"]:
+        raise HTTPException(status_code=400, detail="GitHub integration is not enabled.")
+    token = get_credential(_GITHUB_SERVICE, "personal_access_token")
+    if not token:
+        raise HTTPException(status_code=400, detail="GitHub PAT not configured.")
+    owner = cfg["owner"]
+    repo = cfg["repo"]
+    if not owner or not repo:
+        raise HTTPException(status_code=400, detail="GitHub owner/repo not configured.")
+
+    repo_path = _resolve_repo_path(cfg)
+
+    loop = asyncio.get_running_loop()
+    clone_err = await loop.run_in_executor(None, _ensure_repo_clone, repo_path, owner, repo, token)
+    if clone_err:
+        raise HTTPException(status_code=502, detail=clone_err)
+
+    coding_team_url = os.environ.get("CODING_TEAM_SERVICE_URL", "").strip()
+    if not coding_team_url:
+        raise HTTPException(status_code=503, detail="Coding team service not configured (CODING_TEAM_SERVICE_URL).")
+
+    payload = {
+        "owner": owner,
+        "repo": repo,
+        "repo_path": repo_path,
+        "issue_number": body.issue_number,
+        "github_token": token,
+    }
+    if body.base_branch:
+        payload["base_branch"] = body.base_branch
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(f"{coding_team_url.rstrip('/')}/run-from-github", json=payload)
+
+    if resp.status_code != 200:
+        try:
+            detail = resp.json().get("detail", resp.text[:300])
+        except Exception:
+            detail = resp.text[:300]
+        raise HTTPException(status_code=resp.status_code, detail=detail)
+
+    data = resp.json()
+    return RunGitHubIssueResponse(
+        job_id=data["job_id"],
+        issue_number=data["issue_number"],
+        issue_url=data["issue_url"],
+        status=data.get("status", "pending"),
+        message=data.get("message", ""),
+    )

--- a/backend/unified_api/routes/integrations.py
+++ b/backend/unified_api/routes/integrations.py
@@ -1035,18 +1035,46 @@ def _resolve_repo_path(cfg: dict[str, Any]) -> str:
     return str(Path(cache_dir) / "github_workspaces" / cfg["owner"] / cfg["repo"])
 
 
+def _git_auth_env(token: str) -> dict[str, str]:
+    """Build env dict that injects a Bearer token via GIT_CONFIG_* env vars.
+
+    Unlike ``-c http.extraHeader``, environment-based config is transient
+    and never written to ``.git/config`` — safe for clone and fetch alike.
+    """
+    return {
+        **os.environ,
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "http.extraHeader",
+        "GIT_CONFIG_VALUE_0": f"Authorization: Bearer {token}",
+        "GIT_TERMINAL_PROMPT": "0",
+    }
+
+
 def _ensure_repo_clone(repo_path: str, owner: str, repo: str, token: str) -> str | None:
     """Clone or fetch the repository. Returns error string on failure, None on success.
 
-    Auth is passed via ``-c http.extraHeader`` so the token never persists
-    in ``.git/config`` (unlike ``https://token@host`` remote URLs).
+    Auth is passed via ``GIT_CONFIG_*`` environment variables so the token
+    is transient and never persisted in ``.git/config``.
     """
-    auth_header = f"Authorization: Bearer {token}"
+    env = _git_auth_env(token)
+    expected_suffix = f"{owner}/{repo}"
     path = Path(repo_path)
+
     if path.is_dir() and (path / ".git").is_dir():
+        url_check = subprocess.run(
+            ["git", "-C", repo_path, "remote", "get-url", "origin"],
+            capture_output=True, text=True, timeout=10,
+        )
+        url_out = url_check.stdout.strip()
+        if url_check.returncode != 0 or expected_suffix not in url_out:
+            return (
+                f"existing checkout at {repo_path} does not match "
+                f"{owner}/{repo} (remote origin: {url_out[:120]})"
+            )
+
         result = subprocess.run(
-            ["git", "-C", repo_path, "-c", f"http.extraHeader={auth_header}", "fetch", "--all"],
-            capture_output=True, text=True, timeout=120,
+            ["git", "-C", repo_path, "fetch", "--all"],
+            capture_output=True, text=True, timeout=120, env=env,
         )
         if result.returncode != 0:
             return f"git fetch failed: {result.stderr[:300]}"
@@ -1055,8 +1083,8 @@ def _ensure_repo_clone(repo_path: str, owner: str, repo: str, token: str) -> str
     path.parent.mkdir(parents=True, exist_ok=True)
     clone_url = f"https://github.com/{owner}/{repo}.git"
     result = subprocess.run(
-        ["git", "clone", "-c", f"http.extraHeader={auth_header}", clone_url, repo_path],
-        capture_output=True, text=True, timeout=300,
+        ["git", "clone", clone_url, repo_path],
+        capture_output=True, text=True, timeout=300, env=env,
     )
     if result.returncode != 0:
         safe_err = result.stderr.replace(token, "***")[:300]

--- a/backend/unified_api/routes/integrations.py
+++ b/backend/unified_api/routes/integrations.py
@@ -1036,11 +1036,16 @@ def _resolve_repo_path(cfg: dict[str, Any]) -> str:
 
 
 def _ensure_repo_clone(repo_path: str, owner: str, repo: str, token: str) -> str | None:
-    """Clone or fetch the repository. Returns error string on failure, None on success."""
+    """Clone or fetch the repository. Returns error string on failure, None on success.
+
+    Auth is passed via ``-c http.extraHeader`` so the token never persists
+    in ``.git/config`` (unlike ``https://token@host`` remote URLs).
+    """
+    auth_header = f"Authorization: Bearer {token}"
     path = Path(repo_path)
     if path.is_dir() and (path / ".git").is_dir():
         result = subprocess.run(
-            ["git", "-C", repo_path, "fetch", "--all"],
+            ["git", "-C", repo_path, "-c", f"http.extraHeader={auth_header}", "fetch", "--all"],
             capture_output=True, text=True, timeout=120,
         )
         if result.returncode != 0:
@@ -1048,9 +1053,9 @@ def _ensure_repo_clone(repo_path: str, owner: str, repo: str, token: str) -> str
         return None
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    clone_url = f"https://x-access-token:{token}@github.com/{owner}/{repo}.git"
+    clone_url = f"https://github.com/{owner}/{repo}.git"
     result = subprocess.run(
-        ["git", "clone", clone_url, repo_path],
+        ["git", "clone", "-c", f"http.extraHeader={auth_header}", clone_url, repo_path],
         capture_output=True, text=True, timeout=300,
     )
     if result.returncode != 0:

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.html
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.html
@@ -64,7 +64,7 @@
         <div class="github-job-panel__header">
           <mat-icon>engineering</mat-icon>
           <h3>Working on issue #{{ activeJob.issue_number }}</h3>
-          @if (jobStatus?.status === 'completed' || jobStatus?.status === 'failed') {
+          @if (jobStatus?.status === 'completed' || jobStatus?.status === 'failed' || jobStatus?.status === 'cancelled') {
             <button mat-button (click)="dismissJob()">
               <mat-icon>close</mat-icon>
               Dismiss

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.html
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.html
@@ -16,6 +16,193 @@
   <app-health-indicator [healthCheck]="healthCheck" label="Coding Team API" />
 </div>
 
+<!-- ────────────────────────────────────────────────────────────────── -->
+<!-- GitHub Issues Workflow                                             -->
+<!-- ────────────────────────────────────────────────────────────────── -->
+@if (loadingConfig) {
+  <div class="github-section github-section--loading">
+    <mat-spinner diameter="24"></mat-spinner>
+    <span>Checking GitHub integration…</span>
+  </div>
+} @else if (!githubConfigured) {
+  <div class="github-section github-section--unconfigured">
+    <mat-icon>info</mat-icon>
+    <span>
+      GitHub integration is not configured.
+      <a routerLink="/integrations">Set up GitHub</a> to browse issues and start AI-driven coding.
+    </span>
+  </div>
+} @else {
+  <section class="github-section">
+    <div class="github-section__header">
+      <h2>
+        <mat-icon>bug_report</mat-icon>
+        GitHub Issues
+        <span class="github-section__repo">{{ githubOwner }}/{{ githubRepo }}</span>
+      </h2>
+      <button
+        mat-flat-button
+        color="primary"
+        (click)="loadIssues()"
+        [disabled]="loadingIssues"
+      >
+        <mat-icon>refresh</mat-icon>
+        @if (loadingIssues) { Loading… } @else if (issuesLoaded) { Refresh } @else { Load issues }
+      </button>
+    </div>
+
+    @if (issueError) {
+      <div class="github-banner github-banner--error">
+        <mat-icon>error_outline</mat-icon>
+        <span>{{ issueError }}</span>
+      </div>
+    }
+
+    <!-- Active job status -->
+    @if (activeJob) {
+      <div class="github-job-panel">
+        <div class="github-job-panel__header">
+          <mat-icon>engineering</mat-icon>
+          <h3>Working on issue #{{ activeJob.issue_number }}</h3>
+          @if (jobStatus?.status === 'completed' || jobStatus?.status === 'failed') {
+            <button mat-button (click)="dismissJob()">
+              <mat-icon>close</mat-icon>
+              Dismiss
+            </button>
+          }
+        </div>
+
+        <div class="github-job-panel__body">
+          <div class="github-job-panel__field">
+            <span class="github-job-panel__label">Job</span>
+            <code>{{ activeJob.job_id | slice:0:12 }}…</code>
+          </div>
+          @if (jobStatus) {
+            <div class="github-job-panel__field">
+              <span class="github-job-panel__label">Status</span>
+              <span class="github-job-status github-job-status--{{ jobStatus.status }}">
+                {{ jobStatus.status }}
+              </span>
+            </div>
+            @if (jobStatus.phase) {
+              <div class="github-job-panel__field">
+                <span class="github-job-panel__label">Phase</span>
+                <span>{{ jobStatus.phase }}</span>
+              </div>
+            }
+            @if (jobStatus.status_text) {
+              <div class="github-job-panel__field">
+                <span class="github-job-panel__label">Detail</span>
+                <span>{{ jobStatus.status_text }}</span>
+              </div>
+            }
+            @if (jobStatus.task_graph_snapshot && jobStatus.task_graph_snapshot.length > 0) {
+              <div class="github-job-tasks">
+                <span class="github-job-panel__label">Tasks</span>
+                <div class="github-job-tasks__list">
+                  @for (task of jobStatus.task_graph_snapshot; track task.id) {
+                    <div class="github-task-chip github-task-chip--{{ task.status }}">
+                      {{ task.title | slice:0:40 }}
+                      <span class="github-task-chip__status">{{ task.status }}</span>
+                    </div>
+                  }
+                </div>
+              </div>
+            }
+            @if (jobStatus.github_pr_url) {
+              <div class="github-job-panel__field github-job-panel__field--pr">
+                <mat-icon>merge_type</mat-icon>
+                <a [href]="jobStatus.github_pr_url" target="_blank" rel="noopener">
+                  {{ jobStatus.github_pr_url }}
+                </a>
+              </div>
+            }
+            @if (jobStatus.error) {
+              <div class="github-banner github-banner--error">
+                <mat-icon>error_outline</mat-icon>
+                <span>{{ jobStatus.error }}</span>
+              </div>
+            }
+          } @else {
+            <div class="github-job-panel__field">
+              <mat-spinner diameter="18"></mat-spinner>
+              <span>Starting…</span>
+            </div>
+          }
+        </div>
+      </div>
+    }
+
+    <!-- Issue confirmation -->
+    @if (selectedIssue && !activeJob) {
+      <div class="github-confirm-panel">
+        <h3>Start AI coding on this issue?</h3>
+        <div class="github-confirm-panel__issue">
+          <span class="issue-number">#{{ selectedIssue.number }}</span>
+          <span class="issue-title">{{ selectedIssue.title }}</span>
+        </div>
+        @if (selectedIssue.body_preview) {
+          <p class="github-confirm-panel__preview">{{ selectedIssue.body_preview }}</p>
+        }
+        <p class="github-confirm-panel__hint">
+          The coding team will analyze the issue, write code, run quality gates, and open a draft PR when satisfied.
+        </p>
+        <div class="github-confirm-panel__actions">
+          <button
+            mat-flat-button
+            color="primary"
+            (click)="confirmAndRun()"
+            [disabled]="runningIssue"
+          >
+            @if (runningIssue) {
+              <mat-spinner diameter="18"></mat-spinner>
+              Starting…
+            } @else {
+              <ng-container>
+                <mat-icon>play_arrow</mat-icon>
+                Confirm &amp; Start
+              </ng-container>
+            }
+          </button>
+          <button mat-stroked-button (click)="cancelSelection()">Cancel</button>
+        </div>
+      </div>
+    }
+
+    <!-- Issue list -->
+    @if (issuesLoaded && !selectedIssue && !activeJob) {
+      @if (issues.length === 0) {
+        <div class="github-empty">
+          <mat-icon>check_circle_outline</mat-icon>
+          <span>No open issues found.</span>
+        </div>
+      } @else {
+        <div class="github-issues-list">
+          @for (issue of issues; track issue.number) {
+            <button
+              class="github-issue-row"
+              type="button"
+              (click)="selectIssue(issue)"
+            >
+              <span class="github-issue-row__number">#{{ issue.number }}</span>
+              <span class="github-issue-row__title">{{ issue.title }}</span>
+              <span class="github-issue-row__labels">
+                @for (label of issue.labels; track label) {
+                  <span class="github-label-chip">{{ label }}</span>
+                }
+              </span>
+              <mat-icon class="github-issue-row__arrow">chevron_right</mat-icon>
+            </button>
+          }
+        </div>
+      }
+    }
+  </section>
+}
+
+<!-- ────────────────────────────────────────────────────────────────── -->
+<!-- Team Assistant (existing)                                          -->
+<!-- ────────────────────────────────────────────────────────────────── -->
 <app-team-assistant-chat
   [teamApiUrl]="'/api/coding-team/assistant'"
   [teamName]="'Coding Team'"

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.scss
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.scss
@@ -269,6 +269,10 @@
     background: #fce8e6;
     color: #c5221f;
   }
+  &--cancelled {
+    background: #f5f5f5;
+    color: #80868b;
+  }
 }
 
 .github-job-tasks {

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.scss
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.scss
@@ -16,3 +16,303 @@
 .header-row {
   margin-bottom: 1rem;
 }
+
+// ---------------------------------------------------------------------------
+// GitHub Issues section
+// ---------------------------------------------------------------------------
+
+.github-section {
+  margin: 1.5rem 0;
+  padding: 1.25rem;
+  border: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.12));
+  border-radius: 12px;
+  background: var(--mat-sys-surface-container-lowest, #fff);
+
+  &--loading,
+  &--unconfigured {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+    border-radius: 8px;
+    background: var(--mat-sys-surface-container, #f5f5f5);
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.7));
+    margin: 1.5rem 0;
+
+    a {
+      color: var(--mat-sys-primary, #1a73e8);
+      text-decoration: underline;
+    }
+  }
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+
+    h2 {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin: 0;
+      font-size: 1.1rem;
+      font-weight: 500;
+    }
+  }
+
+  &__repo {
+    font-weight: 400;
+    font-size: 0.85rem;
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+    margin-left: 0.25rem;
+  }
+}
+
+.github-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+
+  &--error {
+    background: #fce8e6;
+    color: #c5221f;
+  }
+}
+
+// Issue list
+.github-issues-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.github-issue-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  transition: background-color 0.15s;
+
+  &:hover {
+    background: var(--mat-sys-surface-container, #f5f5f5);
+  }
+
+  &__number {
+    font-weight: 600;
+    color: var(--mat-sys-primary, #1a73e8);
+    min-width: 3.5rem;
+  }
+
+  &__title {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__labels {
+    display: flex;
+    gap: 0.25rem;
+    flex-shrink: 0;
+  }
+
+  &__arrow {
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.5));
+    flex-shrink: 0;
+  }
+}
+
+.github-label-chip {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  background: var(--mat-sys-secondary-container, #e8f0fe);
+  color: var(--mat-sys-on-secondary-container, #1a73e8);
+}
+
+// Confirmation panel
+.github-confirm-panel {
+  padding: 1.25rem;
+  border-radius: 8px;
+  background: var(--mat-sys-surface-container, #f8f9fa);
+  margin-bottom: 1rem;
+
+  h3 {
+    margin: 0 0 0.75rem;
+    font-size: 1rem;
+    font-weight: 500;
+  }
+
+  &__issue {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+
+    .issue-number {
+      font-weight: 600;
+      color: var(--mat-sys-primary, #1a73e8);
+    }
+
+    .issue-title {
+      font-weight: 500;
+    }
+  }
+
+  &__preview {
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+    font-size: 0.875rem;
+    margin: 0.5rem 0;
+    white-space: pre-wrap;
+    max-height: 4rem;
+    overflow: hidden;
+  }
+
+  &__hint {
+    font-size: 0.8rem;
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+    margin: 0.75rem 0;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 1rem;
+  }
+}
+
+// Job status panel
+.github-job-panel {
+  padding: 1.25rem;
+  border-radius: 8px;
+  border: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.12));
+  background: var(--mat-sys-surface-container-lowest, #fff);
+  margin-bottom: 1rem;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+
+    h3 {
+      margin: 0;
+      flex: 1;
+      font-size: 1rem;
+      font-weight: 500;
+    }
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  &__field {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    &--pr {
+      margin-top: 0.5rem;
+      padding: 0.5rem 0.75rem;
+      border-radius: 6px;
+      background: #e6f4ea;
+
+      a {
+        color: #1e8e3e;
+        word-break: break-all;
+      }
+    }
+  }
+
+  &__label {
+    font-weight: 500;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.5));
+    min-width: 4rem;
+  }
+}
+
+.github-job-status {
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.85rem;
+
+  &--pending {
+    background: #fef7e0;
+    color: #f9ab00;
+  }
+  &--running {
+    background: #e8f0fe;
+    color: #1a73e8;
+  }
+  &--completed {
+    background: #e6f4ea;
+    color: #1e8e3e;
+  }
+  &--failed {
+    background: #fce8e6;
+    color: #c5221f;
+  }
+}
+
+.github-job-tasks {
+  margin-top: 0.5rem;
+
+  &__list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.25rem;
+  }
+}
+
+.github-task-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  background: var(--mat-sys-surface-container, #f5f5f5);
+
+  &__status {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    opacity: 0.7;
+  }
+
+  &--merged {
+    background: #e6f4ea;
+  }
+  &--in_progress {
+    background: #e8f0fe;
+  }
+  &--in_review {
+    background: #fef7e0;
+  }
+}
+
+.github-empty {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1.5rem;
+  justify-content: center;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.5));
+}

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
@@ -133,7 +133,7 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
     this.pollSub = interval(5000)
       .pipe(
         switchMap(() => this.api.getJobStatus(jobId)),
-        takeWhile((status) => status.status !== 'completed' && status.status !== 'failed', true),
+        takeWhile((status) => !['completed', 'failed', 'cancelled'].includes(status.status), true),
       )
       .subscribe({
         next: (status: CodingTeamJobStatus) => {

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
@@ -6,8 +6,8 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatChipsModule } from '@angular/material/chips';
 import { RouterLink } from '@angular/router';
-import { Subscription, interval } from 'rxjs';
-import { switchMap, takeWhile } from 'rxjs/operators';
+import { EMPTY, Subscription, interval } from 'rxjs';
+import { catchError, switchMap, takeWhile } from 'rxjs/operators';
 import { CodingTeamApiService } from '../../services/coding-team-api.service';
 import { IntegrationsApiService } from '../../services/integrations-api.service';
 import { HealthIndicatorComponent } from '../health-indicator/health-indicator.component';
@@ -128,19 +128,31 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
     });
   }
 
+  private pollErrors = 0;
+
   private startPolling(jobId: string): void {
     this.stopPolling();
+    this.pollErrors = 0;
     this.pollSub = interval(5000)
       .pipe(
-        switchMap(() => this.api.getJobStatus(jobId)),
+        switchMap(() =>
+          this.api.getJobStatus(jobId).pipe(
+            catchError(() => {
+              this.pollErrors++;
+              if (this.pollErrors >= 3) {
+                this.issueError = 'Lost connection to the coding team — status polling failed.';
+                this.stopPolling();
+              }
+              return EMPTY;
+            }),
+          ),
+        ),
         takeWhile((status) => !['completed', 'failed', 'cancelled'].includes(status.status), true),
       )
       .subscribe({
         next: (status: CodingTeamJobStatus) => {
+          this.pollErrors = 0;
           this.jobStatus = status;
-        },
-        error: () => {
-          // polling error — job might have been cleaned up
         },
       });
   }

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
@@ -1,17 +1,30 @@
-import { Component, inject } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatChipsModule } from '@angular/material/chips';
 import { RouterLink } from '@angular/router';
+import { Subscription, interval } from 'rxjs';
+import { switchMap, takeWhile } from 'rxjs/operators';
 import { CodingTeamApiService } from '../../services/coding-team-api.service';
+import { IntegrationsApiService } from '../../services/integrations-api.service';
 import { HealthIndicatorComponent } from '../health-indicator/health-indicator.component';
 import { TeamAssistantChatComponent } from '../team-assistant-chat/team-assistant-chat.component';
+import type { GitHubIssueItem, RunGitHubIssueResponse } from '../../models/integrations.model';
+import type { CodingTeamJobStatus } from '../../models/coding-team.model';
 
 @Component({
   selector: 'app-coding-team-page',
   standalone: true,
   imports: [
+    CommonModule,
+    FormsModule,
     MatIconModule,
     MatButtonModule,
+    MatProgressSpinnerModule,
+    MatChipsModule,
     RouterLink,
     HealthIndicatorComponent,
     TeamAssistantChatComponent,
@@ -19,12 +32,131 @@ import { TeamAssistantChatComponent } from '../team-assistant-chat/team-assistan
   templateUrl: './coding-team-page.component.html',
   styleUrl: './coding-team-page.component.scss',
 })
-export class CodingTeamPageComponent {
+export class CodingTeamPageComponent implements OnInit, OnDestroy {
   private readonly api = inject(CodingTeamApiService);
+  private readonly integrationsApi = inject(IntegrationsApiService);
 
   latestJobId: string | null = null;
 
   healthCheck = (): ReturnType<CodingTeamApiService['health']> => this.api.health();
+
+  // GitHub integration state
+  githubConfigured = false;
+  githubOwner = '';
+  githubRepo = '';
+  loadingConfig = true;
+
+  // Issue list
+  issues: GitHubIssueItem[] = [];
+  loadingIssues = false;
+  issuesLoaded = false;
+  issueError: string | null = null;
+
+  // Issue selection & confirmation
+  selectedIssue: GitHubIssueItem | null = null;
+  runningIssue = false;
+
+  // Active job tracking
+  activeJob: RunGitHubIssueResponse | null = null;
+  jobStatus: CodingTeamJobStatus | null = null;
+  private pollSub: Subscription | null = null;
+
+  ngOnInit(): void {
+    this.checkGitHubConfig();
+  }
+
+  ngOnDestroy(): void {
+    this.stopPolling();
+  }
+
+  checkGitHubConfig(): void {
+    this.loadingConfig = true;
+    this.integrationsApi.getGitHubConfig().subscribe({
+      next: (cfg) => {
+        this.githubConfigured = cfg.enabled && cfg.token_configured && !!cfg.owner && !!cfg.repo;
+        this.githubOwner = cfg.owner;
+        this.githubRepo = cfg.repo;
+        this.loadingConfig = false;
+      },
+      error: () => {
+        this.githubConfigured = false;
+        this.loadingConfig = false;
+      },
+    });
+  }
+
+  loadIssues(): void {
+    this.loadingIssues = true;
+    this.issueError = null;
+    this.selectedIssue = null;
+    this.integrationsApi.getGitHubIssues().subscribe({
+      next: (issues) => {
+        this.issues = issues;
+        this.issuesLoaded = true;
+        this.loadingIssues = false;
+      },
+      error: (err: { error?: { detail?: string }; message?: string }) => {
+        this.issueError = err?.error?.detail || err?.message || 'Failed to load issues.';
+        this.loadingIssues = false;
+      },
+    });
+  }
+
+  selectIssue(issue: GitHubIssueItem): void {
+    this.selectedIssue = issue;
+  }
+
+  cancelSelection(): void {
+    this.selectedIssue = null;
+  }
+
+  confirmAndRun(): void {
+    if (!this.selectedIssue) return;
+    this.runningIssue = true;
+    this.issueError = null;
+    this.integrationsApi.runGitHubIssue({ issue_number: this.selectedIssue.number }).subscribe({
+      next: (resp: RunGitHubIssueResponse) => {
+        this.activeJob = resp;
+        this.selectedIssue = null;
+        this.runningIssue = false;
+        this.startPolling(resp.job_id);
+      },
+      error: (err: { error?: { detail?: string }; message?: string }) => {
+        this.issueError = err?.error?.detail || err?.message || 'Failed to start job.';
+        this.runningIssue = false;
+      },
+    });
+  }
+
+  private startPolling(jobId: string): void {
+    this.stopPolling();
+    this.pollSub = interval(5000)
+      .pipe(
+        switchMap(() => this.api.getJobStatus(jobId)),
+        takeWhile((status) => status.status !== 'completed' && status.status !== 'failed', true),
+      )
+      .subscribe({
+        next: (status: CodingTeamJobStatus) => {
+          this.jobStatus = status;
+        },
+        error: () => {
+          // polling error — job might have been cleaned up
+        },
+      });
+  }
+
+  private stopPolling(): void {
+    if (this.pollSub) {
+      this.pollSub.unsubscribe();
+      this.pollSub = null;
+    }
+  }
+
+  dismissJob(): void {
+    this.stopPolling();
+    this.activeJob = null;
+    this.jobStatus = null;
+  }
 
   onWorkflowLaunched(event: { job_id: string | null; conversation_id: string }): void {
     this.latestJobId = event.job_id;

--- a/user-interface/src/app/components/integrations-dashboard/integrations-dashboard-extra.spec.ts
+++ b/user-interface/src/app/components/integrations-dashboard/integrations-dashboard-extra.spec.ts
@@ -17,6 +17,7 @@ interface ApiStub {
   mediumBrowserLoginSession: ReturnType<typeof vi.fn>;
   getSlackOAuthUrl: ReturnType<typeof vi.fn>;
   disconnectSlack: ReturnType<typeof vi.fn>;
+  getGitHubConfig: ReturnType<typeof vi.fn>;
 }
 
 describe('IntegrationsDashboardComponent (extra coverage)', () => {
@@ -54,6 +55,7 @@ describe('IntegrationsDashboardComponent (extra coverage)', () => {
       updateMediumConfig: vi.fn().mockReturnValue(of({ enabled: true, oauth_provider: 'google', session_configured: true })),
       mediumBrowserLoginSession: vi.fn().mockReturnValue(of({ enabled: true, oauth_provider: 'google', session_configured: true })),
       getSlackOAuthUrl: vi.fn().mockReturnValue(of({ url: 'https://slack.com/oauth' })),
+      getGitHubConfig: vi.fn().mockReturnValue(of({ enabled: false, token_configured: false, owner: '', repo: '', default_label: '' })),
       disconnectSlack: vi.fn().mockReturnValue(of({
         enabled: false,
         webhook_configured: false,

--- a/user-interface/src/app/components/integrations-dashboard/integrations-dashboard.component.html
+++ b/user-interface/src/app/components/integrations-dashboard/integrations-dashboard.component.html
@@ -585,5 +585,149 @@
       }
     </article>
 
+    <!-- ─────────────────────────────────────────────────────────────── -->
+    <!-- GitHub                                                         -->
+    <!-- ─────────────────────────────────────────────────────────────── -->
+    <article
+      class="integration-card"
+      [class.integration-card--expanded]="expanded === 'github'"
+      [attr.aria-busy]="githubLoading || null"
+    >
+      <header class="integration-card__head">
+        <div class="integration-card__brand">
+          <div class="integration-card__icon integration-card__icon--github" aria-hidden="true">
+            <mat-icon>code</mat-icon>
+          </div>
+          <div class="integration-card__title-block">
+            <h2 class="integration-card__title">GitHub</h2>
+            <p class="integration-card__tag">
+              @if (githubTokenConfigured && githubOwner && githubRepo) {
+                {{ githubOwner }}/{{ githubRepo }}
+              } @else {
+                Issue-to-PR workflow
+              }
+            </p>
+          </div>
+        </div>
+
+        <div class="integration-card__status">
+          @if (githubLoading) {
+            <mat-spinner diameter="20" class="integration-card__spinner"></mat-spinner>
+          } @else if (githubTokenConfigured && githubOwner && githubRepo) {
+            <span class="status-chip status-chip--success">
+              <mat-icon aria-hidden="true">check_circle</mat-icon>
+              Connected
+            </span>
+          } @else {
+            <span class="status-chip status-chip--neutral">Not configured</span>
+          }
+        </div>
+      </header>
+
+      <p class="integration-card__summary">
+        Connect a GitHub repository so the <strong>Coding Team</strong> can pick up issues and deliver draft PRs autonomously.
+      </p>
+
+      <div class="integration-card__actions">
+        <button
+          type="button"
+          mat-flat-button
+          color="primary"
+          (click)="toggleExpanded('github')"
+          [disabled]="githubLoading"
+        >
+          <mat-icon>{{ expanded === 'github' ? 'expand_less' : 'tune' }}</mat-icon>
+          {{ expanded === 'github' ? 'Hide settings' : (githubTokenConfigured ? 'Manage' : 'Configure') }}
+        </button>
+
+        @if (githubTokenConfigured) {
+          <button
+            type="button"
+            mat-stroked-button
+            color="warn"
+            (click)="disconnectGitHub()"
+            [disabled]="githubDisconnecting || githubSaving"
+          >
+            @if (githubDisconnecting) { Disconnecting… } @else { Disconnect }
+          </button>
+        }
+      </div>
+
+      @if (expanded === 'github') {
+        <div class="integration-card__body">
+          @if (githubError) {
+            <div class="status-banner status-banner--error">
+              <mat-icon aria-hidden="true">error_outline</mat-icon>
+              <span>{{ githubError }}</span>
+            </div>
+          }
+          @if (githubSuccess) {
+            <div class="status-banner status-banner--success">
+              <mat-icon aria-hidden="true">check_circle_outline</mat-icon>
+              <span>{{ githubSuccess }}</span>
+            </div>
+          }
+
+          <p class="form-hint">
+            Enter a <strong>Personal Access Token</strong> with <code>repo</code> scope, along with the repository owner and name.
+          </p>
+
+          <div class="form-grid">
+            <mat-form-field appearance="outline">
+              <mat-label>Personal Access Token</mat-label>
+              <input
+                matInput
+                type="password"
+                [(ngModel)]="githubPat"
+                placeholder="ghp_..."
+                autocomplete="new-password"
+              />
+              @if (githubTokenConfigured && !githubPat) {
+                <mat-hint align="end">Saved</mat-hint>
+              }
+              <mat-hint>Classic or fine-grained token with repo access.</mat-hint>
+            </mat-form-field>
+          </div>
+
+          <div class="form-grid form-grid--two">
+            <mat-form-field appearance="outline">
+              <mat-label>Owner / Organization</mat-label>
+              <input matInput [(ngModel)]="githubOwner" placeholder="my-org" autocomplete="off" />
+            </mat-form-field>
+            <mat-form-field appearance="outline">
+              <mat-label>Repository</mat-label>
+              <input matInput [(ngModel)]="githubRepo" placeholder="my-repo" autocomplete="off" />
+            </mat-form-field>
+          </div>
+
+          <div class="form-grid">
+            <mat-form-field appearance="outline">
+              <mat-label>Default label filter (optional)</mat-label>
+              <input matInput [(ngModel)]="githubDefaultLabel" placeholder="ai-ready" autocomplete="off" />
+              <mat-hint>Only show issues with this label when browsing.</mat-hint>
+            </mat-form-field>
+          </div>
+
+          <div class="setting-row">
+            <mat-slide-toggle [(ngModel)]="githubEnabled" color="primary">
+              Enable GitHub integration
+            </mat-slide-toggle>
+          </div>
+
+          <div class="form-actions">
+            <button
+              mat-flat-button
+              color="primary"
+              type="button"
+              (click)="saveGitHubConfig()"
+              [disabled]="githubSaving || (!githubOwner.trim() && !githubTokenConfigured) || (!githubRepo.trim() && !githubTokenConfigured)"
+            >
+              @if (githubSaving) { Saving… } @else { Save GitHub settings }
+            </button>
+          </div>
+        </div>
+      }
+    </article>
+
   </div>
 </div>

--- a/user-interface/src/app/components/integrations-dashboard/integrations-dashboard.component.html
+++ b/user-interface/src/app/components/integrations-dashboard/integrations-dashboard.component.html
@@ -640,7 +640,7 @@
           {{ expanded === 'github' ? 'Hide settings' : (githubTokenConfigured ? 'Manage' : 'Configure') }}
         </button>
 
-        @if (githubTokenConfigured) {
+        @if (githubTokenConfigured || githubOwner || githubRepo) {
           <button
             type="button"
             mat-stroked-button

--- a/user-interface/src/app/components/integrations-dashboard/integrations-dashboard.component.scss
+++ b/user-interface/src/app/components/integrations-dashboard/integrations-dashboard.component.scss
@@ -181,6 +181,12 @@
       font-size: 1.25rem;
       border: 1px solid var(--kh-border);
     }
+
+    &--github {
+      background: linear-gradient(135deg, rgba(110, 84, 148, 0.25), rgba(110, 84, 148, 0.10));
+      color: #b39ddb;
+      border: 1px solid rgba(110, 84, 148, 0.30);
+    }
   }
 
   &__status {

--- a/user-interface/src/app/components/integrations-dashboard/integrations-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/integrations-dashboard/integrations-dashboard.component.spec.ts
@@ -20,6 +20,7 @@ describe('IntegrationsDashboardComponent', () => {
     disconnectSlack: ReturnType<typeof vi.fn>;
     putGoogleBrowserLoginCredentials: ReturnType<typeof vi.fn>;
     deleteGoogleBrowserLoginCredentials: ReturnType<typeof vi.fn>;
+    getGitHubConfig: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(async () => {
@@ -34,6 +35,7 @@ describe('IntegrationsDashboardComponent', () => {
       disconnectSlack: vi.fn(),
       putGoogleBrowserLoginCredentials: vi.fn(),
       deleteGoogleBrowserLoginCredentials: vi.fn(),
+      getGitHubConfig: vi.fn(),
     };
     apiSpy.getSlackConfig.mockReturnValue(of({
       enabled: false,
@@ -46,6 +48,7 @@ describe('IntegrationsDashboardComponent', () => {
     }));
     apiSpy.getGoogleBrowserLoginStatus.mockReturnValue(of({ configured: false }));
     apiSpy.getMediumConfig.mockReturnValue(of({ enabled: false }));
+    apiSpy.getGitHubConfig.mockReturnValue(of({ enabled: false, token_configured: false, owner: '', repo: '', default_label: '' }));
 
     await TestBed.configureTestingModule({
       imports: [IntegrationsDashboardComponent, NoopAnimationsModule],

--- a/user-interface/src/app/components/integrations-dashboard/integrations-dashboard.component.ts
+++ b/user-interface/src/app/components/integrations-dashboard/integrations-dashboard.component.ts
@@ -13,6 +13,8 @@ import { MatDividerModule } from '@angular/material/divider';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { IntegrationsApiService } from '../../services/integrations-api.service';
 import type {
+  GitHubConfigResponse,
+  GitHubConfigUpdate,
   GoogleBrowserLoginCredentialsBody,
   MediumConfigResponse,
   MediumConfigUpdate,
@@ -24,7 +26,7 @@ import type {
 
 const SLACK_WEBHOOK_PREFIX = 'https://hooks.slack.com/';
 
-type IntegrationKey = 'google' | 'slack' | 'medium';
+type IntegrationKey = 'google' | 'slack' | 'medium' | 'github';
 
 @Component({
   selector: 'app-integrations-dashboard',
@@ -63,13 +65,14 @@ export class IntegrationsDashboardComponent implements OnInit {
     this.expanded = this.expanded === key ? null : key;
   }
 
-  readonly totalIntegrations = 3;
+  readonly totalIntegrations = 4;
 
   get connectedCount(): number {
     let n = 0;
     if (this.googleBrowserLoginConfigured) n += 1;
     if (this.oauthConnected) n += 1;
     if (this.mediumReadyForStats) n += 1;
+    if (this.githubTokenConfigured && this.githubOwner && this.githubRepo) n += 1;
     return n;
   }
 
@@ -102,6 +105,7 @@ export class IntegrationsDashboardComponent implements OnInit {
     this.loadGoogleBrowserLoginStatus();
     this.loadSlackConfig();
     this.loadMediumConfig();
+    this.loadGitHubConfig();
     this.handleOAuthCallback();
   }
 
@@ -549,6 +553,95 @@ export class IntegrationsDashboardComponent implements OnInit {
       error: (err) => {
         this.error = err?.error?.detail || err?.message || 'Failed to save Slack config.';
         this.saving = false;
+      },
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // GitHub
+  // ---------------------------------------------------------------------------
+
+  githubLoading = false;
+  githubSaving = false;
+  githubDisconnecting = false;
+  githubError: string | null = null;
+  githubSuccess: string | null = null;
+
+  githubEnabled = false;
+  githubOwner = '';
+  githubRepo = '';
+  githubPat = '';
+  githubDefaultLabel = '';
+  githubTokenConfigured = false;
+
+  loadGitHubConfig(): void {
+    this.githubLoading = true;
+    this.githubError = null;
+    this.api.getGitHubConfig().subscribe({
+      next: (res: GitHubConfigResponse) => {
+        this.githubEnabled = res.enabled;
+        this.githubOwner = res.owner;
+        this.githubRepo = res.repo;
+        this.githubDefaultLabel = res.default_label;
+        this.githubTokenConfigured = res.token_configured;
+        this.githubPat = '';
+        this.githubLoading = false;
+      },
+      error: (err: { error?: { detail?: string }; message?: string }) => {
+        this.githubError = err?.error?.detail || err?.message || 'Failed to load GitHub config.';
+        this.githubLoading = false;
+      },
+    });
+  }
+
+  saveGitHubConfig(): void {
+    this.githubSaving = true;
+    this.githubError = null;
+    this.githubSuccess = null;
+    const body: GitHubConfigUpdate = {
+      enabled: this.githubEnabled,
+      owner: this.githubOwner.trim(),
+      repo: this.githubRepo.trim(),
+      token: this.githubPat,
+      default_label: this.githubDefaultLabel.trim(),
+      repo_path: '',
+    };
+    this.api.updateGitHubConfig(body).subscribe({
+      next: (res: GitHubConfigResponse) => {
+        this.githubEnabled = res.enabled;
+        this.githubOwner = res.owner;
+        this.githubRepo = res.repo;
+        this.githubDefaultLabel = res.default_label;
+        this.githubTokenConfigured = res.token_configured;
+        this.githubPat = '';
+        this.githubSuccess = 'GitHub integration saved.';
+        this.githubSaving = false;
+      },
+      error: (err: { error?: { detail?: string }; message?: string }) => {
+        this.githubError = err?.error?.detail || err?.message || 'Failed to save GitHub config.';
+        this.githubSaving = false;
+      },
+    });
+  }
+
+  disconnectGitHub(): void {
+    this.githubDisconnecting = true;
+    this.githubError = null;
+    this.githubSuccess = null;
+    this.api.deleteGitHubConfig().subscribe({
+      next: (res: GitHubConfigResponse) => {
+        this.githubEnabled = res.enabled;
+        this.githubOwner = res.owner;
+        this.githubRepo = res.repo;
+        this.githubDefaultLabel = res.default_label;
+        this.githubTokenConfigured = res.token_configured;
+        this.githubPat = '';
+        this.githubSuccess = 'GitHub disconnected.';
+        this.githubDisconnecting = false;
+      },
+      error: (err: { error?: { detail?: string }; message?: string }) => {
+        this.githubError = err?.error?.detail || err?.message || 'Failed to disconnect GitHub.';
+        this.githubDisconnecting = false;
       },
     });
   }

--- a/user-interface/src/app/models/coding-team.model.ts
+++ b/user-interface/src/app/models/coding-team.model.ts
@@ -1,0 +1,22 @@
+export interface CodingTeamJobStatus {
+  job_id: string;
+  status: string;
+  phase?: string;
+  status_text?: string;
+  error?: string;
+  github_context?: {
+    owner: string;
+    repo: string;
+    issue_number: number;
+    issue_url: string;
+  };
+  github_pr_url?: string;
+  task_graph_snapshot?: TaskSnapshot[];
+}
+
+export interface TaskSnapshot {
+  id: string;
+  title: string;
+  status: string;
+  assigned_agent_id?: string;
+}

--- a/user-interface/src/app/models/integrations.model.ts
+++ b/user-interface/src/app/models/integrations.model.ts
@@ -87,3 +87,46 @@ export interface GoogleBrowserLoginCredentialsBody {
   email: string;
   password: string;
 }
+
+/** GitHub config response (GET /api/integrations/github). */
+export interface GitHubConfigResponse {
+  enabled: boolean;
+  token_configured: boolean;
+  owner: string;
+  repo: string;
+  default_label: string;
+}
+
+/** Request body for PUT /api/integrations/github. */
+export interface GitHubConfigUpdate {
+  enabled: boolean;
+  owner: string;
+  repo: string;
+  token: string;
+  default_label: string;
+  repo_path: string;
+}
+
+/** Single GitHub issue item from GET /api/integrations/github/issues. */
+export interface GitHubIssueItem {
+  number: number;
+  title: string;
+  body_preview: string;
+  labels: string[];
+  html_url: string;
+}
+
+/** Request body for POST /api/integrations/github/run-issue. */
+export interface RunGitHubIssueRequest {
+  issue_number: number;
+  base_branch?: string;
+}
+
+/** Response from POST /api/integrations/github/run-issue. */
+export interface RunGitHubIssueResponse {
+  job_id: string;
+  issue_number: number;
+  issue_url: string;
+  status: string;
+  message: string;
+}

--- a/user-interface/src/app/services/coding-team-api.service.ts
+++ b/user-interface/src/app/services/coding-team-api.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 import type { HealthResponse } from '../models/health.model';
+import type { CodingTeamJobStatus } from '../models/coding-team.model';
 
 /**
  * Coding Team API (Software Engineering sub-team). Base URL from environment.codingTeamApiUrl.
@@ -14,5 +15,9 @@ export class CodingTeamApiService {
 
   health(): Observable<HealthResponse> {
     return this.http.get<HealthResponse>(`${this.baseUrl}/health`);
+  }
+
+  getJobStatus(jobId: string): Observable<CodingTeamJobStatus> {
+    return this.http.get<CodingTeamJobStatus>(`${this.baseUrl}/status/${jobId}`);
   }
 }

--- a/user-interface/src/app/services/integrations-api.service.ts
+++ b/user-interface/src/app/services/integrations-api.service.ts
@@ -3,12 +3,17 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 import type {
+  GitHubConfigResponse,
+  GitHubConfigUpdate,
+  GitHubIssueItem,
   GoogleBrowserLoginCredentialsBody,
   GoogleBrowserLoginStatusResponse,
   IntegrationListItem,
   MediumConfigResponse,
   MediumConfigUpdate,
   MediumSessionImportBody,
+  RunGitHubIssueRequest,
+  RunGitHubIssueResponse,
   SlackConfigResponse,
   SlackConfigUpdate,
   SlackOAuthConnectResponse,
@@ -94,5 +99,34 @@ export class IntegrationsApiService {
   /** DELETE /api/integrations/medium/session */
   clearMediumSession(): Observable<MediumConfigResponse> {
     return this.http.delete<MediumConfigResponse>(`${this.baseUrl}/medium/session`);
+  }
+
+  /** GET /api/integrations/github */
+  getGitHubConfig(): Observable<GitHubConfigResponse> {
+    return this.http.get<GitHubConfigResponse>(`${this.baseUrl}/github`);
+  }
+
+  /** PUT /api/integrations/github */
+  updateGitHubConfig(body: GitHubConfigUpdate): Observable<GitHubConfigResponse> {
+    return this.http.put<GitHubConfigResponse>(`${this.baseUrl}/github`, body);
+  }
+
+  /** DELETE /api/integrations/github */
+  deleteGitHubConfig(): Observable<GitHubConfigResponse> {
+    return this.http.delete<GitHubConfigResponse>(`${this.baseUrl}/github`);
+  }
+
+  /** GET /api/integrations/github/issues */
+  getGitHubIssues(label?: string): Observable<GitHubIssueItem[]> {
+    const params: Record<string, string> = {};
+    if (label) {
+      params['label'] = label;
+    }
+    return this.http.get<GitHubIssueItem[]>(`${this.baseUrl}/github/issues`, { params });
+  }
+
+  /** POST /api/integrations/github/run-issue */
+  runGitHubIssue(body: RunGitHubIssueRequest): Observable<RunGitHubIssueResponse> {
+    return this.http.post<RunGitHubIssueResponse>(`${this.baseUrl}/github/run-issue`, body);
   }
 }


### PR DESCRIPTION
## Summary\n\n- Adds GitHub integration to the Integrations Dashboard (PAT + owner/repo config with encrypted credential storage)\n- Extends the Coding Team page with an issue browser that lets users select an open GitHub issue, confirm it, and have the coding team autonomously work on it\n- Backend auto-clones/fetches the repo workspace and proxies to the coding team's existing `run-from-github` endpoint\n- Live job status polling with task graph visualization and draft PR link once complete\n\n## What it does\n\n1. **Integrations Dashboard** — new GitHub card where users configure their PAT (stored encrypted in Postgres), repository owner/org, repo name, and optional label filter\n2. **Coding Team Page** — once GitHub is configured, users can load open issues, select one, confirm the assignment, and watch the coding team work through task creation, implementation, quality gates, and draft PR creation\n3. **Backend endpoints** — `GET/PUT/DELETE /api/integrations/github` for config, `GET /api/integrations/github/issues` to list open issues, `POST /api/integrations/github/run-issue` to kick off the coding team with automatic workspace resolution (auto-clone if needed)\n\n## Test plan\n\n- [ ] Backend lint passes (`ruff check`)\n- [ ] Frontend builds and lint passes (`ng build && ng lint`)\n- [ ] Navigate to Integrations → configure GitHub PAT + owner/repo → verify status shows \"Connected\"\n- [ ] Navigate to Coding Team → verify issues load from configured repo\n- [ ] Select an issue → confirm → verify job starts and status polls correctly\n- [ ] Verify existing integrations (Slack, Medium, Google) still work\n- [ ] Run existing test suites to check for regressions\n\nCloses #645\n\nhttps://claude.ai/code/session_01HDtscrq8yuw2zHkzESoBWK

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDtscrq8yuw2zHkzESoBWK)_