### PR TITLE
sales_team: register Agent Console manifests and mount invoke shim

### DIFF
--- a/backend/agents/sales_team/agent_console/manifests/closer.yaml
+++ b/backend/agents/sales_team/agent_console/manifests/closer.yaml
@@ -1,0 +1,15 @@
+schema_version: 1
+id: sales.closer
+team: sales_team
+name: Sales — Closer
+summary: Develops closing strategies and objection handlers using Zig Ziglar techniques.
+tags: [sales, closing]
+inputs:
+  schema_ref: sales_team.models:CloserRequest
+outputs:
+  schema_ref: sales_team.models:ClosingStrategyBody
+sandbox:
+  manifest_path: default.yaml
+  access_tier: standard
+source:
+  entrypoint: sales_team.invoke_runners:invoke_closer

--- a/backend/agents/sales_team/agent_console/manifests/coach.yaml
+++ b/backend/agents/sales_team/agent_console/manifests/coach.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+id: sales.coach
+team: sales_team
+name: Sales — Pipeline Coach
+summary: Reviews the pipeline and provides Gong-style coaching with deal risk signals.
+tags: [sales, coaching]
+inputs:
+  schema_ref: sales_team.models:CoachingRequest
+outputs:
+  schema_ref: sales_team.models:PipelineCoachingReport
+invoke:
+  kind: http
+  method: POST
+  path: /api/sales/coaching
+sandbox:
+  manifest_path: default.yaml
+  access_tier: standard
+source:
+  entrypoint: sales_team.invoke_runners:invoke_coach

--- a/backend/agents/sales_team/agent_console/manifests/decision_maker_mapper.yaml
+++ b/backend/agents/sales_team/agent_console/manifests/decision_maker_mapper.yaml
@@ -1,0 +1,15 @@
+schema_version: 1
+id: sales.decision_maker_mapper
+team: sales_team
+name: Sales — Decision-Maker Mapper
+summary: Maps named decision-makers at a target company given ICP criteria.
+tags: [sales, research]
+inputs:
+  schema_ref: sales_team.models:DecisionMakerMapperRequest
+outputs:
+  schema_ref: sales_team.models:DecisionMakerList
+sandbox:
+  manifest_path: default.yaml
+  access_tier: standard
+source:
+  entrypoint: sales_team.invoke_runners:invoke_decision_maker_mapper

--- a/backend/agents/sales_team/agent_console/manifests/discovery.yaml
+++ b/backend/agents/sales_team/agent_console/manifests/discovery.yaml
@@ -1,0 +1,15 @@
+schema_version: 1
+id: sales.discovery
+team: sales_team
+name: Sales — Discovery Specialist
+summary: Prepares SPIN-based discovery call guides and demo agendas.
+tags: [sales, discovery]
+inputs:
+  schema_ref: sales_team.models:DiscoveryRequest
+outputs:
+  schema_ref: sales_team.models:DiscoveryPlanBody
+sandbox:
+  manifest_path: default.yaml
+  access_tier: standard
+source:
+  entrypoint: sales_team.invoke_runners:invoke_discovery

--- a/backend/agents/sales_team/agent_console/manifests/dossier_builder.yaml
+++ b/backend/agents/sales_team/agent_console/manifests/dossier_builder.yaml
@@ -1,0 +1,15 @@
+schema_version: 1
+id: sales.dossier_builder
+team: sales_team
+name: Sales — Dossier Builder
+summary: Builds a full ProspectDossier with executive summary, triggers, and conversation hooks.
+tags: [sales, research, requires-live-integration]
+inputs:
+  schema_ref: sales_team.models:DossierRequest
+outputs:
+  schema_ref: sales_team.models:ProspectDossier
+sandbox:
+  manifest_path: default.yaml
+  access_tier: elevated
+source:
+  entrypoint: sales_team.invoke_runners:invoke_dossier_builder

--- a/backend/agents/sales_team/agent_console/manifests/nurture.yaml
+++ b/backend/agents/sales_team/agent_console/manifests/nurture.yaml
@@ -7,7 +7,10 @@ tags: [sales, nurture]
 inputs:
   schema_ref: sales_team.models:NurtureRequest
 outputs:
