### PR TITLE
Make alignment audit a hard pre-publication gate

### DIFF
--- a/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
+++ b/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
@@ -109,6 +109,7 @@ class _AlignmentLoopOutcome:
     alignment_attempts: List[str] = field(default_factory=list)
     alignment_reports: List[Any] = field(default_factory=list)
     trades_aligned: bool = False
+    rejection_reason: Optional[str] = None
 
     @property
     def alignment_rounds(self) -> int:

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -1473,6 +1473,12 @@ class StrategyLabOrchestrator:
                 f"Override: deterministic gate found {len(unresolved_criticals)} "
                 "unresolved critical finding(s) despite report claiming aligned"
             )
+            for gate in reversed(all_gate_results):
+                if gate.gate_name == "trade_alignment":
+                    gate.passed = False
+                    gate.severity = "critical"
+                    gate.details = last_report.rationale  # type: ignore[union-attr]
+                    break
 
         trades_aligned_final = last_aligned and not unresolved_criticals
         rejection_reason: Optional[str] = None

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -1449,6 +1449,31 @@ class StrategyLabOrchestrator:
             if round_outcome.terminate:
                 break
 
+        has_reports = bool(alignment_reports)
+        last_report = alignment_reports[-1] if has_reports else None
+
+        unresolved_criticals: List[Any] = []
+        if last_report and last_report.alignment_findings:
+            unresolved_criticals = [
+                f
+                for f in last_report.alignment_findings
+                if not f.passed and f.severity == "critical"
+            ]
+
+        last_aligned = has_reports and last_report.aligned  # type: ignore[union-attr]
+        if unresolved_criticals and last_aligned:
+            logger.warning(
+                "Alignment report claims aligned but %d critical findings "
+                "remain unresolved for %s; overriding trades_aligned=False",
+                len(unresolved_criticals),
+                spec.strategy_id,
+            )
+
+        trades_aligned_final = last_aligned and not unresolved_criticals
+        rejection_reason: Optional[str] = None
+        if has_reports and not trades_aligned_final:
+            rejection_reason = "alignment_unresolved"
+
         return _AlignmentLoopOutcome(
             spec=spec,
             code=code,
@@ -1456,7 +1481,8 @@ class StrategyLabOrchestrator:
             metrics=metrics,
             alignment_attempts=alignment_attempts,
             alignment_reports=alignment_reports,
-            trades_aligned=bool(alignment_reports and alignment_reports[-1].aligned),
+            trades_aligned=trades_aligned_final,
+            rejection_reason=rejection_reason,
         )
 
     def _run_alignment_round(
@@ -2025,13 +2051,23 @@ class StrategyLabOrchestrator:
 
         if execution_succeeded and trades and alignment_reports and not trades_aligned:
             last_report = alignment_reports[-1]
-            # NOTE: do NOT name this ``rationale`` — the strategy-rationale
-            # string is bound by the caller's ideation result and is also
-            # what gets persisted to ``StrategyLabRecord.strategy_rationale``.
-            align_rationale = (last_report.rationale or "").strip()
+            alignment_criticals = [
+                f
+                for f in last_report.alignment_findings
+                if not f.passed and f.severity == "critical"
+            ]
+            if alignment_criticals:
+                detail = "; ".join(
+                    f"[{f.check_name}] trade#{f.trade_num}: {f.details}"
+                    for f in alignment_criticals[:10]
+                )
+                if len(alignment_criticals) > 10:
+                    detail += f" (+{len(alignment_criticals) - 10} more)"
+            else:
+                detail = (last_report.rationale or "").strip()
             suffix = (
-                f"alignment_failed: {align_rationale}"
-                if align_rationale
+                f"alignment_unresolved: {detail}"
+                if detail
                 else "alignment_failed: trades did not implement strategy spec"
             )
             metrics, upstream_admitted = _apply_veto_to_acceptance_reason(
@@ -2621,9 +2657,13 @@ class StrategyLabOrchestrator:
         metrics = alignment_outcome.metrics
         alignment_rounds = alignment_outcome.alignment_rounds
         trades_aligned = alignment_outcome.trades_aligned
-        # ``alignment_reports`` flows through to the alignment-veto guard
-        # below; the guard reads it to know whether the audit actually ran
-        # (skipped when ``market_data`` is None).
+        alignment_rejection_reason = alignment_outcome.rejection_reason
+        if alignment_rejection_reason:
+            logger.info(
+                "Alignment loop for %s ended with rejection_reason=%s",
+                spec.strategy_id,
+                alignment_rejection_reason,
+            )
         alignment_reports = alignment_outcome.alignment_reports
 
         # ── Phase 2.6: TRIAL COUNTING (issue #247) ────────────────────

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -1468,6 +1468,11 @@ class StrategyLabOrchestrator:
                 len(unresolved_criticals),
                 spec.strategy_id,
             )
+            last_report.aligned = False  # type: ignore[union-attr]
+            last_report.rationale = (  # type: ignore[union-attr]
+                f"Override: deterministic gate found {len(unresolved_criticals)} "
+                "unresolved critical finding(s) despite report claiming aligned"
+            )
 
         trades_aligned_final = last_aligned and not unresolved_criticals
         rejection_reason: Optional[str] = None

--- a/backend/agents/investment_team/tests/test_strategy_lab_alignment.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_alignment.py
@@ -1312,3 +1312,209 @@ def test_loop_persists_alignment_findings_for_record() -> None:
     last_report = outcome.alignment_reports[-1]
     assert last_report.alignment_findings
     assert all(f.passed for f in last_report.alignment_findings)
+
+
+# ---------------------------------------------------------------------------
+# `_run_trade_alignment_loop` — rejection_reason + explicit trades_aligned
+# ---------------------------------------------------------------------------
+
+
+def test_loop_sets_rejection_reason_on_unresolved_criticals() -> None:
+    """When the loop exits with unresolved critical findings (e.g. no fix
+    proposed), the outcome carries ``rejection_reason='alignment_unresolved'``
+    and ``trades_aligned=False``."""
+    orch, _align_stub, _checker_stub = _make_orchestrator(
+        check_results=[_misaligned_check_result()],
+        propose_results=[],
+    )
+
+    outcome = orch._run_trade_alignment_loop(
+        spec=_spec(),
+        code="code-v0",
+        trades=_trade_records(),
+        metrics=_metrics(),
+        market_data=_market_data(),
+        config=_config(),
+        execution_succeeded=True,
+        all_gate_results=[],
+        emit=lambda *_a, **_kw: None,
+    )
+
+    assert outcome.trades_aligned is False
+    assert outcome.rejection_reason == "alignment_unresolved"
+
+
+def test_loop_no_rejection_reason_when_aligned() -> None:
+    """When the loop succeeds (all critical findings pass), rejection_reason
+    is ``None`` and ``trades_aligned=True``."""
+    orch, _align_stub, _checker_stub = _make_orchestrator(
+        check_results=[_aligned_check_result()],
+    )
+
+    outcome = orch._run_trade_alignment_loop(
+        spec=_spec(),
+        code="code-v0",
+        trades=_trade_records(),
+        metrics=_metrics(),
+        market_data=_market_data(),
+        config=_config(),
+        execution_succeeded=True,
+        all_gate_results=[],
+        emit=lambda *_a, **_kw: None,
+    )
+
+    assert outcome.trades_aligned is True
+    assert outcome.rejection_reason is None
+
+
+def test_loop_no_rejection_reason_when_skipped() -> None:
+    """When the loop is skipped (execution failed), rejection_reason is
+    ``None`` — alignment was not attempted, not failed."""
+    orch, _align_stub, _checker_stub = _make_orchestrator(
+        check_results=[],
+    )
+
+    outcome = orch._run_trade_alignment_loop(
+        spec=_spec(),
+        code="code-v0",
+        trades=[],
+        metrics=_metrics(),
+        market_data=_market_data(),
+        config=_config(),
+        execution_succeeded=False,
+        all_gate_results=[],
+        emit=lambda *_a, **_kw: None,
+    )
+
+    assert outcome.trades_aligned is False
+    assert outcome.rejection_reason is None
+
+
+def test_loop_cross_check_overrides_inconsistent_aligned_flag() -> None:
+    """If ``report.aligned=True`` leaks through but critical findings with
+    ``passed=False`` remain, the explicit cross-check forces
+    ``trades_aligned=False``. This is a defence-in-depth net — normally
+    the clamp at ``_run_alignment_audit`` prevents this state."""
+    inconsistent_result = AlignmentCheckResult(
+        aligned=True,
+        findings=[
+            AlignmentFinding(
+                trade_num=1,
+                rule_id="entry[0]",
+                check_name="entry_signal",
+                passed=False,
+                severity="critical",
+                details="entry signal violated",
+            )
+        ],
+        gate_results=[],
+        rationale="all green",
+    )
+    orch, _align_stub, _checker_stub = _make_orchestrator(
+        check_results=[inconsistent_result],
+    )
+
+    outcome = orch._run_trade_alignment_loop(
+        spec=_spec(),
+        code="code-v0",
+        trades=_trade_records(),
+        metrics=_metrics(),
+        market_data=_market_data(),
+        config=_config(),
+        execution_succeeded=True,
+        all_gate_results=[],
+        emit=lambda *_a, **_kw: None,
+    )
+
+    assert outcome.trades_aligned is False
+    assert outcome.rejection_reason == "alignment_unresolved"
+
+
+# ---------------------------------------------------------------------------
+# Alignment veto — critical finding details in acceptance_reason
+# ---------------------------------------------------------------------------
+
+
+def test_alignment_veto_surfaces_critical_finding_details() -> None:
+    """The alignment veto in ``_run_verification_phase`` surfaces the
+    deterministic critical-finding details — not the LLM's vague
+    rationale string — into ``metrics.acceptance_reason``."""
+    orch = StrategyLabOrchestrator()
+
+    findings = [
+        AlignmentFinding(
+            trade_num=2,
+            rule_id="entry[0]",
+            check_name="entry_signal",
+            passed=False,
+            severity="critical",
+            details="rsi above 30 at entry",
+            computed_value=42.0,
+            expected_value=30.0,
+        ),
+        AlignmentFinding(
+            trade_num=5,
+            rule_id="universe",
+            check_name="universe",
+            passed=False,
+            severity="critical",
+            details="traded XYZ not in spec universe",
+        ),
+    ]
+    report = TradeAlignmentReport(
+        aligned=False,
+        rationale="vague LLM narrative",
+        alignment_findings=findings,
+    )
+
+    _events, emit = _collect_emit()
+    verification = orch._run_verification_phase(
+        spec=_spec(),
+        trades=_trade_records(),
+        metrics=_metrics(),
+        market_data=_market_data(),
+        config=_config(),
+        execution_succeeded=True,
+        trades_aligned=False,
+        alignment_reports=[report],
+        all_gate_results=[],
+        emit=emit,
+    )
+
+    reason = verification.metrics.acceptance_reason or ""
+    assert "entry_signal" in reason
+    assert "rsi above 30 at entry" in reason
+    assert "universe" in reason
+    assert "traded XYZ not in spec universe" in reason
+    assert "vague LLM narrative" not in reason
+    assert verification.is_winning is False
+
+
+def test_alignment_veto_falls_back_to_rationale_when_no_findings() -> None:
+    """When ``alignment_findings`` is empty (defensive path), the veto
+    falls back to the report's rationale string."""
+    orch = StrategyLabOrchestrator()
+
+    report = TradeAlignmentReport(
+        aligned=False,
+        rationale="some fallback reason",
+        alignment_findings=[],
+    )
+
+    _events, emit = _collect_emit()
+    verification = orch._run_verification_phase(
+        spec=_spec(),
+        trades=_trade_records(),
+        metrics=_metrics(),
+        market_data=_market_data(),
+        config=_config(),
+        execution_succeeded=True,
+        trades_aligned=False,
+        alignment_reports=[report],
+        all_gate_results=[],
+        emit=emit,
+    )
+
+    reason = verification.metrics.acceptance_reason or ""
+    assert "some fallback reason" in reason
+    assert verification.is_winning is False

--- a/backend/agents/investment_team/tests/test_strategy_lab_alignment.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_alignment.py
@@ -1428,6 +1428,12 @@ def test_loop_cross_check_overrides_inconsistent_aligned_flag() -> None:
 
     assert outcome.trades_aligned is False
     assert outcome.rejection_reason == "alignment_unresolved"
+    last_report = outcome.alignment_reports[-1]
+    assert last_report.aligned is False, (
+        "cross-check must also clamp report.aligned so "
+        "_resolve_alignment_report_for_analysis sees the override"
+    )
+    assert "Override" in last_report.rationale
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/tests/test_strategy_lab_alignment.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_alignment.py
@@ -1414,6 +1414,7 @@ def test_loop_cross_check_overrides_inconsistent_aligned_flag() -> None:
         check_results=[inconsistent_result],
     )
 
