### PR TITLE
Engine as single source of truth for predicate evaluation

### DIFF
--- a/backend/agents/investment_team/strategy_lab/executor/predicate_evaluator.py
+++ b/backend/agents/investment_team/strategy_lab/executor/predicate_evaluator.py
@@ -14,13 +14,11 @@ from __future__ import annotations
 
 import math
 from collections import deque
-from dataclasses import dataclass, field
-from typing import Any, Dict, List, Literal, Optional, Protocol, Sequence, Tuple
+from dataclasses import dataclass
+from typing import Any, Dict, Literal, Optional, Protocol, Sequence, Tuple
 
-import numpy as np
 import pandas as pd
 
-from .. import executor as _ind_mod
 from ..executor import indicators as ind
 from ..spec_dsl import (
     EntryRule,

--- a/backend/agents/investment_team/strategy_lab/executor/predicate_evaluator.py
+++ b/backend/agents/investment_team/strategy_lab/executor/predicate_evaluator.py
@@ -1,0 +1,410 @@
+"""Shared predicate evaluator for engine runtime and alignment audit.
+
+Promotes the deterministic predicate-evaluation logic from the alignment
+gate (``alignment_checks.py``) into a reusable module behind a
+``HistoryView`` protocol.  Both the engine's per-bar entry/exit
+dispatchers and the post-hoc alignment audit consume these functions,
+guaranteeing identical evaluation semantics.
+
+The module is intentionally side-effect-free: every function takes an
+immutable view of market data and returns a pure result.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Literal, Optional, Protocol, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+
+from .. import executor as _ind_mod
+from ..executor import indicators as ind
+from ..spec_dsl import (
+    EntryRule,
+    IndicatorRef,
+    Predicate,
+    SignalExitRule,
+)
+
+# ---------------------------------------------------------------------------
+# HistoryView protocol
+# ---------------------------------------------------------------------------
+
+_PRICE_REF_FIELDS: dict[str, str] = {
+    "bar.close": "close",
+    "bar.high": "high",
+    "bar.low": "low",
+    "bar.volume": "volume",
+}
+
+
+class HistoryView(Protocol):
+    """Read-only view over a symbol's bar history + indicator values."""
+
+    def length(self) -> int: ...
+    def bar_field(self, field_name: str, i: int) -> float: ...
+    def indicator(self, ref: IndicatorRef, i: int) -> Optional[float]: ...
+
+
+# ---------------------------------------------------------------------------
+# EvaluationResult
+# ---------------------------------------------------------------------------
+
+EvalStatus = Literal["satisfied", "miss", "warmup"]
+
+
+@dataclass(frozen=True)
+class EvaluationResult:
+    status: EvalStatus
+    lhs: Optional[float] = None
+    rhs: Optional[float] = None
+    rel_miss: Optional[float] = None
+
+
+# ---------------------------------------------------------------------------
+# Pure evaluation functions
+# ---------------------------------------------------------------------------
+
+
+def resolve_side_value(
+    side: Any,
+    view: HistoryView,
+    i: int,
+) -> Optional[float]:
+    """Resolve one side of a predicate to a scalar at bar index ``i``.
+
+    Pre: ``i`` is in ``[0, view.length())``.
+    Post: returns ``None`` when the indicator value is NaN (warmup);
+    ``float`` literals and bar-field references are always resolvable.
+    """
+    if isinstance(side, IndicatorRef):
+        return view.indicator(side, i)
+    if isinstance(side, str):
+        col = _PRICE_REF_FIELDS.get(side)
+        if col is None:
+            raise ValueError(f"unexpected bar-ref string: {side!r}")
+        return view.bar_field(col, i)
+    if isinstance(side, (int, float)) and not isinstance(side, bool):
+        return float(side)
+    raise TypeError(f"unsupported predicate side type: {type(side).__name__}")
+
+
+def compare(
+    op: str,
+    lhs: float,
+    rhs: float,
+    *,
+    prev_lhs: Optional[float] = None,
+    prev_rhs: Optional[float] = None,
+) -> bool:
+    """Evaluate a comparison op on two scalars.
+
+    ``cross_above`` / ``cross_below`` require previous-bar values;
+    returns ``False`` (fail-closed) when they are unavailable.
+    """
+    if op == "<":
+        return lhs < rhs
+    if op == "<=":
+        return lhs <= rhs
+    if op == ">":
+        return lhs > rhs
+    if op == ">=":
+        return lhs >= rhs
+    if op == "==":
+        return math.isclose(lhs, rhs, rel_tol=1e-9, abs_tol=1e-12)
+    if op == "cross_above":
+        if prev_lhs is None or prev_rhs is None:
+            return False
+        return prev_lhs <= prev_rhs and lhs > rhs
+    if op == "cross_below":
+        if prev_lhs is None or prev_rhs is None:
+            return False
+        return prev_lhs >= prev_rhs and lhs < rhs
+    raise ValueError(f"unknown comparison op: {op!r}")
+
+
+def relative_miss(computed: float, threshold: float) -> float:
+    """``|computed - threshold| / max(|threshold|, |computed|, 1e-12)``."""
+    denom = max(abs(threshold), abs(computed), 1e-12)
+    return abs(computed - threshold) / denom
+
+
+def evaluate_predicate(
+    pred: Predicate,
+    view: HistoryView,
+    i: int,
+) -> EvaluationResult:
+    """Evaluate a single predicate at bar index ``i``.
+
+    Pre: ``i`` is in ``[0, view.length())``.
+    Post: ``status`` is ``"satisfied"`` when the predicate is true,
+    ``"miss"`` when it is false, or ``"warmup"`` when an indicator
+    returns ``None`` (insufficient history).
+    """
+    try:
+        lhs_val = resolve_side_value(pred.lhs, view, i)
+        rhs_val = resolve_side_value(pred.rhs, view, i)
+    except (ValueError, TypeError):
+        return EvaluationResult(status="warmup")
+
+    if lhs_val is None or rhs_val is None:
+        return EvaluationResult(status="warmup")
+
+    prev_lhs: Optional[float] = None
+    prev_rhs: Optional[float] = None
+    if pred.op in ("cross_above", "cross_below") and i > 0:
+        try:
+            prev_lhs = resolve_side_value(pred.lhs, view, i - 1)
+            prev_rhs = resolve_side_value(pred.rhs, view, i - 1)
+        except (ValueError, TypeError):
+            pass
+
+    is_cross = pred.op in ("cross_above", "cross_below")
+    if is_cross and (prev_lhs is None or prev_rhs is None) and i == 0:
+        return EvaluationResult(status="warmup", lhs=lhs_val, rhs=rhs_val)
+
+    satisfied = compare(
+        pred.op,
+        lhs_val,
+        rhs_val,
+        prev_lhs=prev_lhs,
+        prev_rhs=prev_rhs,
+    )
+    if satisfied:
+        return EvaluationResult(status="satisfied", lhs=lhs_val, rhs=rhs_val, rel_miss=0.0)
+
+    rm = None if is_cross else relative_miss(lhs_val, rhs_val)
+    return EvaluationResult(status="miss", lhs=lhs_val, rhs=rhs_val, rel_miss=rm)
+
+
+def evaluate_entry_rules(
+    rules: Sequence[EntryRule],
+    view: HistoryView,
+    i: int,
+    *,
+    side_filter: Optional[str] = None,
+) -> Optional[Tuple[EntryRule, int]]:
+    """Return the first entry rule whose predicate fires at bar ``i``.
+
+    Pre: ``rules`` is the spec's ``entry_rules`` list.
+    Post: returns ``(rule, original_index)`` or ``None``.
+    """
+    for idx, rule in enumerate(rules):
+        if not isinstance(rule, EntryRule):
+            continue
+        if side_filter is not None and rule.side != side_filter:
+            continue
+        result = evaluate_predicate(rule.when, view, i)
+        if result.status == "satisfied":
+            return rule, idx
+    return None
+
+
+def evaluate_signal_exit_rules(
+    rules: Sequence[Any],
+    view: HistoryView,
+    i: int,
+) -> Optional[Tuple[SignalExitRule, int]]:
+    """Return the first signal-exit rule whose predicate fires at bar ``i``.
+
+    Pre: ``rules`` is the spec's ``exit_rules`` list (may contain
+    non-``SignalExitRule`` members, which are skipped).
+    Post: returns ``(rule, original_index)`` or ``None``.
+    """
+    for idx, rule in enumerate(rules):
+        if not isinstance(rule, SignalExitRule):
+            continue
+        result = evaluate_predicate(rule.when, view, i)
+        if result.status == "satisfied":
+            return rule, idx
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Indicator computation (shared by both HistoryView implementations)
+# ---------------------------------------------------------------------------
+
+
+def select_source_series(df: pd.DataFrame, source: str) -> pd.Series:
+    """Return the input series the indicator should read from."""
+    if source == "hl2":
+        return (df["high"] + df["low"]) / 2.0
+    if source == "ohlc4":
+        return (df["open"] + df["high"] + df["low"] + df["close"]) / 4.0
+    return df[source]
+
+
+def compute_indicator_series(ref: IndicatorRef, df: pd.DataFrame) -> pd.Series:
+    """Compute the full indicator series for ``ref`` on ``df``.
+
+    Pre: ``df`` has the standard OHLCV columns.
+    Post: returns a ``pd.Series`` aligned with ``df``'s index.
+    NaN during warmup is pandas' natural behaviour.
+    """
+    name = ref.name
+    if name == "sma":
+        return ind.sma(select_source_series(df, ref.source), int(ref.param("period")))
+    if name == "ema":
+        return ind.ema(select_source_series(df, ref.source), int(ref.param("period")))
+    if name == "rsi":
+        return ind.rsi(select_source_series(df, ref.source), int(ref.param("period")))
+    if name == "macd":
+        series = select_source_series(df, ref.source)
+        macd_line, signal_line, hist = ind.macd(
+            series,
+            fast=int(ref.param("fast")),
+            slow=int(ref.param("slow")),
+            signal=int(ref.param("signal")),
+        )
+        output = ref.param("output")
+        if output == "signal":
+            return signal_line
+        if output == "histogram":
+            return hist
+        return macd_line
+    if name == "bollinger":
+        series = select_source_series(df, ref.source)
+        upper, middle, lower = ind.bollinger_bands(
+            series,
+            period=int(ref.param("period")),
+            num_std=float(ref.param("num_std")),
+        )
+        band = ref.param("band")
+        if band == "upper":
+            return upper
+        if band == "lower":
+            return lower
+        return middle
+    if name == "atr":
+        return ind.atr(df["high"], df["low"], df["close"], period=int(ref.param("period")))
+    if name == "adx":
+        return ind.adx(df["high"], df["low"], df["close"], period=int(ref.param("period")))
+    if name == "stochastic":
+        pct_k, pct_d = ind.stochastic(
+            df["high"],
+            df["low"],
+            df["close"],
+            k_period=int(ref.param("k_period")),
+            d_period=int(ref.param("d_period")),
+        )
+        return pct_d if ref.param("output") == "d" else pct_k
+    if name == "vwap":
+        return ind.vwap(df["high"], df["low"], df["close"], df["volume"])
+    raise ValueError(f"unknown indicator name: {name!r}")
+
+
+# ---------------------------------------------------------------------------
+# PandasHistoryView — wraps the alignment gate's (DataFrame, cache) pair
+# ---------------------------------------------------------------------------
+
+
+class PandasHistoryView:
+    """``HistoryView`` backed by a pre-built DataFrame + indicator cache.
+
+    Used by the alignment gate to evaluate predicates against full
+    market-data frames. The indicator cache is populated lazily and
+    shared across trades for the same symbol.
+    """
+
+    def __init__(self, df: pd.DataFrame, indicator_cache: Dict[str, pd.Series]) -> None:
+        self._df = df
+        self._cache = indicator_cache
+
+    def length(self) -> int:
+        return len(self._df)
+
+    def bar_field(self, field_name: str, i: int) -> float:
+        return float(self._df[field_name].iloc[i])
+
+    def indicator(self, ref: IndicatorRef, i: int) -> Optional[float]:
+        key = ref.model_dump_json()
+        if key not in self._cache:
+            self._cache[key] = compute_indicator_series(ref, self._df)
+        series = self._cache[key]
+        if i >= len(series):
+            return None
+        value = series.iloc[i]
+        if value is None or (isinstance(value, float) and math.isnan(value)):
+            return None
+        return float(value)
+
+
+# ---------------------------------------------------------------------------
+# StreamingHistoryView — deque-backed, for the engine's per-bar runtime
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BarRecord:
+    """Minimal bar representation for the streaming view."""
+
+    timestamp: str
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+
+class StreamingHistoryView:
+    """``HistoryView`` backed by a bounded deque of bars.
+
+    Designed for the engine's per-bar loop. Bars are appended
+    incrementally; indicator values are lazily computed from the
+    full deque (converted to a DataFrame on each access).  The
+    DataFrame + indicator series are cached and invalidated when a
+    new bar is appended.
+
+    The deque is bounded to ``max_bars`` (default 500, matching the
+    ``StrategyContext._ingest_bar`` retention ceiling).
+    """
+
+    def __init__(self, max_bars: int = 500) -> None:
+        self._bars: deque[BarRecord] = deque(maxlen=max_bars)
+        self._df: Optional[pd.DataFrame] = None
+        self._indicator_cache: Dict[str, pd.Series] = {}
+
+    def append(self, bar: BarRecord) -> None:
+        """Append a bar and invalidate caches."""
+        self._bars.append(bar)
+        self._df = None
+        self._indicator_cache.clear()
+
+    def length(self) -> int:
+        return len(self._bars)
+
+    def bar_field(self, field_name: str, i: int) -> float:
+        b = self._bars[i]
+        return float(getattr(b, field_name))
+
+    def indicator(self, ref: IndicatorRef, i: int) -> Optional[float]:
+        key = ref.model_dump_json()
+        if key not in self._indicator_cache:
+            df = self._ensure_df()
+            self._indicator_cache[key] = compute_indicator_series(ref, df)
+        series = self._indicator_cache[key]
+        if i >= len(series):
+            return None
+        value = series.iloc[i]
+        if value is None or (isinstance(value, float) and math.isnan(value)):
+            return None
+        return float(value)
+
+    def _ensure_df(self) -> pd.DataFrame:
+        if self._df is not None:
+            return self._df
+        rows = [
+            {
+                "open": b.open,
+                "high": b.high,
+                "low": b.low,
+                "close": b.close,
+                "volume": b.volume,
+            }
+            for b in self._bars
+        ]
+        self._df = pd.DataFrame(rows)
+        return self._df

--- a/backend/agents/investment_team/strategy_lab/executor/rule_compiler.py
+++ b/backend/agents/investment_team/strategy_lab/executor/rule_compiler.py
@@ -12,10 +12,10 @@ Supported rule kinds (matching the discriminated ``ExitRule`` union in
   ``entry_price`` / ``trailing_high`` / ``trailing_low``.
 * ``TakeProfitRule(pct)`` — close when the bar's high (long) or low
   (short) clears the rule's price target.
-* ``SignalExitRule(when)`` — close when a predicate fires. Not yet
-  engine-enforced (the parent engine has no per-bar indicator runtime
-  today); the evaluator treats it as a silent no-op so a spec mixing
-  signal exits with stop/take-profit still gets the latter enforced.
+* ``SignalExitRule(when)`` — close when a predicate fires.  Requires a
+  ``HistoryView`` per symbol passed via the ``views`` keyword to
+  :func:`evaluate_exit_rules`.  When no view is available, the rule is
+  a silent no-op for backward compatibility.
 
 Bar-counting "time stops" are deliberately absent: real traders close
 on price action, P&L, or signal reversal — not on an arbitrary "Nth
@@ -31,7 +31,7 @@ book.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, Mapping, Sequence
+from typing import Literal, Mapping, Optional, Sequence
 
 from ..spec_dsl import (
     ExitRule,
@@ -39,6 +39,7 @@ from ..spec_dsl import (
     StopLossRule,
     TakeProfitRule,
 )
+from .predicate_evaluator import HistoryView, evaluate_signal_exit_rules
 
 ExitRuleKind = Literal["stop_loss", "take_profit", "signal_exit"]
 
@@ -81,6 +82,8 @@ def evaluate_exit_rules(
     rules: Sequence[ExitRule],
     positions: Mapping[str, PositionState],
     bars: Mapping[str, BarSnapshot],
+    *,
+    views: Optional[Mapping[str, HistoryView]] = None,
 ) -> list[ExitIntent]:
     """Return one ``ExitIntent`` per (open position × first triggered rule).
 
@@ -89,8 +92,10 @@ def evaluate_exit_rules(
         position wins. Subsequent rules for the same position are skipped
         on the same bar (only one close per position per bar).
       * Positions with no open qty (or missing from ``bars``) are skipped.
-      * ``SignalExitRule`` is a silent no-op (returns ``False`` from
-        ``_rule_triggers``) — see module docstring for rationale.
+      * ``SignalExitRule`` evaluation requires a ``HistoryView`` for the
+        symbol (passed via ``views``). When ``views`` is ``None`` or the
+        symbol has no view, ``SignalExitRule`` is a silent no-op for
+        backward compatibility.
     """
     intents: list[ExitIntent] = []
     for symbol, position in positions.items():
@@ -99,8 +104,9 @@ def evaluate_exit_rules(
         bar = bars.get(symbol)
         if bar is None:
             continue
+        sym_view = views.get(symbol) if views is not None else None
         for idx, rule in enumerate(rules):
-            if _rule_triggers(rule, position, bar):
+            if _rule_triggers(rule, position, bar, sym_view):
                 intents.append(
                     ExitIntent(
                         symbol=symbol,
@@ -123,7 +129,12 @@ def _kind_of(rule: ExitRule) -> ExitRuleKind:
     raise TypeError(f"unknown ExitRule subclass: {type(rule).__name__}")
 
 
-def _rule_triggers(rule: ExitRule, position: PositionState, bar: BarSnapshot) -> bool:
+def _rule_triggers(
+    rule: ExitRule,
+    position: PositionState,
+    bar: BarSnapshot,
+    view: Optional[HistoryView] = None,
+) -> bool:
     if isinstance(rule, StopLossRule):
         return _stop_loss_triggers(rule, position, bar)
 
@@ -131,13 +142,13 @@ def _rule_triggers(rule: ExitRule, position: PositionState, bar: BarSnapshot) ->
         return _take_profit_triggers(rule, position, bar)
 
     if isinstance(rule, SignalExitRule):
-        # Predicate-based exits need a shared per-bar indicator runtime in
-        # the parent engine — out of scope for the issue #527 MVP. Treat as
-        # a no-op so the evaluator can still process surrounding rules; the
-        # conformance gate flags SignalExit presence in an info row. Callers
-        # who need explicit detection should check ``isinstance`` before
-        # calling :func:`evaluate_exit_rules`.
-        return False
+        if view is None:
+            return False
+        i = view.length() - 1
+        if i < 0:
+            return False
+        match = evaluate_signal_exit_rules([rule], view, i)
+        return match is not None
 
     raise TypeError(f"unknown ExitRule subclass: {type(rule).__name__}")
 

--- a/backend/agents/investment_team/strategy_lab/quality_gates/alignment_checks.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/alignment_checks.py
@@ -46,6 +46,13 @@ from pydantic import BaseModel, Field
 
 from ..alignment_findings import AlignmentFinding, NearMissVerdict, Severity
 from ..executor import indicators as ind
+from ..executor.predicate_evaluator import (
+    PandasHistoryView,
+    compare as _compare_shared,
+    evaluate_predicate as _evaluate_predicate_shared,
+    relative_miss as _relative_miss_shared,
+    resolve_side_value as _resolve_side_value_shared,
+)
 from ..spec_dsl import (
     EntryRule,
     FixedFractionSizing,
@@ -143,15 +150,8 @@ def _near_miss_pct() -> float:
 
 
 def _relative_miss(computed: float, threshold: float) -> float:
-    """Relative magnitude of the gap between ``computed`` and ``threshold``.
-
-    Returns ``|computed - threshold| / max(|threshold|, |computed|, 1e-12)``.
-    The denominator floor of ``1e-12`` prevents division-by-zero when
-    both sides are zero (in which case the miss is also zero and the
-    ratio is well-defined).
-    """
-    denom = max(abs(threshold), abs(computed), 1e-12)
-    return abs(computed - threshold) / denom
+    """Delegate to the shared predicate evaluator."""
+    return _relative_miss_shared(computed, threshold)
 
 
 # ---------------------------------------------------------------------------
@@ -260,36 +260,9 @@ def _resolve_side_value(
     entry_idx: int,
     indicator_cache: Dict[str, pd.Series],
 ) -> Optional[float]:
-    """Resolve one side of a predicate to a scalar at ``entry_idx``.
-
-    Returns ``None`` when the indicator value is ``NaN`` at the entry
-    bar (warmup not yet satisfied). ``float`` literals and ``bar.*``
-    references are always resolvable.
-    """
-    if isinstance(side, IndicatorRef):
-        key = side.model_dump_json()
-        if key not in indicator_cache:
-            indicator_cache[key] = _evaluate_indicator(side, df)
-        series = indicator_cache[key]
-        if entry_idx >= len(series):
-            return None
-        value = series.iloc[entry_idx]
-        if value is None or (isinstance(value, float) and math.isnan(value)):
-            return None
-        return float(value)
-    if isinstance(side, str):
-        if side == "bar.close":
-            return float(df["close"].iloc[entry_idx])
-        if side == "bar.high":
-            return float(df["high"].iloc[entry_idx])
-        if side == "bar.low":
-            return float(df["low"].iloc[entry_idx])
-        if side == "bar.volume":
-            return float(df["volume"].iloc[entry_idx])
-        raise ValueError(f"unexpected bar-ref string: {side!r}")
-    if isinstance(side, (int, float)) and not isinstance(side, bool):
-        return float(side)
-    raise TypeError(f"unsupported predicate side type: {type(side).__name__}")
+    """Delegate to the shared predicate evaluator via ``PandasHistoryView``."""
+    view = PandasHistoryView(df, indicator_cache)
+    return _resolve_side_value_shared(side, view, entry_idx)
 
 
 def _compare(
@@ -300,38 +273,8 @@ def _compare(
     prev_lhs: Optional[float] = None,
     prev_rhs: Optional[float] = None,
 ) -> bool:
-    """Evaluate a comparison op on two scalars.
-
-    ``cross_above`` / ``cross_below`` are state transitions: the
-    previous bar must have been on or below (resp. on or above) the
-    threshold AND the current bar must be strictly above (resp.
-    below) it. Collapsing them to ``>`` / ``<`` at the entry bar
-    alone would mark any sustained-above strategy as having "crossed
-    above" on every bar, letting non-cross strategies wave through
-    the gate. When the previous-bar values are not available (e.g.
-    entry is the first bar in market_data, or warmup left an
-    indicator NaN), the cross is treated as not satisfied —
-    deterministic-fail-closed.
-    """
-    if op == "<":
-        return lhs < rhs
-    if op == "<=":
-        return lhs <= rhs
-    if op == ">":
-        return lhs > rhs
-    if op == ">=":
-        return lhs >= rhs
-    if op == "==":
-        return math.isclose(lhs, rhs, rel_tol=1e-9, abs_tol=1e-12)
-    if op == "cross_above":
-        if prev_lhs is None or prev_rhs is None:
-            return False
-        return prev_lhs <= prev_rhs and lhs > rhs
-    if op == "cross_below":
-        if prev_lhs is None or prev_rhs is None:
-            return False
-        return prev_lhs >= prev_rhs and lhs < rhs
-    raise ValueError(f"unknown comparison op: {op!r}")
+    """Delegate to the shared predicate evaluator."""
+    return _compare_shared(op, lhs, rhs, prev_lhs=prev_lhs, prev_rhs=prev_rhs)
 
 
 def _format_predicate(p: Predicate) -> str:

--- a/backend/agents/investment_team/strategy_lab/quality_gates/alignment_checks.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/alignment_checks.py
@@ -48,9 +48,14 @@ from ..alignment_findings import AlignmentFinding, NearMissVerdict, Severity
 from ..executor import indicators as ind
 from ..executor.predicate_evaluator import (
     PandasHistoryView,
+)
+from ..executor.predicate_evaluator import (
     compare as _compare_shared,
-    evaluate_predicate as _evaluate_predicate_shared,
+)
+from ..executor.predicate_evaluator import (
     relative_miss as _relative_miss_shared,
+)
+from ..executor.predicate_evaluator import (
     resolve_side_value as _resolve_side_value_shared,
 )
 from ..spec_dsl import (

--- a/backend/agents/investment_team/tests/test_engine_entry_dispatch.py
+++ b/backend/agents/investment_team/tests/test_engine_entry_dispatch.py
@@ -12,7 +12,6 @@ from investment_team.strategy_lab.spec_dsl import (
     EntryRule,
     FixedFractionSizing,
     FixedNotionalSizing,
-    IndicatorRef,
     Predicate,
 )
 from investment_team.trading_service.service import (
@@ -21,7 +20,9 @@ from investment_team.trading_service.service import (
 )
 
 
-def _make_bar(symbol="AAA", close=100.0, high=101.0, low=99.0, volume=1000.0, timestamp="2024-01-10"):
+def _make_bar(
+    symbol="AAA", close=100.0, high=101.0, low=99.0, volume=1000.0, timestamp="2024-01-10"
+):
     bar = MagicMock()
     bar.symbol = symbol
     bar.close = close

--- a/backend/agents/investment_team/tests/test_engine_entry_dispatch.py
+++ b/backend/agents/investment_team/tests/test_engine_entry_dispatch.py
@@ -1,0 +1,171 @@
+"""Unit tests for ``_EngineEntryDispatcher`` in ``trading_service.service``."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from investment_team.strategy_lab.executor.predicate_evaluator import (
+    BarRecord,
+    StreamingHistoryView,
+)
+from investment_team.strategy_lab.spec_dsl import (
+    EntryRule,
+    FixedFractionSizing,
+    FixedNotionalSizing,
+    IndicatorRef,
+    Predicate,
+)
+from investment_team.trading_service.service import (
+    TradingServiceResult,
+    _EngineEntryDispatcher,
+)
+
+
+def _make_bar(symbol="AAA", close=100.0, high=101.0, low=99.0, volume=1000.0, timestamp="2024-01-10"):
+    bar = MagicMock()
+    bar.symbol = symbol
+    bar.close = close
+    bar.high = high
+    bar.low = low
+    bar.open = close
+    bar.volume = volume
+    bar.timestamp = timestamp
+    return bar
+
+
+def _make_portfolio(capital=100000.0, positions=None):
+    port = MagicMock()
+    port.positions = positions or {}
+    port.mark_to_market.return_value = capital
+    return port
+
+
+def _build_view(closes: list[float]) -> StreamingHistoryView:
+    view = StreamingHistoryView()
+    for i, c in enumerate(closes):
+        view.append(
+            BarRecord(
+                timestamp=f"2024-01-{i + 1:02d}",
+                open=c,
+                high=c + 1,
+                low=c - 1,
+                close=c,
+                volume=1000.0,
+            )
+        )
+    return view
+
+
+def test_entry_fires_when_predicate_satisfied():
+    rules = [
+        EntryRule(side="long", when=Predicate(lhs="bar.close", op=">", rhs=90.0)),
+    ]
+    dispatcher = _EngineEntryDispatcher(
+        entry_rules=rules,
+        sizing=FixedFractionSizing(fraction=0.02),
+    )
+    bar = _make_bar(close=100.0)
+    portfolio = _make_portfolio()
+    pending: list = []
+    views = {"AAA": _build_view([80.0, 90.0, 100.0])}
+    result = TradingServiceResult()
+
+    dispatcher.maybe_emit(
+        cur_bar=bar,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        views=views,
+        result=result,
+    )
+    assert len(pending) == 1
+    assert pending[0].side.value == "long"
+    assert pending[0].reason.startswith("engine_entry:")
+
+
+def test_entry_skipped_when_position_exists():
+    rules = [
+        EntryRule(side="long", when=Predicate(lhs="bar.close", op=">", rhs=90.0)),
+    ]
+    dispatcher = _EngineEntryDispatcher(
+        entry_rules=rules,
+        sizing=FixedFractionSizing(fraction=0.02),
+    )
+    bar = _make_bar(close=100.0)
+    portfolio = _make_portfolio(positions={"AAA": MagicMock()})
+    pending: list = []
+    views = {"AAA": _build_view([80.0, 90.0, 100.0])}
+    result = TradingServiceResult()
+
+    dispatcher.maybe_emit(
+        cur_bar=bar,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        views=views,
+        result=result,
+    )
+    assert len(pending) == 0
+
+
+def test_entry_skipped_when_predicate_not_satisfied():
+    rules = [
+        EntryRule(side="long", when=Predicate(lhs="bar.close", op=">", rhs=200.0)),
+    ]
+    dispatcher = _EngineEntryDispatcher(
+        entry_rules=rules,
+        sizing=FixedFractionSizing(fraction=0.02),
+    )
+    bar = _make_bar(close=100.0)
+    portfolio = _make_portfolio()
+    pending: list = []
+    views = {"AAA": _build_view([80.0, 90.0, 100.0])}
+    result = TradingServiceResult()
+
+    dispatcher.maybe_emit(
+        cur_bar=bar,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        views=views,
+        result=result,
+    )
+    assert len(pending) == 0
+
+
+def test_entry_disabled_when_no_rules():
+    dispatcher = _EngineEntryDispatcher(entry_rules=[], sizing=None)
+    bar = _make_bar()
+    portfolio = _make_portfolio()
+    pending: list = []
+    result = TradingServiceResult()
+    dispatcher.maybe_emit(
+        cur_bar=bar,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        views={"AAA": _build_view([100.0])},
+        result=result,
+    )
+    assert len(pending) == 0
+
+
+def test_sizing_fixed_notional():
+    rules = [
+        EntryRule(side="long", when=Predicate(lhs="bar.close", op=">", rhs=50.0)),
+    ]
+    dispatcher = _EngineEntryDispatcher(
+        entry_rules=rules,
+        sizing=FixedNotionalSizing(notional_usd=5000.0),
+    )
+    bar = _make_bar(close=100.0)
+    portfolio = _make_portfolio()
+    pending: list = []
+    views = {"AAA": _build_view([60.0, 70.0, 80.0])}
+    result = TradingServiceResult()
+
+    dispatcher.maybe_emit(
+        cur_bar=bar,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        views=views,
+        result=result,
+    )
+    assert len(pending) == 1
+    assert pending[0].qty == 50  # 5000 / 100

--- a/backend/agents/investment_team/tests/test_predicate_evaluator.py
+++ b/backend/agents/investment_team/tests/test_predicate_evaluator.py
@@ -1,0 +1,275 @@
+"""Unit tests for ``executor.predicate_evaluator``."""
+
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+
+from investment_team.strategy_lab.executor.predicate_evaluator import (
+    BarRecord,
+    EvaluationResult,
+    PandasHistoryView,
+    StreamingHistoryView,
+    compare,
+    evaluate_entry_rules,
+    evaluate_predicate,
+    evaluate_signal_exit_rules,
+    relative_miss,
+    resolve_side_value,
+)
+from investment_team.strategy_lab.spec_dsl import (
+    EntryRule,
+    IndicatorRef,
+    Predicate,
+    SignalExitRule,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_df(closes: list[float]) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "open": closes,
+            "high": [c + 1 for c in closes],
+            "low": [c - 1 for c in closes],
+            "close": closes,
+            "volume": [1000.0] * len(closes),
+        }
+    )
+
+
+def _pandas_view(closes: list[float]) -> PandasHistoryView:
+    return PandasHistoryView(_make_df(closes), {})
+
+
+def _streaming_view(closes: list[float]) -> StreamingHistoryView:
+    view = StreamingHistoryView()
+    for i, c in enumerate(closes):
+        view.append(
+            BarRecord(
+                timestamp=f"2024-01-{i + 1:02d}",
+                open=c,
+                high=c + 1,
+                low=c - 1,
+                close=c,
+                volume=1000.0,
+            )
+        )
+    return view
+
+
+# ---------------------------------------------------------------------------
+# compare()
+# ---------------------------------------------------------------------------
+
+
+def test_compare_less_than():
+    assert compare("<", 1.0, 2.0) is True
+    assert compare("<", 2.0, 1.0) is False
+
+
+def test_compare_greater_than():
+    assert compare(">", 2.0, 1.0) is True
+    assert compare(">", 1.0, 2.0) is False
+
+
+def test_compare_less_equal():
+    assert compare("<=", 1.0, 1.0) is True
+    assert compare("<=", 2.0, 1.0) is False
+
+
+def test_compare_greater_equal():
+    assert compare(">=", 1.0, 1.0) is True
+    assert compare(">=", 0.5, 1.0) is False
+
+
+def test_compare_equal():
+    assert compare("==", 1.0, 1.0) is True
+    assert compare("==", 1.0, 2.0) is False
+
+
+def test_compare_cross_above():
+    assert compare("cross_above", 11.0, 10.0, prev_lhs=9.0, prev_rhs=10.0) is True
+    assert compare("cross_above", 11.0, 10.0, prev_lhs=11.0, prev_rhs=10.0) is False
+    assert compare("cross_above", 11.0, 10.0) is False
+
+
+def test_compare_cross_below():
+    assert compare("cross_below", 9.0, 10.0, prev_lhs=11.0, prev_rhs=10.0) is True
+    assert compare("cross_below", 9.0, 10.0, prev_lhs=9.0, prev_rhs=10.0) is False
+    assert compare("cross_below", 9.0, 10.0) is False
+
+
+# ---------------------------------------------------------------------------
+# relative_miss()
+# ---------------------------------------------------------------------------
+
+
+def test_relative_miss_zero():
+    assert relative_miss(10.0, 10.0) == 0.0
+
+
+def test_relative_miss_nonzero():
+    assert math.isclose(relative_miss(11.0, 10.0), 1.0 / 11.0)
+
+
+# ---------------------------------------------------------------------------
+# evaluate_predicate() — simple ops
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_predicate_gt_satisfied():
+    pred = Predicate(lhs=IndicatorRef(name="sma", params={"period": 3}), op=">", rhs=50.0)
+    view = _pandas_view([40.0, 50.0, 60.0, 70.0, 80.0])
+    result = evaluate_predicate(pred, view, 4)
+    assert result.status == "satisfied"
+
+
+def test_evaluate_predicate_gt_miss():
+    pred = Predicate(lhs=IndicatorRef(name="sma", params={"period": 3}), op=">", rhs=200.0)
+    view = _pandas_view([40.0, 50.0, 60.0, 70.0, 80.0])
+    result = evaluate_predicate(pred, view, 4)
+    assert result.status == "miss"
+
+
+def test_evaluate_predicate_warmup():
+    pred = Predicate(lhs=IndicatorRef(name="sma", params={"period": 20}), op=">", rhs=50.0)
+    view = _pandas_view([40.0, 50.0, 60.0])
+    result = evaluate_predicate(pred, view, 2)
+    assert result.status == "warmup"
+
+
+# ---------------------------------------------------------------------------
+# evaluate_predicate() — cross ops
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_predicate_cross_above_satisfied():
+    sma_fast = IndicatorRef(name="sma", params={"period": 2})
+    sma_slow = IndicatorRef(name="sma", params={"period": 3})
+    pred = Predicate(lhs=sma_fast, op="cross_above", rhs=sma_slow)
+    closes = [10.0, 12.0, 11.0, 9.0, 8.0, 10.0, 14.0, 18.0]
+    view = _pandas_view(closes)
+    satisfied_any = False
+    for i in range(3, len(closes)):
+        r = evaluate_predicate(pred, view, i)
+        if r.status == "satisfied":
+            satisfied_any = True
+            break
+    assert satisfied_any
+
+
+def test_evaluate_predicate_cross_above_not_at_first_bar():
+    sma_fast = IndicatorRef(name="sma", params={"period": 2})
+    pred = Predicate(lhs=sma_fast, op="cross_above", rhs=5.0)
+    view = _pandas_view([10.0, 20.0])
+    result = evaluate_predicate(pred, view, 0)
+    assert result.status == "warmup"
+
+
+# ---------------------------------------------------------------------------
+# evaluate_entry_rules()
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_entry_rules_first_match():
+    rules = [
+        EntryRule(side="long", when=Predicate(lhs="bar.close", op=">", rhs=100.0)),
+        EntryRule(side="long", when=Predicate(lhs="bar.close", op=">", rhs=50.0)),
+    ]
+    view = _pandas_view([60.0, 70.0, 80.0])
+    result = evaluate_entry_rules(rules, view, 2)
+    assert result is not None
+    _rule, idx = result
+    assert idx == 1
+
+
+def test_evaluate_entry_rules_no_match():
+    rules = [
+        EntryRule(side="long", when=Predicate(lhs="bar.close", op=">", rhs=100.0)),
+    ]
+    view = _pandas_view([60.0])
+    result = evaluate_entry_rules(rules, view, 0)
+    assert result is None
+
+
+def test_evaluate_entry_rules_side_filter():
+    rules = [
+        EntryRule(side="long", when=Predicate(lhs="bar.close", op=">", rhs=50.0)),
+        EntryRule(side="short", when=Predicate(lhs="bar.close", op=">", rhs=50.0)),
+    ]
+    view = _pandas_view([60.0])
+    result = evaluate_entry_rules(rules, view, 0, side_filter="short")
+    assert result is not None
+    _rule, idx = result
+    assert idx == 1
+
+
+# ---------------------------------------------------------------------------
+# evaluate_signal_exit_rules()
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_signal_exit_rules_match():
+    rules = [
+        SignalExitRule(when=Predicate(lhs="bar.close", op=">", rhs=100.0)),
+    ]
+    view = _pandas_view([110.0])
+    result = evaluate_signal_exit_rules(rules, view, 0)
+    assert result is not None
+
+
+def test_evaluate_signal_exit_rules_no_match():
+    rules = [
+        SignalExitRule(when=Predicate(lhs="bar.close", op=">", rhs=100.0)),
+    ]
+    view = _pandas_view([50.0])
+    result = evaluate_signal_exit_rules(rules, view, 0)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# StreamingHistoryView parity with PandasHistoryView
+# ---------------------------------------------------------------------------
+
+
+def test_streaming_pandas_parity():
+    closes = [100.0, 101.0, 102.0, 103.0, 104.0, 105.0, 106.0, 107.0, 108.0, 109.0,
+              110.0, 111.0, 112.0, 113.0, 114.0, 115.0, 116.0, 117.0, 118.0, 119.0]
+    pandas_view = _pandas_view(closes)
+    streaming = _streaming_view(closes)
+    ref = IndicatorRef(name="sma", params={"period": 5})
+    last = len(closes) - 1
+    p_val = pandas_view.indicator(ref, last)
+    s_val = streaming.indicator(ref, last)
+    assert p_val is not None and s_val is not None
+    assert math.isclose(p_val, s_val, rel_tol=1e-9)
+
+
+def test_streaming_view_bar_field():
+    view = _streaming_view([100.0, 200.0])
+    assert view.bar_field("close", 0) == 100.0
+    assert view.bar_field("close", 1) == 200.0
+    assert view.bar_field("high", 1) == 201.0
+
+
+def test_streaming_view_length():
+    view = _streaming_view([1.0, 2.0, 3.0])
+    assert view.length() == 3
+
+
+def test_streaming_view_cache_invalidation():
+    view = StreamingHistoryView()
+    for c in [100.0, 101.0, 102.0]:
+        view.append(BarRecord(timestamp="2024-01-01", open=c, high=c+1, low=c-1, close=c, volume=1000.0))
+    ref = IndicatorRef(name="sma", params={"period": 2})
+    v1 = view.indicator(ref, 2)
+    view.append(BarRecord(timestamp="2024-01-02", open=200, high=201, low=199, close=200, volume=1000.0))
+    v2 = view.indicator(ref, 3)
+    assert v1 is not None and v2 is not None
+    assert v1 != v2

--- a/backend/agents/investment_team/tests/test_predicate_evaluator.py
+++ b/backend/agents/investment_team/tests/test_predicate_evaluator.py
@@ -8,7 +8,6 @@ import pandas as pd
 
 from investment_team.strategy_lab.executor.predicate_evaluator import (
     BarRecord,
-    EvaluationResult,
     PandasHistoryView,
     StreamingHistoryView,
     compare,
@@ -16,7 +15,6 @@ from investment_team.strategy_lab.executor.predicate_evaluator import (
     evaluate_predicate,
     evaluate_signal_exit_rules,
     relative_miss,
-    resolve_side_value,
 )
 from investment_team.strategy_lab.spec_dsl import (
     EntryRule,
@@ -24,7 +22,6 @@ from investment_team.strategy_lab.spec_dsl import (
     Predicate,
     SignalExitRule,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -239,8 +236,28 @@ def test_evaluate_signal_exit_rules_no_match():
 
 
 def test_streaming_pandas_parity():
-    closes = [100.0, 101.0, 102.0, 103.0, 104.0, 105.0, 106.0, 107.0, 108.0, 109.0,
-              110.0, 111.0, 112.0, 113.0, 114.0, 115.0, 116.0, 117.0, 118.0, 119.0]
+    closes = [
+        100.0,
+        101.0,
+        102.0,
+        103.0,
+        104.0,
+        105.0,
+        106.0,
+        107.0,
+        108.0,
+        109.0,
+        110.0,
+        111.0,
+        112.0,
+        113.0,
+        114.0,
+        115.0,
+        116.0,
+        117.0,
+        118.0,
+        119.0,
+    ]
     pandas_view = _pandas_view(closes)
     streaming = _streaming_view(closes)
     ref = IndicatorRef(name="sma", params={"period": 5})
@@ -266,10 +283,14 @@ def test_streaming_view_length():
 def test_streaming_view_cache_invalidation():
     view = StreamingHistoryView()
     for c in [100.0, 101.0, 102.0]:
-        view.append(BarRecord(timestamp="2024-01-01", open=c, high=c+1, low=c-1, close=c, volume=1000.0))
+        view.append(
+            BarRecord(timestamp="2024-01-01", open=c, high=c + 1, low=c - 1, close=c, volume=1000.0)
+        )
     ref = IndicatorRef(name="sma", params={"period": 2})
     v1 = view.indicator(ref, 2)
-    view.append(BarRecord(timestamp="2024-01-02", open=200, high=201, low=199, close=200, volume=1000.0))
+    view.append(
+        BarRecord(timestamp="2024-01-02", open=200, high=201, low=199, close=200, volume=1000.0)
+    )
     v2 = view.indicator(ref, 3)
     assert v1 is not None and v2 is not None
     assert v1 != v2

--- a/backend/agents/investment_team/tests/test_rule_compiler.py
+++ b/backend/agents/investment_team/tests/test_rule_compiler.py
@@ -7,6 +7,10 @@ and asserts on the returned intents without touching the trading service.
 
 from __future__ import annotations
 
+from investment_team.strategy_lab.executor.predicate_evaluator import (
+    BarRecord,
+    StreamingHistoryView,
+)
 from investment_team.strategy_lab.executor.rule_compiler import (
     BarSnapshot,
     PositionState,
@@ -216,42 +220,92 @@ def test_position_without_matching_bar_skipped() -> None:
 
 
 # ---------------------------------------------------------------------------
-# SignalExitRule — silent no-op (not yet engine-enforced)
+# Helpers for HistoryView-backed tests
 # ---------------------------------------------------------------------------
 
 
-def test_signal_exit_rule_is_silent_noop() -> None:
-    # SignalExitRule is not yet engine-enforced (predicate evaluation needs a
-    # shared per-bar indicator runtime). The evaluator treats it as a no-op
-    # so other rules in the same spec still get enforced — see module
-    # docstring + ``ExitRuleConformanceGate`` for the user-facing surface.
+def _build_view(closes: list[float], symbol: str = "AAA") -> StreamingHistoryView:
+    view = StreamingHistoryView()
+    for i, c in enumerate(closes):
+        view.append(
+            BarRecord(
+                timestamp=f"2024-01-{i + 1:02d}",
+                open=c,
+                high=c + 1,
+                low=c - 1,
+                close=c,
+                volume=1000.0,
+            )
+        )
+    return view
+
+
+# ---------------------------------------------------------------------------
+# SignalExitRule — no-op without views, enforced with views
+# ---------------------------------------------------------------------------
+
+
+def test_signal_exit_rule_noop_without_views() -> None:
     pos = _long()
     rule = SignalExitRule(
-        when=Predicate(
-            lhs=IndicatorRef(name="rsi", params={"period": 14}),
-            op=">",
-            rhs=70.0,
-        )
+        when=Predicate(lhs="bar.close", op=">", rhs=90.0)
     )
     intents = evaluate_exit_rules([rule], {"AAA": pos}, {"AAA": _bar()})
     assert intents == []
 
 
-def test_signal_exit_does_not_block_other_rules_in_spec() -> None:
-    # Mix SignalExit + StopLoss. StopLoss should still fire even though the
-    # SignalExit is iterated first.
+def test_signal_exit_fires_with_view_when_predicate_satisfied() -> None:
     pos = _long()
-    signal = SignalExitRule(
+    rule = SignalExitRule(
+        when=Predicate(lhs="bar.close", op=">", rhs=90.0)
+    )
+    views = {"AAA": _build_view([80.0, 90.0, 100.0])}
+    intents = evaluate_exit_rules(
+        [rule], {"AAA": pos}, {"AAA": _bar(close=100.0)}, views=views,
+    )
+    assert len(intents) == 1
+    assert intents[0].rule_kind == "signal_exit"
+
+
+def test_signal_exit_does_not_fire_when_predicate_not_satisfied() -> None:
+    pos = _long()
+    rule = SignalExitRule(
+        when=Predicate(lhs="bar.close", op=">", rhs=200.0)
+    )
+    views = {"AAA": _build_view([80.0, 90.0, 100.0])}
+    intents = evaluate_exit_rules(
+        [rule], {"AAA": pos}, {"AAA": _bar(close=100.0)}, views=views,
+    )
+    assert intents == []
+
+
+def test_signal_exit_warmup_returns_none() -> None:
+    pos = _long()
+    rule = SignalExitRule(
         when=Predicate(
-            lhs=IndicatorRef(name="rsi", params={"period": 14}),
+            lhs=IndicatorRef(name="sma", params={"period": 50}),
             op=">",
-            rhs=70.0,
+            rhs=90.0,
         )
     )
+    views = {"AAA": _build_view([100.0, 101.0, 102.0])}
+    intents = evaluate_exit_rules(
+        [rule], {"AAA": pos}, {"AAA": _bar()}, views=views,
+    )
+    assert intents == []
+
+
+def test_signal_exit_does_not_block_other_rules_in_spec() -> None:
+    pos = _long()
+    signal = SignalExitRule(
+        when=Predicate(lhs="bar.close", op=">", rhs=200.0)
+    )
+    views = {"AAA": _build_view([80.0, 90.0, 100.0])}
     intents = evaluate_exit_rules(
         [signal, StopLossRule(pct=0.05)],
         {"AAA": pos},
         {"AAA": _bar(low=94)},
+        views=views,
     )
     assert len(intents) == 1
     assert intents[0].rule_kind == "stop_loss"

--- a/backend/agents/investment_team/tests/test_rule_compiler.py
+++ b/backend/agents/investment_team/tests/test_rule_compiler.py
@@ -247,21 +247,20 @@ def _build_view(closes: list[float], symbol: str = "AAA") -> StreamingHistoryVie
 
 def test_signal_exit_rule_noop_without_views() -> None:
     pos = _long()
-    rule = SignalExitRule(
-        when=Predicate(lhs="bar.close", op=">", rhs=90.0)
-    )
+    rule = SignalExitRule(when=Predicate(lhs="bar.close", op=">", rhs=90.0))
     intents = evaluate_exit_rules([rule], {"AAA": pos}, {"AAA": _bar()})
     assert intents == []
 
 
 def test_signal_exit_fires_with_view_when_predicate_satisfied() -> None:
     pos = _long()
-    rule = SignalExitRule(
-        when=Predicate(lhs="bar.close", op=">", rhs=90.0)
-    )
+    rule = SignalExitRule(when=Predicate(lhs="bar.close", op=">", rhs=90.0))
     views = {"AAA": _build_view([80.0, 90.0, 100.0])}
     intents = evaluate_exit_rules(
-        [rule], {"AAA": pos}, {"AAA": _bar(close=100.0)}, views=views,
+        [rule],
+        {"AAA": pos},
+        {"AAA": _bar(close=100.0)},
+        views=views,
     )
     assert len(intents) == 1
     assert intents[0].rule_kind == "signal_exit"
@@ -269,12 +268,13 @@ def test_signal_exit_fires_with_view_when_predicate_satisfied() -> None:
 
 def test_signal_exit_does_not_fire_when_predicate_not_satisfied() -> None:
     pos = _long()
-    rule = SignalExitRule(
-        when=Predicate(lhs="bar.close", op=">", rhs=200.0)
-    )
+    rule = SignalExitRule(when=Predicate(lhs="bar.close", op=">", rhs=200.0))
     views = {"AAA": _build_view([80.0, 90.0, 100.0])}
     intents = evaluate_exit_rules(
-        [rule], {"AAA": pos}, {"AAA": _bar(close=100.0)}, views=views,
+        [rule],
+        {"AAA": pos},
+        {"AAA": _bar(close=100.0)},
+        views=views,
     )
     assert intents == []
 
@@ -290,16 +290,17 @@ def test_signal_exit_warmup_returns_none() -> None:
     )
     views = {"AAA": _build_view([100.0, 101.0, 102.0])}
     intents = evaluate_exit_rules(
-        [rule], {"AAA": pos}, {"AAA": _bar()}, views=views,
+        [rule],
+        {"AAA": pos},
+        {"AAA": _bar()},
+        views=views,
     )
     assert intents == []
 
 
 def test_signal_exit_does_not_block_other_rules_in_spec() -> None:
     pos = _long()
-    signal = SignalExitRule(
-        when=Predicate(lhs="bar.close", op=">", rhs=200.0)
-    )
+    signal = SignalExitRule(when=Predicate(lhs="bar.close", op=">", rhs=200.0))
     views = {"AAA": _build_view([80.0, 90.0, 100.0])}
     intents = evaluate_exit_rules(
         [signal, StopLossRule(pct=0.05)],

--- a/backend/agents/investment_team/tests/test_trading_service.py
+++ b/backend/agents/investment_team/tests/test_trading_service.py
@@ -617,12 +617,16 @@ def test_diagnostics_emitted_and_accepted_counts_round_trip() -> None:
     diagnostics = run.service_result.execution_diagnostics
 
     assert run.service_result.error is None, run.service_result.error
-    # SMA(5) crossover emits one long entry then one opposite-side close.
-    assert diagnostics.orders_emitted == 2
-    assert diagnostics.orders_accepted == 2
+    # SMA(5) crossover: strategy emits 1 entry + 1 exit. The engine's
+    # signal-exit dispatcher also emits a close when the SignalExitRule
+    # predicate fires on the same bar (dedup at fill time ensures only
+    # one close fills). Total emits = 3 (1 entry + 1 strategy exit +
+    # 1 engine signal-exit).
+    assert diagnostics.orders_emitted == 3
+    assert diagnostics.orders_accepted == 3
     assert diagnostics.orders_rejected == 0
     assert diagnostics.orders_unfilled == 0
-    assert diagnostics.exits_emitted == 1
+    assert diagnostics.exits_emitted == 2
     # #410: FillSimulator now reports entry/exit fill lifecycle events.
     # The SMA round-trip lands one FULL entry and one FULL exit.
     assert diagnostics.entries_filled == 1

--- a/backend/agents/investment_team/trading_service/modes/backtest.py
+++ b/backend/agents/investment_team/trading_service/modes/backtest.py
@@ -183,6 +183,8 @@ def run_backtest(
             # does. Empty list (no rules in spec) preserves the legacy
             # strategy-code-only path.
             exit_rules=list(strategy.exit_rules),
+            entry_rules=list(strategy.entry_rules) if not strategy.requires_custom_code else None,
+            sizing=strategy.sizing if not strategy.requires_custom_code else None,
         )
         outcome = service.run(stream)
         run_metrics = compute_metrics(

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -32,6 +32,8 @@ from ..models import (
 from ..strategy_lab.executor.predicate_evaluator import (
     BarRecord,
     StreamingHistoryView,
+)
+from ..strategy_lab.executor.predicate_evaluator import (
     evaluate_entry_rules as _evaluate_entry_rules_pred,
 )
 from ..strategy_lab.executor.rule_compiler import (
@@ -45,7 +47,6 @@ from ..strategy_lab.spec_dsl import (
     ExitRule,
     FixedFractionSizing,
     FixedNotionalSizing,
-    SizingRule,
     VolatilityTargetSizing,
 )
 from .data_stream.protocol import BarEvent, EndOfStreamEvent, StreamEvent
@@ -287,7 +288,10 @@ class _EngineExitDispatcher:
         snapshot = tracked.snapshot(sym, pos.qty)
         bar_snap = BarSnapshot(high=cur_bar.high, low=cur_bar.low, close=cur_bar.close)
         intents = evaluate_exit_rules(
-            self.exit_rules, {sym: snapshot}, {sym: bar_snap}, views=self.views,
+            self.exit_rules,
+            {sym: snapshot},
+            {sym: bar_snap},
+            views=self.views,
         )
         return intents[0] if intents else None
 
@@ -536,7 +540,10 @@ class _EngineEntryDispatcher:
         sym = cur_bar.symbol
         if portfolio.positions.get(sym) is not None:
             return
-        if any(req.symbol == sym and req.side in (OrderSide.LONG, OrderSide.SHORT) for req in pending_for_prev):
+        if any(
+            req.symbol == sym and req.side in (OrderSide.LONG, OrderSide.SHORT)
+            for req in pending_for_prev
+        ):
             return
         view = views.get(sym)
         if view is None or view.length() == 0:
@@ -1855,14 +1862,16 @@ class TradingService:
         sym = cur_bar.symbol
         if sym not in views:
             views[sym] = StreamingHistoryView()
-        views[sym].append(BarRecord(
-            timestamp=cur_bar.timestamp,
-            open=cur_bar.open,
-            high=cur_bar.high,
-            low=cur_bar.low,
-            close=cur_bar.close,
-            volume=getattr(cur_bar, "volume", 0.0),
-        ))
+        views[sym].append(
+            BarRecord(
+                timestamp=cur_bar.timestamp,
+                open=cur_bar.open,
+                high=cur_bar.high,
+                low=cur_bar.low,
+                close=cur_bar.close,
+                volume=getattr(cur_bar, "volume", 0.0),
+            )
+        )
 
     @staticmethod
     def _update_position_tracker(

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -606,9 +606,7 @@ class _EngineEntryDispatcher:
         if isinstance(sizing, FixedNotionalSizing):
             return max(1, int(float(sizing.notional_usd) / close))
         if isinstance(sizing, VolatilityTargetSizing):
-            from ..strategy_lab.spec_dsl import IndicatorRef
-
-            atr_ref = IndicatorRef(name="atr")
+            atr_ref = self._find_atr_ref()
             view = views.get(cur_bar.symbol)
             if view is None or view.length() == 0:
                 return 1
@@ -617,6 +615,23 @@ class _EngineEntryDispatcher:
                 return 1
             return max(1, int(equity * float(sizing.target_annual_vol) / (close * atr_val)))
         return 1
+
+    def _find_atr_ref(self):
+        """Find an ATR IndicatorRef from the spec's entry rules.
+
+        Scans entry-rule predicates for an ATR indicator and returns it
+        so vol-target sizing uses the spec's configured period.  Falls
+        back to the default ATR(14) when no ATR appears in the rules.
+        """
+        from ..strategy_lab.spec_dsl import IndicatorRef
+
+        for rule in self.entry_rules:
+            if not isinstance(rule, EntryRule):
+                continue
+            for side in (rule.when.lhs, rule.when.rhs):
+                if isinstance(side, IndicatorRef) and side.name == "atr":
+                    return side
+        return IndicatorRef(name="atr")
 
 
 # Default chunk size for the batched-bar protocol (issue #377). 1 keeps
@@ -1316,7 +1331,10 @@ class TradingService:
                                 portfolio=portfolio,
                             )
 
-                        self._append_streaming_bar(streaming_views, cur_bar)
+                    # Append every bar (including warm-up) to the streaming
+                    # view so indicators have full history for predicate
+                    # evaluation once warm-up ends.
+                    self._append_streaming_bar(streaming_views, cur_bar)
 
                     # 4) Deliver the current bar to the strategy and collect
                     #    any orders it submits in response. Warm-up bars set
@@ -1586,7 +1604,10 @@ class TradingService:
                             portfolio=portfolio,
                         )
 
-                    self._append_streaming_bar(streaming_views, cur_bar)
+                # Append every bar (including warm-up) to the streaming
+                # view so indicators have full history for predicate
+                # evaluation once warm-up ends.
+                self._append_streaming_bar(streaming_views, cur_bar)
 
                 # 4) Process the strategy's response for this bar.
                 try:

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -29,13 +29,25 @@ from ..models import (
     OrderLifecycleEvent,
     TradeRecord,
 )
+from ..strategy_lab.executor.predicate_evaluator import (
+    BarRecord,
+    StreamingHistoryView,
+    evaluate_entry_rules as _evaluate_entry_rules_pred,
+)
 from ..strategy_lab.executor.rule_compiler import (
     BarSnapshot,
     ExitIntent,
     PositionState,
     evaluate_exit_rules,
 )
-from ..strategy_lab.spec_dsl import ExitRule
+from ..strategy_lab.spec_dsl import (
+    EntryRule,
+    ExitRule,
+    FixedFractionSizing,
+    FixedNotionalSizing,
+    SizingRule,
+    VolatilityTargetSizing,
+)
 from .data_stream.protocol import BarEvent, EndOfStreamEvent, StreamEvent
 from .engine.execution_model import build_execution_model
 from .engine.fill_simulator import FillOutcome, FillSimulator, FillSimulatorConfig
@@ -134,6 +146,7 @@ class _EngineExitDispatcher:
     exit_rules: Sequence[ExitRule]
     engine_exit_bindings: Dict[str, str] = field(default_factory=dict)
     _next_seq: int = 0
+    views: Optional[Dict[str, StreamingHistoryView]] = None
 
     # ------------------------------------------------------------------
 
@@ -273,7 +286,9 @@ class _EngineExitDispatcher:
         """
         snapshot = tracked.snapshot(sym, pos.qty)
         bar_snap = BarSnapshot(high=cur_bar.high, low=cur_bar.low, close=cur_bar.close)
-        intents = evaluate_exit_rules(self.exit_rules, {sym: snapshot}, {sym: bar_snap})
+        intents = evaluate_exit_rules(
+            self.exit_rules, {sym: snapshot}, {sym: bar_snap}, views=self.views,
+        )
         return intents[0] if intents else None
 
     @staticmethod
@@ -484,6 +499,117 @@ class _EngineExitDispatcher:
             order_type=OrderType.MARKET.value,
             reason=req.reason,
         )
+
+
+ENGINE_ENTRY_REASON_PREFIX = "engine_entry:"
+
+
+@dataclass
+class _EngineEntryDispatcher:
+    """Per-run owner of engine-side entry-rule enforcement.
+
+    Parallel to :class:`_EngineExitDispatcher`.  Evaluates structured
+    entry predicates deterministically using a per-symbol
+    :class:`StreamingHistoryView` and auto-submits entry orders with
+    spec-derived sizing when a predicate fires.
+
+    Empty ``entry_rules`` (or ``None`` sizing) makes
+    :meth:`maybe_emit` a no-op — the strategy subprocess handles
+    entries via its ``on_bar`` code as before.
+    """
+
+    entry_rules: Sequence[EntryRule]
+    sizing: Any
+    _next_seq: int = 0
+
+    def maybe_emit(
+        self,
+        *,
+        cur_bar,
+        portfolio: Portfolio,
+        pending_for_prev: List[OrderRequest],
+        views: Dict[str, StreamingHistoryView],
+        result: "TradingServiceResult",
+    ) -> None:
+        if not self.entry_rules or self.sizing is None:
+            return
+        sym = cur_bar.symbol
+        if portfolio.positions.get(sym) is not None:
+            return
+        if any(req.symbol == sym and req.side in (OrderSide.LONG, OrderSide.SHORT) for req in pending_for_prev):
+            return
+        view = views.get(sym)
+        if view is None or view.length() == 0:
+            return
+        match = _evaluate_entry_rules_pred(self.entry_rules, view, view.length() - 1)
+        if match is None:
+            return
+        rule, rule_idx = match
+        qty = self._compute_qty(rule.side, cur_bar, portfolio, views)
+        if qty <= 0:
+            return
+        self._next_seq += 1
+        side = OrderSide.LONG if rule.side == "long" else OrderSide.SHORT
+        req = OrderRequest(
+            client_order_id=f"e_entry_{self._next_seq}",
+            symbol=sym,
+            side=side,
+            qty=qty,
+            order_type=OrderType.MARKET,
+            tif=TimeInForce.DAY,
+            reason=f"{ENGINE_ENTRY_REASON_PREFIX}entry[{rule_idx}]",
+        )
+        try:
+            req.validate_prices()
+        except Exception as exc:
+            logger.error(
+                "engine-issued entry order failed validation (rule=%d symbol=%s): %s",
+                rule_idx,
+                sym,
+                exc,
+            )
+            return
+        pending_for_prev.append(req)
+        diag = result.execution_diagnostics
+        diag.orders_emitted += 1
+        _record_event(
+            diag,
+            "emitted",
+            timestamp=cur_bar.timestamp,
+            symbol=sym,
+            side=req.side.value,
+            order_type=OrderType.MARKET.value,
+            reason=req.reason,
+        )
+
+    def _compute_qty(
+        self,
+        side: str,
+        cur_bar,
+        portfolio: Portfolio,
+        views: Dict[str, StreamingHistoryView],
+    ) -> int:
+        equity = portfolio.mark_to_market()
+        close = cur_bar.close
+        if close <= 0:
+            return 0
+        sizing = self.sizing
+        if isinstance(sizing, FixedFractionSizing):
+            return max(1, int(equity * float(sizing.fraction) / close))
+        if isinstance(sizing, FixedNotionalSizing):
+            return max(1, int(float(sizing.notional_usd) / close))
+        if isinstance(sizing, VolatilityTargetSizing):
+            from ..strategy_lab.spec_dsl import IndicatorRef
+
+            atr_ref = IndicatorRef(name="atr")
+            view = views.get(cur_bar.symbol)
+            if view is None or view.length() == 0:
+                return 1
+            atr_val = view.indicator(atr_ref, view.length() - 1)
+            if atr_val is None or atr_val <= 0:
+                return 1
+            return max(1, int(equity * float(sizing.target_annual_vol) / (close * atr_val)))
+        return 1
 
 
 # Default chunk size for the batched-bar protocol (issue #377). 1 keeps
@@ -840,6 +966,8 @@ class TradingService:
         bar_chunk_size: Optional[int] = None,
         coverage_probe_mode: bool = False,
         exit_rules: Optional[List[ExitRule]] = None,
+        entry_rules: Optional[List[EntryRule]] = None,
+        sizing: Optional[Any] = None,
     ) -> None:
         self.strategy_code = strategy_code
         self.config = config
@@ -860,6 +988,8 @@ class TradingService:
         # each bar's strategy response. Empty list (or None) preserves the
         # legacy behaviour where strategy code is the only source of exits.
         self._exit_rules: List[ExitRule] = list(exit_rules or [])
+        self._entry_rules: List[EntryRule] = list(entry_rules or [])
+        self._sizing = sizing
         # Issue #377: when set, overrides ``BAR_CHUNK_SIZE`` env. Paper-trade
         # mode pins this to 1 so live-bar handling never buffers. Reject
         # zero/negative or non-int explicitly so a future caller passing
@@ -901,7 +1031,12 @@ class TradingService:
         # counter, and the per-bar dispatch logic split across
         # :meth:`_EngineExitDispatcher.maybe_emit` sub-steps. No-op
         # when ``self._exit_rules`` is empty.
-        engine_exits = _EngineExitDispatcher(exit_rules=self._exit_rules)
+        streaming_views: Dict[str, StreamingHistoryView] = {}
+        engine_exits = _EngineExitDispatcher(exit_rules=self._exit_rules, views=streaming_views)
+        engine_entries = _EngineEntryDispatcher(
+            entry_rules=self._entry_rules,
+            sizing=self._sizing,
+        )
         execution_model = build_execution_model(
             self.config.execution_model,
             participation_cap=self.config.fill_participation_cap,
@@ -1003,6 +1138,8 @@ class TradingService:
                     eod_buffer=eod_buffer,
                     position_tracker=position_tracker,
                     engine_exits=engine_exits,
+                    engine_entries=engine_entries,
+                    streaming_views=streaming_views,
                 )
 
             # We need one-bar lookahead in the fill simulator, so we buffer
@@ -1172,6 +1309,8 @@ class TradingService:
                                 portfolio=portfolio,
                             )
 
+                        self._append_streaming_bar(streaming_views, cur_bar)
+
                     # 4) Deliver the current bar to the strategy and collect
                     #    any orders it submits in response. Warm-up bars set
                     #    ``ctx.is_warmup = True`` in the subprocess so the
@@ -1200,6 +1339,8 @@ class TradingService:
                         pending_for_prev=pending_for_prev,
                         position_tracker=position_tracker,
                         engine_exits=engine_exits,
+                        engine_entries=engine_entries,
+                        streaming_views=streaming_views,
                         result=result,
                     )
 
@@ -1275,6 +1416,8 @@ class TradingService:
         eod_buffer: "_StreamingEquityBuffer",
         position_tracker: Dict[str, _TrackedPosition],
         engine_exits: _EngineExitDispatcher,
+        engine_entries: _EngineEntryDispatcher,
+        streaming_views: Dict[str, StreamingHistoryView],
     ) -> TradingServiceResult:
         prev_bar = None
         pending_for_prev: List[OrderRequest] = []
@@ -1436,6 +1579,8 @@ class TradingService:
                             portfolio=portfolio,
                         )
 
+                    self._append_streaming_bar(streaming_views, cur_bar)
+
                 # 4) Process the strategy's response for this bar.
                 try:
                     self._process_bar_strategy_response(
@@ -1448,6 +1593,8 @@ class TradingService:
                         pending_for_prev=pending_for_prev,
                         position_tracker=position_tracker,
                         engine_exits=engine_exits,
+                        engine_entries=engine_entries,
+                        streaming_views=streaming_views,
                         result=result,
                     )
                 except StrategyRuntimeError:
@@ -1553,11 +1700,13 @@ class TradingService:
         pending_for_prev: List[OrderRequest],
         position_tracker: Dict[str, _TrackedPosition],
         engine_exits: _EngineExitDispatcher,
+        engine_entries: _EngineEntryDispatcher,
+        streaming_views: Dict[str, StreamingHistoryView],
         result: TradingServiceResult,
     ) -> None:
         """Apply one bar's strategy response (cancels + orders) to the
         order book and pending-submit queue, then run the engine's
-        structured-exit-rule enforcement step.
+        structured entry- and exit-rule enforcement steps.
 
         Shared between the per-bar (``run``) and chunked
         (``_run_chunked``) paths — extracted because earlier the engine-
@@ -1688,6 +1837,32 @@ class TradingService:
         # lookahead). No-op when the spec has no exit rules.
         if self._exit_rules:
             self._extend_watermarks(tracker=position_tracker, cur_bar=cur_bar)
+
+        engine_entries.maybe_emit(
+            cur_bar=cur_bar,
+            portfolio=portfolio,
+            pending_for_prev=pending_for_prev,
+            views=streaming_views,
+            result=result,
+        )
+
+    @staticmethod
+    def _append_streaming_bar(
+        views: Dict[str, StreamingHistoryView],
+        cur_bar,
+    ) -> None:
+        """Append a bar to the per-symbol streaming view."""
+        sym = cur_bar.symbol
+        if sym not in views:
+            views[sym] = StreamingHistoryView()
+        views[sym].append(BarRecord(
+            timestamp=cur_bar.timestamp,
+            open=cur_bar.open,
+            high=cur_bar.high,
+            low=cur_bar.low,
+            close=cur_bar.close,
+            volume=getattr(cur_bar, "volume", 0.0),
+        ))
 
     @staticmethod
     def _update_position_tracker(


### PR DESCRIPTION
## Summary

- **New `predicate_evaluator.py`**: Extracts predicate evaluation logic from `alignment_checks.py` into a shared module behind a `HistoryView` protocol. Two implementations: `PandasHistoryView` (for the alignment audit) and `StreamingHistoryView` (deque-backed, for the engine's per-bar runtime).
- **`SignalExitRule` is no longer a no-op**: `rule_compiler.evaluate_exit_rules` accepts an optional `views` parameter; when provided, signal-exit predicates are evaluated deterministically via the shared evaluator. The engine auto-emits close orders when signal-exit predicates fire.
- **New `_EngineEntryDispatcher`**: Evaluates entry predicates per bar and auto-submits entry orders with spec-derived sizing (FixedFraction/FixedNotional/VolatilityTarget). Disabled for `requires_custom_code=True` specs — the old freeform code path is preserved.
- **`alignment_checks.py`** delegates `_compare`, `_resolve_side_value`, and `_relative_miss` to the shared evaluator, guaranteeing identical semantics between audit-time and runtime.
- **`backtest.py`** passes `entry_rules` and `sizing` to `TradingService` for non-custom-code specs.

## Test plan

- [x] `test_predicate_evaluator.py` — 23 tests covering `compare`, `evaluate_predicate`, `evaluate_entry_rules`, `evaluate_signal_exit_rules`, `StreamingHistoryView`/`PandasHistoryView` parity
- [x] `test_engine_entry_dispatch.py` — 5 tests covering entry fires, skips (position exists, predicate miss, no rules), sizing variants
- [x] `test_rule_compiler.py` — signal-exit no-op-without-views, fires-with-view, warmup, does-not-block-other-rules (replaces old silent-noop test)
- [x] `test_alignment_checks.py` — all 47 existing tests pass unchanged (delegation preserves behavior)
- [x] `test_trading_service.py` — all 24 tests pass (diagnostics test updated for engine signal-exit emission)
- [x] `test_engine_exit_enforcement.py` — all 7 tests pass unchanged
- [x] `test_engine_exit_helpers.py` + `test_exit_rule_conformance_gate.py` — all 47 tests pass

https://claude.ai/code/session_01Auu2K8Cj4TTsmzC46x7LtX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Auu2K8Cj4TTsmzC46x7LtX)_