-  schema_ref: sales_team.models:NurtureSequenceBody
+  description: >-
+    Per-prospect grouped results: {"duration_days": N, "results": [{prospect_id, prospect_company,
+    touchpoints, re_engagement_triggers, content_recommendations}, ...]}.
+    Each entry contains the NurtureSequenceBody output for one prospect.
 invoke:
   kind: http
   method: POST

--- a/backend/agents/sales_team/agent_console/manifests/nurture.yaml
+++ b/backend/agents/sales_team/agent_console/manifests/nurture.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+id: sales.nurture
+team: sales_team
+name: Sales — Nurture Specialist
+summary: Builds long-cycle nurture sequences for leads not ready to buy.
+tags: [sales, nurture]
+inputs:
+  schema_ref: sales_team.models:NurtureRequest
+outputs:
+  schema_ref: sales_team.models:NurtureSequenceBody
+invoke:
+  kind: http
+  method: POST
+  path: /api/sales/nurture
+sandbox:
+  manifest_path: default.yaml
+  access_tier: standard
+source:
+  entrypoint: sales_team.invoke_runners:invoke_nurture

--- a/backend/agents/sales_team/agent_console/manifests/outreach.yaml
+++ b/backend/agents/sales_team/agent_console/manifests/outreach.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+id: sales.outreach
+team: sales_team
+name: Sales — Outreach Specialist
+summary: Crafts hyper-personalized cold outreach sequences with citation-backed personalization.
+tags: [sales, outreach]
+inputs:
+  schema_ref: sales_team.models:OutreachRequest
+outputs:
+  schema_ref: sales_team.models:OutreachVariantList
+invoke:
+  kind: http
+  method: POST
+  path: /api/sales/outreach
+sandbox:
+  manifest_path: default.yaml
+  access_tier: standard
+source:
+  entrypoint: sales_team.invoke_runners:invoke_outreach

--- a/backend/agents/sales_team/agent_console/manifests/outreach.yaml
+++ b/backend/agents/sales_team/agent_console/manifests/outreach.yaml
@@ -7,7 +7,9 @@ tags: [sales, outreach]
 inputs:
   schema_ref: sales_team.models:OutreachRequest
 outputs:
-  schema_ref: sales_team.models:OutreachVariantList
+  description: >-
+    Per-prospect grouped results: {"results": [{prospect_id, prospect_company, variants}, ...]}.
+    Each entry contains the OutreachVariantList output for one prospect.
 invoke:
   kind: http
   method: POST

--- a/backend/agents/sales_team/agent_console/manifests/proposal.yaml
+++ b/backend/agents/sales_team/agent_console/manifests/proposal.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+id: sales.proposal
+team: sales_team
+name: Sales — Proposal Writer
+summary: Generates ROI-driven sales proposals with Level-4 Value Creation methodology.
+tags: [sales, proposal]
+inputs:
+  schema_ref: sales_team.models:ProposalRequest
+outputs:
+  schema_ref: sales_team.models:SalesProposalBody
+invoke:
+  kind: http
+  method: POST
+  path: /api/sales/proposal
+sandbox:
+  manifest_path: default.yaml
+  access_tier: standard
+source:
+  entrypoint: sales_team.invoke_runners:invoke_proposal

--- a/backend/agents/sales_team/agent_console/manifests/prospector.yaml
+++ b/backend/agents/sales_team/agent_console/manifests/prospector.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+id: sales.prospector
+team: sales_team
+name: Sales — Prospector
+summary: Identifies and researches prospects matching the ICP using Fanatical Prospecting frameworks.
+tags: [sales, prospecting]
+inputs:
+  schema_ref: sales_team.models:ProspectingRequest
+outputs:
+  schema_ref: sales_team.models:ProspectList
+invoke:
+  kind: http
+  method: POST
+  path: /api/sales/prospect
+sandbox:
+  manifest_path: default.yaml
+  access_tier: standard
+source:
+  entrypoint: sales_team.invoke_runners:invoke_prospector

--- a/backend/agents/sales_team/agent_console/manifests/qualifier.yaml
+++ b/backend/agents/sales_team/agent_console/manifests/qualifier.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+id: sales.qualifier
+team: sales_team
+name: Sales — Lead Qualifier
+summary: Scores leads using BANT, MEDDIC, and Iannarino's value-creation tiers.
+tags: [sales, qualification]
+inputs:
+  schema_ref: sales_team.models:QualificationRequest
+outputs:
+  schema_ref: sales_team.models:QualificationScoreBody
+invoke:
+  kind: http
+  method: POST
+  path: /api/sales/qualify
+sandbox:
+  manifest_path: default.yaml
+  access_tier: standard
+source:
+  entrypoint: sales_team.invoke_runners:invoke_qualifier