+    all_gate_results: List[QualityGateResult] = []
     outcome = orch._run_trade_alignment_loop(
         spec=_spec(),
         code="code-v0",
@@ -1422,7 +1423,7 @@ def test_loop_cross_check_overrides_inconsistent_aligned_flag() -> None:
         market_data=_market_data(),
         config=_config(),
         execution_succeeded=True,
-        all_gate_results=[],
+        all_gate_results=all_gate_results,
         emit=lambda *_a, **_kw: None,
     )
 
@@ -1434,6 +1435,13 @@ def test_loop_cross_check_overrides_inconsistent_aligned_flag() -> None:
         "_resolve_alignment_report_for_analysis sees the override"
     )
     assert "Override" in last_report.rationale
+    alignment_gates = [g for g in all_gate_results if g.gate_name == "trade_alignment"]
+    assert alignment_gates, "aggregate trade_alignment gate must exist"
+    assert alignment_gates[-1].passed is False, (
+        "cross-check must also flip the aggregate gate row so the "
+        "persisted audit trail is consistent with the override"
+    )
+    assert alignment_gates[-1].severity == "critical"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
@@ -864,7 +864,7 @@ def test_failed_alignment_forces_is_winning_false_on_acceptance_path(monkeypatch
     """#529: even when the walk-forward acceptance gate passes every check,
     a final alignment report with ``aligned=False`` must veto publication.
     The audit trail keeps the ``trade_alignment`` gate (passed=False) on
-    ``quality_gate_results`` and surfaces ``alignment_failed`` on
+    ``quality_gate_results`` and surfaces ``alignment_unresolved`` on
     ``acceptance_reason`` for downstream consumers."""
 
     from investment_team.models import StrategyLabRecord
@@ -930,7 +930,7 @@ def test_failed_alignment_forces_is_winning_false_on_acceptance_path(monkeypatch
     assert all(g["passed"] is False for g in alignment_gates)
     assert record.analysis_narrative  # narrative still generated for context
     reason = record.backtest.result.acceptance_reason or ""
-    assert "alignment_failed" in reason
+    assert "alignment_unresolved" in reason
     assert "entries fire before signal triggers" in reason
     # When the acceptance gate fully passed but alignment vetoed, the
     # ``"all four criteria met"`` summary is no longer truthful — the
@@ -1021,7 +1021,7 @@ def test_failed_alignment_forces_is_winning_false_on_walk_forward_fallback(monke
     ]
     assert alignment_gates and all(g["passed"] is False for g in alignment_gates)
     reason = record.backtest.result.acceptance_reason or ""
-    assert "alignment_failed" in reason
+    assert "alignment_unresolved" in reason
     # Bug 1 symmetry on the fallback path: the anomaly recheck admitted
     # the run (no criticals + return > threshold), so its
     # ``"walk_forward_fallback_passed: ..."`` summary is no longer
@@ -1097,8 +1097,8 @@ def test_acceptance_failures_and_alignment_failure_both_recorded(monkeypatch):
     assert "trade count below floor" in reason
     # Alignment cause appended after a " | " boundary so the categories
     # are distinguishable.
-    assert " | alignment_failed:" in reason, (
-        f"expected ' | alignment_failed:' boundary in {reason!r}"
+    assert " | alignment_unresolved:" in reason, (
+        f"expected ' | alignment_unresolved:' boundary in {reason!r}"
     )
     assert "entries fire on wrong symbol" in reason
     # PR #573 round-4 regression guard (rationale-shadowing).


### PR DESCRIPTION
## Summary

- Replace the implicit `trades_aligned` derivation (`alignment_reports[-1].aligned`) with an explicit cross-check of unresolved critical deterministic findings — any `AlignmentFinding` with `severity="critical"` and `passed=False` now forces `trades_aligned=False` regardless of the report's aggregate `.aligned` flag
- Enhance the alignment veto block to surface specific critical finding details (`[check_name] trade#N: details`) instead of the LLM's vague rationale string, mirroring the `exit_rule_conformance` veto pattern
- Add `rejection_reason` field to `_AlignmentLoopOutcome` so downstream consumers can distinguish "alignment skipped" (`None`) from "alignment ran but critical findings unresolved" (`"alignment_unresolved"`)

## Test plan

- [x] All 24 existing `test_strategy_lab_alignment.py` tests pass unchanged
- [x] 6 new tests added covering: unresolved-critical path, aligned-success path, skipped path, cross-check override of inconsistent `.aligned` flag, veto detail surfacing with critical findings, veto fallback to rationale when no findings
- [x] 3 walk-forward integration tests updated to match new `alignment_unresolved:` prefix (was `alignment_failed:`)
- [x] Full investment team suite: 2665 passed, 0 failed
- [x] Ruff lint clean on all modified files

Closes #656

https://claude.ai/code/session_01Cyb6Ag59Nh58fBdKMJDysa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cyb6Ag59Nh58fBdKMJDysa)_