--- a/backend/agents/sales_team/api/main.py
+++ b/backend/agents/sales_team/api/main.py
@@ -48,6 +48,7 @@ from sales_team.outcome_store import (
     record_deal_outcome,
     record_stage_outcome,
 )
+from shared_agent_invoke import mount_invoke_shim
 from shared_observability import init_otel, instrument_fastapi_app
 
 init_otel(service_name="sales-team", team_key="sales_team")
@@ -88,6 +89,7 @@ app = FastAPI(
     lifespan=_sales_lifespan,
 )
 instrument_fastapi_app(app, team_key="sales_team")
+mount_invoke_shim(app)
 
 logger = logging.getLogger(__name__)
 _job_manager = JobServiceClient(team="sales_team")

--- a/backend/agents/sales_team/invoke_runners.py
+++ b/backend/agents/sales_team/invoke_runners.py
@@ -1,0 +1,170 @@
+"""Invoke-shim entrypoints for sales team agents.
+
+Each function accepts a raw ``body`` dict from the Agent Console sandbox
+dispatcher and delegates to the corresponding agent's domain method.
+The dispatcher calls plain functions directly (no ``make_*`` factory or
+class instantiation needed).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .agents import (
+    CloserAgent,
+    DecisionMakerMapperAgent,
+    DiscoveryAgent,
+    DossierBuilderAgent,
+    LeadQualifierAgent,
+    NurtureAgent,
+    OutreachAgent,
+    ProposalAgent,
+    ProspectorAgent,
+    SalesCoachAgent,
+)
+from .models import (
+    CloserRequest,
+    CoachingRequest,
+    DecisionMakerMapperRequest,
+    DiscoveryRequest,
+    DossierRequest,
+    NurtureRequest,
+    OutreachRequest,
+    ProposalRequest,
+    ProspectDossier,
+    ProspectingRequest,
+    QualificationRequest,
+)
+
+
+def invoke_prospector(body: dict[str, Any]) -> dict[str, Any]:
+    req = ProspectingRequest(**body)
+    agent = ProspectorAgent()
+    result = agent.prospect(
+        icp_json=req.icp.model_dump_json(),
+        product_name=req.product_name,
+        value_proposition=req.value_proposition,
+        max_prospects=req.max_prospects,
+        company_context=req.company_context,
+    )
+    return result.model_dump(mode="json")
+
+
+def invoke_decision_maker_mapper(body: dict[str, Any]) -> dict[str, Any]:
+    req = DecisionMakerMapperRequest(**body)
+    agent = DecisionMakerMapperAgent()
+    result = agent.map_contacts(
+        company_json=req.company.model_dump_json(),
+        icp_json=req.icp.model_dump_json(),
+        product_name=req.product_name,
+        value_proposition=req.value_proposition,
+        max_contacts=req.max_contacts,
+    )
+    return result.model_dump(mode="json")
+
+
+def invoke_dossier_builder(body: dict[str, Any]) -> dict[str, Any]:
+    req = DossierRequest(**body)
+    agent = DossierBuilderAgent()
+    result = agent.build(
+        prospect_json=req.prospect.model_dump_json(),
+        product_name=req.product_name,
+        value_proposition=req.value_proposition,
+    )
+    return result.model_dump(mode="json")
+
+
+def invoke_outreach(body: dict[str, Any]) -> dict[str, Any]:
+    req = OutreachRequest(**body)
+    agent = OutreachAgent()
+    dossier = ProspectDossier(**body["dossier"]) if "dossier" in body else ProspectDossier(
+        prospect_name=req.prospects[0].name if req.prospects else "Unknown",
+        company_name=req.prospects[0].company if req.prospects else "Unknown",
+        executive_summary="No dossier provided.",
+    )
+    prospect_json = req.prospects[0].model_dump_json() if req.prospects else "{}"
+    result = agent.generate_sequence(
+        prospect_json=prospect_json,
+        dossier=dossier,
+        product_name=req.product_name,
+        value_proposition=req.value_proposition,
+        case_studies="\n".join(req.case_study_snippets),
+        company_context=req.company_context,
+    )
+    return result.model_dump(mode="json")
+
+
+def invoke_qualifier(body: dict[str, Any]) -> dict[str, Any]:
+    req = QualificationRequest(**body)
+    agent = LeadQualifierAgent()
+    result = agent.qualify(
+        prospect_json=req.prospect.model_dump_json(),
+        product_name=req.product_name,
+        value_proposition=req.value_proposition,
+        call_notes=req.call_notes,
+    )
+    return result.model_dump(mode="json")
+
+
+def invoke_nurture(body: dict[str, Any]) -> dict[str, Any]:
+    req = NurtureRequest(**body)
+    agent = NurtureAgent()
+    prospect_json = req.prospects[0].model_dump_json() if req.prospects else "{}"
+    result = agent.build_sequence(
+        prospect_json=prospect_json,
+        product_name=req.product_name,
+        value_proposition=req.value_proposition,
+        duration_days=req.duration_days,
+    )
+    return result.model_dump(mode="json")
+
+
+def invoke_discovery(body: dict[str, Any]) -> dict[str, Any]:
+    req = DiscoveryRequest(**body)
+    agent = DiscoveryAgent()
+    result = agent.prepare(
+        prospect_json=req.prospect.model_dump_json(),
+        qualification_json=req.qualification.model_dump_json(),
+        product_name=req.product_name,
+        value_proposition=req.value_proposition,
+    )
+    return result.model_dump(mode="json")
+
+
+def invoke_proposal(body: dict[str, Any]) -> dict[str, Any]:
+    req = ProposalRequest(**body)
+    agent = ProposalAgent()
+    result = agent.write(
+        prospect_json=req.prospect.model_dump_json(),
+        product_name=req.product_name,
+        value_proposition=req.value_proposition,
+        annual_cost_usd=req.annual_cost_usd,
+        discovery_notes=req.discovery_notes,
+        case_studies="\n".join(req.case_study_snippets),
+        company_context=req.company_context,
+    )
+    return result.model_dump(mode="json")
+
+
+def invoke_closer(body: dict[str, Any]) -> dict[str, Any]:
+    req = CloserRequest(**body)
+    agent = CloserAgent()
+    result = agent.develop_strategy(
+        prospect_json=req.prospect.model_dump_json(),
+        proposal_json=req.proposal.model_dump_json(),
+        product_name=req.product_name,
+        value_proposition=req.value_proposition,
+    )
+    return result.model_dump(mode="json")
+
+
+def invoke_coach(body: dict[str, Any]) -> dict[str, Any]:
+    req = CoachingRequest(**body)
+    agent = SalesCoachAgent()
+    prospects_json = "[" + ", ".join(p.model_dump_json() for p in req.prospects) + "]"
+    result = agent.review(
+        prospects_json=prospects_json,
+        product_name=req.product_name,
+        pipeline_context=req.pipeline_context,
+    )
+    return result.model_dump(mode="json")

--- a/backend/agents/sales_team/invoke_runners.py
+++ b/backend/agents/sales_team/invoke_runners.py
@@ -80,7 +80,7 @@ def invoke_outreach(body: dict[str, Any]) -> dict[str, Any]:
         raise ValueError("OutreachRequest.prospects must not be empty")
     agent = OutreachAgent()
     case_studies = "\n".join(req.case_study_snippets)
-    all_variants: list = []
+    per_prospect_results: list[dict[str, Any]] = []
     for prospect in req.prospects:
         dossier = ProspectDossier(
             prospect_id=prospect.id or "unknown",
@@ -97,8 +97,12 @@ def invoke_outreach(body: dict[str, Any]) -> dict[str, Any]:
             case_studies=case_studies,
             company_context=req.company_context,
         )
-        all_variants.extend(result.model_dump(mode="json")["variants"])
-    return {"variants": all_variants}
+        per_prospect_results.append({
+            "prospect_id": prospect.id,
+            "prospect_company": prospect.company_name,
+            "variants": result.model_dump(mode="json")["variants"],
+        })
+    return {"results": per_prospect_results}
 
 
 def invoke_qualifier(body: dict[str, Any]) -> dict[str, Any]:
@@ -118,9 +122,7 @@ def invoke_nurture(body: dict[str, Any]) -> dict[str, Any]:
     if not req.prospects:
         raise ValueError("NurtureRequest.prospects must not be empty")
     agent = NurtureAgent()
-    all_touchpoints: list = []
-    all_triggers: list = []
-    all_recommendations: list = []
+    per_prospect_results: list[dict[str, Any]] = []
     for prospect in req.prospects:
         result = agent.build_sequence(
             prospect_json=prospect.model_dump_json(),
@@ -129,15 +131,10 @@ def invoke_nurture(body: dict[str, Any]) -> dict[str, Any]:
             duration_days=req.duration_days,
         )
         dumped = result.model_dump(mode="json")
-        all_touchpoints.extend(dumped.get("touchpoints", []))
-        all_triggers.extend(dumped.get("re_engagement_triggers", []))
-        all_recommendations.extend(dumped.get("content_recommendations", []))
-    return {
-        "duration_days": req.duration_days,
-        "touchpoints": all_touchpoints,
-        "re_engagement_triggers": all_triggers,
-        "content_recommendations": all_recommendations,
-    }
+        dumped["prospect_id"] = prospect.id
+        dumped["prospect_company"] = prospect.company_name
+        per_prospect_results.append(dumped)
+    return {"duration_days": req.duration_days, "results": per_prospect_results}
 
 
 def invoke_discovery(body: dict[str, Any]) -> dict[str, Any]:

--- a/backend/agents/sales_team/invoke_runners.py
+++ b/backend/agents/sales_team/invoke_runners.py
@@ -76,22 +76,27 @@ def invoke_dossier_builder(body: dict[str, Any]) -> dict[str, Any]:
 
 def invoke_outreach(body: dict[str, Any]) -> dict[str, Any]:
     req = OutreachRequest(**body)
+    if not req.prospects:
+        raise ValueError("OutreachRequest.prospects must not be empty")
     agent = OutreachAgent()
-    dossier = ProspectDossier(**body["dossier"]) if "dossier" in body else ProspectDossier(
-        prospect_name=req.prospects[0].name if req.prospects else "Unknown",
-        company_name=req.prospects[0].company if req.prospects else "Unknown",
-        executive_summary="No dossier provided.",
-    )
-    prospect_json = req.prospects[0].model_dump_json() if req.prospects else "{}"
-    result = agent.generate_sequence(
-        prospect_json=prospect_json,
-        dossier=dossier,
-        product_name=req.product_name,
-        value_proposition=req.value_proposition,
-        case_studies="\n".join(req.case_study_snippets),
-        company_context=req.company_context,
-    )
-    return result.model_dump(mode="json")
+    case_studies = "\n".join(req.case_study_snippets)
+    all_variants: list = []
+    for prospect in req.prospects:
+        dossier = ProspectDossier(
+            prospect_name=prospect.name,
+            company_name=prospect.company,
+            executive_summary="No dossier provided.",
+        )
+        result = agent.generate_sequence(
+            prospect_json=prospect.model_dump_json(),
+            dossier=dossier,
+            product_name=req.product_name,
+            value_proposition=req.value_proposition,
+            case_studies=case_studies,
+            company_context=req.company_context,
+        )
+        all_variants.extend(result.model_dump(mode="json")["variants"])
+    return {"variants": all_variants}
 
 
 def invoke_qualifier(body: dict[str, Any]) -> dict[str, Any]:
@@ -108,15 +113,29 @@ def invoke_qualifier(body: dict[str, Any]) -> dict[str, Any]:
 
 def invoke_nurture(body: dict[str, Any]) -> dict[str, Any]:
     req = NurtureRequest(**body)
+    if not req.prospects:
+        raise ValueError("NurtureRequest.prospects must not be empty")
     agent = NurtureAgent()
-    prospect_json = req.prospects[0].model_dump_json() if req.prospects else "{}"
-    result = agent.build_sequence(
-        prospect_json=prospect_json,
-        product_name=req.product_name,
-        value_proposition=req.value_proposition,
-        duration_days=req.duration_days,
-    )
-    return result.model_dump(mode="json")
+    all_touchpoints: list = []
+    all_triggers: list = []
+    all_recommendations: list = []
+    for prospect in req.prospects:
+        result = agent.build_sequence(
+            prospect_json=prospect.model_dump_json(),
+            product_name=req.product_name,
+            value_proposition=req.value_proposition,
+            duration_days=req.duration_days,
+        )
+        dumped = result.model_dump(mode="json")
+        all_touchpoints.extend(dumped.get("touchpoints", []))
+        all_triggers.extend(dumped.get("re_engagement_triggers", []))
+        all_recommendations.extend(dumped.get("content_recommendations", []))
+    return {
+        "duration_days": req.duration_days,
+        "touchpoints": all_touchpoints,
+        "re_engagement_triggers": all_triggers,
+        "content_recommendations": all_recommendations,
+    }
 
 
 def invoke_discovery(body: dict[str, Any]) -> dict[str, Any]:

--- a/backend/agents/sales_team/invoke_runners.py
+++ b/backend/agents/sales_team/invoke_runners.py
@@ -83,9 +83,11 @@ def invoke_outreach(body: dict[str, Any]) -> dict[str, Any]:
     all_variants: list = []
     for prospect in req.prospects:
         dossier = ProspectDossier(
-            prospect_name=prospect.name,
-            company_name=prospect.company,
-            executive_summary="No dossier provided.",
+            prospect_id=prospect.id or "unknown",
+            full_name=prospect.contact_name or prospect.company_name,
+            current_title=prospect.contact_title or "Unknown",
+            current_company=prospect.company_name,
+            executive_summary="Stub dossier for sandbox invoke — no deep research performed.",
         )
         result = agent.generate_sequence(
             prospect_json=prospect.model_dump_json(),

--- a/backend/agents/sales_team/models.py
+++ b/backend/agents/sales_team/models.py
@@ -924,6 +924,47 @@ class CoachingRequest(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Standalone invoke request models (Agent Console sandbox dispatch)
+# ---------------------------------------------------------------------------
+
+
+class DossierRequest(BaseModel):
+    """Invoke request for the DossierBuilder agent."""
+
+    prospect: Prospect
+    product_name: str
+    value_proposition: str
+
+
+class DecisionMakerMapperRequest(BaseModel):
+    """Invoke request for the DecisionMakerMapper agent."""
+
+    company: Prospect
+    icp: IdealCustomerProfile
+    product_name: str
+    value_proposition: str
+    max_contacts: int = Field(default=2, ge=1, le=10)
+
+
+class DiscoveryRequest(BaseModel):
+    """Invoke request for the Discovery agent."""
+
+    prospect: Prospect
+    qualification: QualificationScoreBody
+    product_name: str
+    value_proposition: str
+
+
+class CloserRequest(BaseModel):
+    """Invoke request for the Closer agent."""
+
+    prospect: Prospect
+    proposal: SalesProposalBody
+    product_name: str
+    value_proposition: str
+
+
+# ---------------------------------------------------------------------------
 # Outcome tracking models
 # ---------------------------------------------------------------------------
 

--- a/backend/agents/sales_team/tests/test_manifests.py
+++ b/backend/agents/sales_team/tests/test_manifests.py
@@ -1,0 +1,98 @@
+"""Tests for sales team Agent Console manifests.
+
+Validates that every manifest YAML parses, has resolvable schema_refs,
+and has an importable entrypoint. CI-friendly: no LLM, no Strands, no
+Postgres required.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+import yaml
+
+from agent_registry.models import AgentManifest
+from agent_registry.schema_resolver import resolve_schema
+
+MANIFESTS_DIR = Path(__file__).resolve().parent.parent / "agent_console" / "manifests"
+EXPECTED_COUNT = 10
+TEAM_KEY = "sales_team"
+
+
+def _load_all_manifests() -> list[tuple[Path, AgentManifest]]:
+    files = sorted(MANIFESTS_DIR.glob("*.yaml"))
+    results = []
+    for f in files:
+        raw = yaml.safe_load(f.read_text())
+        manifest = AgentManifest.model_validate(raw)
+        results.append((f, manifest))
+    return results
+
+
+@pytest.fixture(scope="module")
+def manifests() -> list[tuple[Path, AgentManifest]]:
+    return _load_all_manifests()
+
+
+def test_expected_manifest_count(manifests):
+    assert len(manifests) == EXPECTED_COUNT, (
+        f"Expected {EXPECTED_COUNT} manifests, found {len(manifests)}"
+    )
+
+
+def test_all_manifests_use_correct_team(manifests):
+    for path, m in manifests:
+        assert m.team == TEAM_KEY, f"{path.name}: team={m.team!r}, expected {TEAM_KEY!r}"
+
+
+def test_no_duplicate_ids(manifests):
+    ids = [m.id for _, m in manifests]
+    assert len(ids) == len(set(ids)), f"Duplicate manifest ids: {ids}"
+
+
+def test_all_ids_start_with_sales(manifests):
+    for path, m in manifests:
+        assert m.id.startswith("sales."), f"{path.name}: id={m.id!r} should start with 'sales.'"
+
+
+@pytest.mark.parametrize("idx", range(EXPECTED_COUNT))
+def test_input_schema_resolves(manifests, idx):
+    _, m = manifests[idx]
+    if m.inputs and m.inputs.schema_ref:
+        schema = resolve_schema(m.inputs.schema_ref)
+        assert isinstance(schema, dict), f"{m.id}: inputs.schema_ref did not resolve to a dict"
+
+
+@pytest.mark.parametrize("idx", range(EXPECTED_COUNT))
+def test_output_schema_resolves(manifests, idx):
+    _, m = manifests[idx]
+    if m.outputs and m.outputs.schema_ref:
+        schema = resolve_schema(m.outputs.schema_ref)
+        assert isinstance(schema, dict), f"{m.id}: outputs.schema_ref did not resolve to a dict"
+
+
+@pytest.mark.parametrize("idx", range(EXPECTED_COUNT))
+def test_entrypoint_importable(manifests, idx):
+    _, m = manifests[idx]
+    ep = m.source.entrypoint
+    module_path, symbol = ep.split(":", 1)
+    mod = importlib.import_module(module_path)
+    target = getattr(mod, symbol, None)
+    assert target is not None, f"{m.id}: {module_path} has no attribute {symbol!r}"
+    assert callable(target), f"{m.id}: {ep} is not callable"
+
+
+def test_dossier_builder_has_live_integration_tag(manifests):
+    dossier = next((m for _, m in manifests if "dossier" in m.id), None)
+    assert dossier is not None, "No dossier_builder manifest found"
+    assert "requires-live-integration" in dossier.tags
+
+
+def test_non_dossier_agents_lack_live_integration_tag(manifests):
+    for path, m in manifests:
+        if "dossier" not in m.id:
+            assert "requires-live-integration" not in m.tags, (
+                f"{path.name} unexpectedly tagged with requires-live-integration"
+            )


### PR DESCRIPTION
## Summary

- Add 10 YAML manifests under `sales_team/agent_console/manifests/` so all sales agents are discoverable and invocable from the Agent Console UI
- Create `invoke_runners.py` with plain dispatch functions bridging the dispatcher's `body: dict` interface to each agent's domain-specific method (e.g. `prospect()`, `qualify()`, `build()`)
- Add 4 missing request models (`DossierRequest`, `DecisionMakerMapperRequest`, `DiscoveryRequest`, `CloserRequest`) for agents that lacked a dedicated input model
- Mount `shared_agent_invoke` shim in the sales team FastAPI app (`POST /_agents/{id}/invoke`)
- Tag `sales.dossier_builder` with `requires-live-integration` (HTTP fetches) — sandbox returns 409, Runner disables the Run button
- Add `test_manifests.py` (36 tests) validating all 10 manifests parse, resolve schema_refs, and have importable entrypoints

## Test plan

- [x] `ruff check agents/sales_team/` passes
- [x] `pytest agents/sales_team/tests/test_manifests.py -v` — all 36 tests pass (manifest count, team key, duplicate IDs, schema resolution, entrypoint importability, live-integration tag)
- [x] `pytest agents/sales_team/tests/ -v` — full 296-test suite passes with no regressions
- [ ] `python3 -m agent_registry.scripts.generate_sample_skeletons` generates sample skeletons for all 10 sales agents
- [ ] Agent Console UI lists all sales agents in the Catalog tab
- [ ] Runner tab invokes Prospector end-to-end with a sample input

Closes #254

https://claude.ai/code/session_01KZbBiYMGmfTwZReoaQ6t9V

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZbBiYMGmfTwZReoaQ6t9V)_