### PR TITLE
Branding UX: chip inputs, remove buried workspace panel, unify theme

### DIFF
--- a/user-interface/src/app/components/brand-preview/brand-preview.component.scss
+++ b/user-interface/src/app/components/brand-preview/brand-preview.component.scss
@@ -1,33 +1,18 @@
 // ---------------------------------------------------------------------------
-// Brand Preview Panel — Premium SaaS Design
+// Brand Preview Panel — Khala Design System tokens
 // ---------------------------------------------------------------------------
 
-$surface-base: #0c0f14;
-$surface-raised: #12161e;
-$surface-card: #181d27;
-$border-subtle: rgba(255, 255, 255, 0.06);
-$border-default: rgba(255, 255, 255, 0.1);
-$text-primary: #f0f3f8;
-$text-secondary: #8b95a5;
-$text-muted: #5c6678;
-$accent-blue: #6c8cff;
+// Component-local accent (no global purple token)
 $accent-purple: #a78bfa;
-$accent-teal: #2dd4bf;
-$accent-green: #34d399;
-$accent-amber: #fbbf24;
-$accent-rose: #fb7185;
-$radius-sm: 8px;
-$radius-md: 12px;
-$radius-lg: 16px;
 
 // ---------------------------------------------------------------------------
 // Panel container
 // ---------------------------------------------------------------------------
 
 .preview-panel {
-  background: $surface-base;
-  border: 1px solid $border-subtle;
-  border-radius: $radius-lg;
+  background: var(--kh-surface-1);
+  border: 1px solid var(--kh-border-subtle);
+  border-radius: var(--kh-radius-xl);
   height: 100%;
   min-height: 400px;
   display: flex;
@@ -36,7 +21,7 @@ $radius-lg: 16px;
   position: relative;
 
   &.has-content {
-    border-color: $border-default;
+    border-color: var(--kh-border);
   }
 
   &::before {
@@ -47,7 +32,7 @@ $radius-lg: 16px;
     transform: translateX(-50%);
     width: 60%;
     height: 1px;
-    background: linear-gradient(90deg, transparent, $accent-blue, transparent);
+    background: linear-gradient(90deg, transparent, var(--kh-info), transparent);
     opacity: 0.5;
     z-index: 1;
   }
@@ -62,7 +47,7 @@ $radius-lg: 16px;
   align-items: center;
   justify-content: space-between;
   padding: 16px 20px;
-  border-bottom: 1px solid $border-subtle;
+  border-bottom: 1px solid var(--kh-border-subtle);
   flex-shrink: 0;
   gap: 12px;
 }
@@ -84,7 +69,7 @@ $radius-lg: 16px;
   width: 36px;
   height: 36px;
   border-radius: 10px;
-  background: linear-gradient(135deg, rgba($accent-blue, 0.15), rgba($accent-purple, 0.15));
+  background: linear-gradient(135deg, color-mix(in srgb, var(--kh-info) 15%, transparent), rgba($accent-purple, 0.15));
   display: flex;
   align-items: center;
   justify-content: center;
@@ -93,7 +78,7 @@ $radius-lg: 16px;
     font-size: 20px;
     width: 20px;
     height: 20px;
-    background: linear-gradient(135deg, $accent-blue, $accent-purple);
+    background: linear-gradient(135deg, var(--kh-info), $accent-purple);
     -webkit-background-clip: text;
     background-clip: text;
     -webkit-text-fill-color: transparent;
@@ -103,18 +88,18 @@ $radius-lg: 16px;
 .panel-title {
   font-size: 0.9375rem;
   font-weight: 600;
-  color: $text-primary;
+  color: var(--kh-text-primary);
   margin: 0;
   letter-spacing: -0.01em;
 }
 
 .panel-subtitle {
   font-size: 0.75rem;
-  color: $text-muted;
+  color: var(--kh-text-muted);
   transition: color 0.3s;
 
   &.active {
-    color: $accent-teal;
+    color: var(--kh-success);
   }
 }
 
@@ -124,7 +109,7 @@ $radius-lg: 16px;
   align-items: center;
   gap: 6px;
   padding: 8px 14px;
-  border-radius: $radius-sm;
+  border-radius: var(--kh-radius-md);
   font-size: 0.8125rem;
   font-weight: 500;
   cursor: pointer;
@@ -138,14 +123,14 @@ $radius-lg: 16px;
 }
 
 .save-btn {
-  border: 1px solid rgba($accent-blue, 0.3);
-  background: rgba($accent-blue, 0.08);
-  color: $accent-blue;
+  border: 1px solid color-mix(in srgb, var(--kh-info) 30%, transparent);
+  background: color-mix(in srgb, var(--kh-info) 8%, transparent);
+  color: var(--kh-info);
 
   &:hover {
-    background: rgba($accent-blue, 0.16);
-    border-color: rgba($accent-blue, 0.5);
-    box-shadow: 0 0 16px rgba($accent-blue, 0.15);
+    background: color-mix(in srgb, var(--kh-info) 16%, transparent);
+    border-color: color-mix(in srgb, var(--kh-info) 50%, transparent);
+    box-shadow: 0 0 16px color-mix(in srgb, var(--kh-info) 15%, transparent);
   }
 }
 
@@ -190,7 +175,7 @@ $radius-lg: 16px;
   width: 36px;
   height: 36px;
   z-index: 1;
-  background: linear-gradient(135deg, $accent-blue, $accent-purple);
+  background: linear-gradient(135deg, var(--kh-info), $accent-purple);
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -204,7 +189,7 @@ $radius-lg: 16px;
   &.orb-1 {
     width: 60px;
     height: 60px;
-    background: radial-gradient(circle, rgba($accent-blue, 0.15) 0%, transparent 70%);
+    background: radial-gradient(circle, color-mix(in srgb, var(--kh-info) 15%, transparent) 0%, transparent 70%);
     top: -5px;
     left: -5px;
     animation-delay: 0s;
@@ -222,7 +207,7 @@ $radius-lg: 16px;
   &.orb-3 {
     width: 40px;
     height: 40px;
-    background: radial-gradient(circle, rgba($accent-teal, 0.1) 0%, transparent 70%);
+    background: radial-gradient(circle, color-mix(in srgb, var(--kh-success) 10%, transparent) 0%, transparent 70%);
     top: 5px;
     right: 0;
     animation-delay: -4s;
@@ -237,14 +222,14 @@ $radius-lg: 16px;
 .empty-title {
   font-size: 1.125rem;
   font-weight: 600;
-  color: $text-primary;
+  color: var(--kh-text-primary);
   margin: 0 0 0.5rem;
   letter-spacing: -0.01em;
 }
 
 .empty-description {
   font-size: 0.875rem;
-  color: $text-secondary;
+  color: var(--kh-text-secondary);
   line-height: 1.6;
   max-width: 300px;
   margin: 0 0 1.5rem;
@@ -263,24 +248,24 @@ $radius-lg: 16px;
   align-items: center;
   gap: 10px;
   padding: 10px 14px;
-  border-radius: $radius-sm;
-  background: $surface-raised;
-  border: 1px solid $border-subtle;
+  border-radius: var(--kh-radius-md);
+  background: var(--kh-surface-2);
+  border: 1px solid var(--kh-border-subtle);
   font-size: 0.8125rem;
-  color: $text-secondary;
+  color: var(--kh-text-secondary);
   transition: all 0.2s;
 
   mat-icon {
     font-size: 16px;
     width: 16px;
     height: 16px;
-    color: $accent-blue;
+    color: var(--kh-info);
     flex-shrink: 0;
   }
 
   &:hover {
-    border-color: $border-default;
-    color: $text-primary;
+    border-color: var(--kh-border);
+    color: var(--kh-text-primary);
   }
 }
 
@@ -302,11 +287,11 @@ $radius-lg: 16px;
   }
 
   &::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.08);
+    background: var(--kh-glass);
     border-radius: 2px;
 
     &:hover {
-      background: rgba(255, 255, 255, 0.14);
+      background: var(--kh-glass-hover);
     }
   }
 }
@@ -336,9 +321,9 @@ $radius-lg: 16px;
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 2px solid $border-default;
-  background: $surface-raised;
-  color: $text-muted;
+  border: 2px solid var(--kh-border);
+  background: var(--kh-surface-2);
+  color: var(--kh-text-muted);
   transition: all 0.25s;
   flex-shrink: 0;
   z-index: 2;
@@ -350,28 +335,28 @@ $radius-lg: 16px;
   }
 
   .phase-completed & {
-    border-color: $accent-green;
-    background: rgba($accent-green, 0.15);
-    color: $accent-green;
+    border-color: var(--kh-success);
+    background: color-mix(in srgb, var(--kh-success) 15%, transparent);
+    color: var(--kh-success);
   }
 
   .phase-in-progress & {
-    border-color: $accent-blue;
-    background: rgba($accent-blue, 0.15);
-    color: $accent-blue;
-    box-shadow: 0 0 0 3px rgba($accent-blue, 0.15);
+    border-color: var(--kh-info);
+    background: color-mix(in srgb, var(--kh-info) 15%, transparent);
+    color: var(--kh-info);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--kh-info) 15%, transparent);
   }
 }
 
 .phase-connector {
   flex: 1;
   width: 2px;
-  background: $border-default;
+  background: var(--kh-border);
   margin-top: 4px;
   min-height: 12px;
 
   .phase-completed & {
-    background: rgba($accent-green, 0.4);
+    background: color-mix(in srgb, var(--kh-success) 40%, transparent);
   }
 }
 
@@ -391,12 +376,12 @@ $radius-lg: 16px;
 .phase-label {
   font-size: 0.9375rem;
   font-weight: 600;
-  color: $text-primary;
+  color: var(--kh-text-primary);
   margin: 0;
   letter-spacing: -0.01em;
 
   .phase-not-started & {
-    color: $text-secondary;
+    color: var(--kh-text-secondary);
   }
 }
 
@@ -411,21 +396,21 @@ $radius-lg: 16px;
   border: 1px solid;
 
   &.chip-completed {
-    color: $accent-green;
-    background: rgba($accent-green, 0.1);
-    border-color: rgba($accent-green, 0.3);
+    color: var(--kh-success);
+    background: color-mix(in srgb, var(--kh-success) 10%, transparent);
+    border-color: color-mix(in srgb, var(--kh-success) 30%, transparent);
   }
 
   &.chip-in-progress {
-    color: $accent-blue;
-    background: rgba($accent-blue, 0.1);
-    border-color: rgba($accent-blue, 0.3);
+    color: var(--kh-info);
+    background: color-mix(in srgb, var(--kh-info) 10%, transparent);
+    border-color: color-mix(in srgb, var(--kh-info) 30%, transparent);
   }
 
   &.chip-not-started {
-    color: $text-muted;
+    color: var(--kh-text-muted);
     background: rgba(255, 255, 255, 0.04);
-    border-color: $border-default;
+    border-color: var(--kh-border);
   }
 }
 
@@ -437,7 +422,7 @@ $radius-lg: 16px;
 
 .phase-empty {
   font-size: 0.8125rem;
-  color: $text-muted;
+  color: var(--kh-text-muted);
   margin: 0;
   line-height: 1.5;
 }
@@ -459,14 +444,14 @@ $radius-lg: 16px;
 }
 
 .foundation-card {
-  background: $surface-raised;
-  border: 1px solid $border-subtle;
-  border-radius: $radius-sm;
+  background: var(--kh-surface-2);
+  border: 1px solid var(--kh-border-subtle);
+  border-radius: var(--kh-radius-md);
   padding: 10px 14px;
   transition: border-color 0.2s;
 
   &:hover {
-    border-color: $border-default;
+    border-color: var(--kh-border);
   }
 
   &.full-width {
@@ -478,7 +463,7 @@ $radius-lg: 16px;
   display: block;
   font-size: 0.6875rem;
   font-weight: 500;
-  color: $text-muted;
+  color: var(--kh-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   margin-bottom: 4px;
@@ -487,7 +472,7 @@ $radius-lg: 16px;
 .field-value {
   display: block;
   font-size: 0.8125rem;
-  color: $text-primary;
+  color: var(--kh-text-primary);
   line-height: 1.5;
 }
 
@@ -506,7 +491,7 @@ $radius-lg: 16px;
 .tag-group-label {
   display: block;
   font-size: 0.6875rem;
-  color: $text-muted;
+  color: var(--kh-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   margin-bottom: 6px;
@@ -537,21 +522,21 @@ $radius-lg: 16px;
   }
 
   &.tag-diff {
-    background: rgba($accent-teal, 0.08);
-    border-color: rgba($accent-teal, 0.2);
-    color: $accent-teal;
+    background: color-mix(in srgb, var(--kh-success) 8%, transparent);
+    border-color: color-mix(in srgb, var(--kh-success) 20%, transparent);
+    color: var(--kh-success);
   }
 
   &.tag-color {
-    background: rgba($accent-amber, 0.08);
-    border-color: rgba($accent-amber, 0.2);
-    color: $accent-amber;
+    background: var(--kh-accent-muted);
+    border-color: var(--kh-accent-subtle);
+    color: var(--kh-accent);
   }
 
   &.tag-muted {
-    background: $surface-raised;
-    border-color: $border-default;
-    color: $text-secondary;
+    background: var(--kh-surface-2);
+    border-color: var(--kh-border);
+    color: var(--kh-text-secondary);
   }
 }
 
@@ -560,16 +545,16 @@ $radius-lg: 16px;
 // ---------------------------------------------------------------------------
 
 .voice-card {
-  background: $surface-raised;
-  border: 1px solid $border-subtle;
-  border-radius: $radius-sm;
+  background: var(--kh-surface-2);
+  border: 1px solid var(--kh-border-subtle);
+  border-radius: var(--kh-radius-md);
   padding: 12px 16px;
-  border-left: 3px solid $accent-teal;
+  border-left: 3px solid var(--kh-success);
 }
 
 .voice-text {
   font-size: 0.8125rem;
-  color: $text-primary;
+  color: var(--kh-text-primary);
   line-height: 1.6;
   margin: 0;
   font-style: italic;
@@ -586,15 +571,15 @@ $radius-lg: 16px;
 }
 
 .palette-card {
-  background: $surface-raised;
-  border: 1px solid $border-subtle;
-  border-radius: $radius-md;
+  background: var(--kh-surface-2);
+  border: 1px solid var(--kh-border-subtle);
+  border-radius: var(--kh-radius-lg);
   padding: 14px;
   transition: all 0.25s;
 
   &.palette-selected {
-    border-color: rgba($accent-green, 0.4);
-    background: rgba($accent-green, 0.04);
+    border-color: color-mix(in srgb, var(--kh-success) 40%, transparent);
+    background: color-mix(in srgb, var(--kh-success) 4%, transparent);
   }
 }
 
@@ -608,7 +593,7 @@ $radius-lg: 16px;
 .palette-name {
   font-size: 0.8125rem;
   font-weight: 600;
-  color: $text-primary;
+  color: var(--kh-text-primary);
 }
 
 .selected-badge {
@@ -617,8 +602,8 @@ $radius-lg: 16px;
   gap: 4px;
   font-size: 0.6875rem;
   font-weight: 500;
-  color: $accent-green;
-  background: rgba($accent-green, 0.1);
+  color: var(--kh-success);
+  background: var(--kh-success-subtle);
   padding: 3px 8px;
   border-radius: 20px;
 
@@ -631,7 +616,7 @@ $radius-lg: 16px;
 
 .palette-description {
   font-size: 0.75rem;
-  color: $text-secondary;
+  color: var(--kh-text-secondary);
   margin: 0 0 10px;
   line-height: 1.5;
 }
@@ -639,7 +624,7 @@ $radius-lg: 16px;
 .swatch-strip {
   display: flex;
   gap: 4px;
-  border-radius: $radius-sm;
+  border-radius: var(--kh-radius-md);
   overflow: hidden;
 }
 
@@ -677,12 +662,12 @@ $radius-lg: 16px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-family: var(--kh-font-mono);
 }
 
 .palette-mood {
   font-size: 0.6875rem;
-  color: $text-muted;
+  color: var(--kh-text-muted);
   font-style: italic;
   margin: 8px 0 0;
 }
@@ -695,10 +680,10 @@ $radius-lg: 16px;
   justify-content: center;
   gap: 6px;
   padding: 8px 12px;
-  border-radius: $radius-sm;
-  border: 1px solid $border-default;
+  border-radius: var(--kh-radius-md);
+  border: 1px solid var(--kh-border);
   background: transparent;
-  color: $text-primary;
+  color: var(--kh-text-primary);
   font-size: 0.8125rem;
   font-weight: 500;
   cursor: pointer;
@@ -711,16 +696,16 @@ $radius-lg: 16px;
   }
 
   &:hover:not(:disabled) {
-    border-color: rgba($accent-blue, 0.4);
-    background: rgba($accent-blue, 0.06);
-    color: $accent-blue;
+    border-color: color-mix(in srgb, var(--kh-info) 40%, transparent);
+    background: color-mix(in srgb, var(--kh-info) 6%, transparent);
+    color: var(--kh-info);
   }
 
   &.is-selected,
   &:disabled {
-    border-color: rgba($accent-green, 0.4);
-    background: rgba($accent-green, 0.1);
-    color: $accent-green;
+    border-color: color-mix(in srgb, var(--kh-success) 40%, transparent);
+    background: var(--kh-success-subtle);
+    color: var(--kh-success);
     cursor: default;
   }
 }
@@ -736,7 +721,7 @@ $radius-lg: 16px;
 .block-title {
   font-size: 0.75rem;
   font-weight: 600;
-  color: $text-secondary;
+  color: var(--kh-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   margin: 0 0 8px;
@@ -747,7 +732,7 @@ $radius-lg: 16px;
 
 .block-text {
   font-size: 0.8125rem;
-  color: $text-primary;
+  color: var(--kh-text-primary);
   line-height: 1.6;
   margin: 0;
 }
@@ -756,7 +741,7 @@ $radius-lg: 16px;
   margin: 0;
   padding-left: 1.125rem;
   font-size: 0.8125rem;
-  color: $text-primary;
+  color: var(--kh-text-primary);
   line-height: 1.7;
 
   li {
@@ -766,13 +751,13 @@ $radius-lg: 16px;
     }
 
     &::marker {
-      color: $text-muted;
+      color: var(--kh-text-muted);
     }
   }
 }
 
 .wiki-meta {
-  color: $text-muted;
+  color: var(--kh-text-muted);
   font-size: 0.75rem;
   margin-left: 4px;
 }
@@ -784,21 +769,21 @@ $radius-lg: 16px;
 }
 
 .do-block {
-  background: rgba($accent-green, 0.04);
-  border: 1px solid rgba($accent-green, 0.12);
-  border-radius: $radius-sm;
+  background: color-mix(in srgb, var(--kh-success) 4%, transparent);
+  border: 1px solid color-mix(in srgb, var(--kh-success) 12%, transparent);
+  border-radius: var(--kh-radius-md);
   padding: 12px;
 }
 
 .dont-block {
-  background: rgba($accent-rose, 0.04);
-  border: 1px solid rgba($accent-rose, 0.12);
-  border-radius: $radius-sm;
+  background: color-mix(in srgb, var(--kh-error) 4%, transparent);
+  border: 1px solid color-mix(in srgb, var(--kh-error) 12%, transparent);
+  border-radius: var(--kh-radius-md);
   padding: 12px;
 }
 
 .do-title {
-  color: $accent-green !important;
+  color: var(--kh-success) !important;
   mat-icon {
     font-size: 16px;
     width: 16px;
@@ -807,7 +792,7 @@ $radius-lg: 16px;
 }
 
 .dont-title {
-  color: $accent-rose !important;
+  color: var(--kh-error) !important;
   mat-icon {
     font-size: 16px;
     width: 16px;
@@ -823,21 +808,21 @@ $radius-lg: 16px;
 }
 
 .moodboard-card {
-  background: $surface-raised;
-  border: 1px solid $border-subtle;
-  border-radius: $radius-md;
+  background: var(--kh-surface-2);
+  border: 1px solid var(--kh-border-subtle);
+  border-radius: var(--kh-radius-lg);
   padding: 16px;
   transition: border-color 0.2s;
 
   &:hover {
-    border-color: $border-default;
+    border-color: var(--kh-border);
   }
 }
 
 .moodboard-title {
   font-size: 0.875rem;
   font-weight: 600;
-  color: $text-primary;
+  color: var(--kh-text-primary);
   margin: 0 0 12px;
 }
 
@@ -853,7 +838,7 @@ $radius-lg: 16px;
   display: block;
   font-size: 0.6875rem;
   font-weight: 500;
-  color: $text-muted;
+  color: var(--kh-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   margin-bottom: 4px;
@@ -861,7 +846,7 @@ $radius-lg: 16px;
 
 .moodboard-detail p {
   font-size: 0.8125rem;
-  color: $text-secondary;
+  color: var(--kh-text-secondary);
   line-height: 1.5;
   margin: 0;
 }
@@ -876,7 +861,7 @@ $radius-lg: 16px;
   width: 28px;
   height: 28px;
   border-radius: 6px;
-  border: 1px solid $border-default;
+  border: 1px solid var(--kh-border);
 }
 
 // ---------------------------------------------------------------------------
@@ -896,16 +881,16 @@ $radius-lg: 16px;
 }
 
 .brand-book-dialog {
-  background: $surface-base;
-  border: 1px solid $border-default;
-  border-radius: $radius-lg;
+  background: var(--kh-surface-1);
+  border: 1px solid var(--kh-border);
+  border-radius: var(--kh-radius-xl);
   width: 100%;
   max-width: 640px;
   max-height: 100%;
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.45);
+  box-shadow: var(--kh-shadow-lg);
 }
 
 .brand-book-dialog-header {
@@ -913,14 +898,14 @@ $radius-lg: 16px;
   align-items: center;
   justify-content: space-between;
   padding: 14px 20px;
-  border-bottom: 1px solid $border-subtle;
+  border-bottom: 1px solid var(--kh-border-subtle);
   gap: 12px;
 
   h3 {
     margin: 0;
     font-size: 0.9375rem;
     font-weight: 600;
-    color: $text-primary;
+    color: var(--kh-text-primary);
   }
 }
 
@@ -936,9 +921,9 @@ $radius-lg: 16px;
   align-items: center;
   gap: 4px;
   padding: 6px 10px;
-  border-radius: $radius-sm;
+  border-radius: var(--kh-radius-md);
   background: transparent;
-  color: $text-secondary;
+  color: var(--kh-text-secondary);
   border: 1px solid transparent;
   cursor: pointer;
   font-size: 0.8125rem;
@@ -951,8 +936,8 @@ $radius-lg: 16px;
   }
 
   &:hover {
-    border-color: $border-default;
-    color: $text-primary;
+    border-color: var(--kh-border);
+    color: var(--kh-text-primary);
   }
 }
 
@@ -965,7 +950,7 @@ $radius-lg: 16px;
   font-family: inherit;
   font-size: 0.8125rem;
   line-height: 1.7;
-  color: $text-primary;
+  color: var(--kh-text-primary);
   margin: 0;
   padding: 20px;
   overflow-y: auto;

--- a/user-interface/src/app/components/branding-chat/branding-chat.component.scss
+++ b/user-interface/src/app/components/branding-chat/branding-chat.component.scss
@@ -1,6 +1,6 @@
 .chat-card {
-  background: #161b22;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--kh-surface-2);
+  border: 1px solid var(--kh-border-subtle);
 
   mat-card-header {
     mat-card-title {
@@ -10,14 +10,14 @@
       font-size: 1.125rem;
 
       mat-icon {
-        color: #58a6ff;
+        color: var(--kh-accent);
       }
     }
   }
 }
 
 .error-text {
-  color: #f85149;
+  color: var(--kh-error);
   font-size: 0.875rem;
   margin-bottom: 0.5rem;
 }
@@ -26,8 +26,8 @@
   height: 400px;
   overflow-y: auto;
   padding: 1rem;
-  background: #0d1117;
-  border-radius: 8px;
+  background: var(--kh-surface-1);
+  border-radius: var(--kh-radius-md);
   margin-bottom: 1rem;
   display: flex;
   flex-direction: column;
@@ -42,11 +42,11 @@
   }
 
   &::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.1);
+    background: var(--kh-glass);
     border-radius: 3px;
 
     &:hover {
-      background: rgba(255, 255, 255, 0.15);
+      background: var(--kh-glass-hover);
     }
   }
 }
@@ -59,20 +59,20 @@
 
   &.user {
     align-self: flex-end;
-    background: linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%);
-    color: #fff;
+    background: var(--kh-accent-gradient);
+    color: #000;
     border-bottom-right-radius: 4px;
 
     .message-time {
-      color: rgba(255, 255, 255, 0.7);
+      color: rgba(0, 0, 0, 0.6);
     }
   }
 
   &.assistant {
     align-self: flex-start;
-    background: #21262d;
-    color: #f0f6fc;
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: var(--kh-surface-3);
+    color: var(--kh-text-primary);
+    border: 1px solid var(--kh-border-subtle);
     border-bottom-left-radius: 4px;
   }
 }
@@ -84,7 +84,7 @@
 
 .message-time {
   font-size: 0.75rem;
-  color: #8b949e;
+  color: var(--kh-text-muted);
   margin-top: 6px;
 }
 
@@ -96,7 +96,7 @@
   span {
     width: 8px;
     height: 8px;
-    background: #8b949e;
+    background: var(--kh-text-muted);
     border-radius: 50%;
     animation: bounce 1.4s infinite ease-in-out;
 
@@ -145,13 +145,13 @@
 
   button {
     font-size: 0.8125rem;
-    border-color: rgba(255, 255, 255, 0.15);
-    color: #c9d1d9;
+    border-color: var(--kh-border-subtle);
+    color: var(--kh-text-secondary);
 
     &:hover {
-      background: rgba(255, 255, 255, 0.05);
-      border-color: #58a6ff;
-      color: #58a6ff;
+      background: var(--kh-glass);
+      border-color: var(--kh-accent);
+      color: var(--kh-accent);
     }
   }
 }

--- a/user-interface/src/app/components/branding-dashboard/brand-edit-panel/brand-edit-panel.component.html
+++ b/user-interface/src/app/components/branding-dashboard/brand-edit-panel/brand-edit-panel.component.html
@@ -29,13 +29,39 @@
       </mat-form-field>
 
       <mat-form-field appearance="outline">
-        <mat-label>Values (comma-separated)</mat-label>
-        <input matInput formControlName="values_csv" />
+        <mat-label>Values</mat-label>
+        <mat-chip-grid #valuesGrid>
+          @for (val of values; track val) {
+            <mat-chip-row (removed)="removeValue(val)">
+              {{ val }}
+              <button matChipRemove><mat-icon>cancel</mat-icon></button>
+            </mat-chip-row>
+          }
+          <input
+            placeholder="Add a value..."
+            [matChipInputFor]="valuesGrid"
+            [matChipInputSeparatorKeyCodes]="separatorKeyCodes"
+            (matChipInputTokenEnd)="addValue($event)"
+          />
+        </mat-chip-grid>
       </mat-form-field>
 
       <mat-form-field appearance="outline">
-        <mat-label>Differentiators (comma-separated)</mat-label>
-        <input matInput formControlName="differentiators_csv" />
+        <mat-label>Differentiators</mat-label>
+        <mat-chip-grid #diffGrid>
+          @for (diff of differentiators; track diff) {
+            <mat-chip-row (removed)="removeDifferentiator(diff)">
+              {{ diff }}
+              <button matChipRemove><mat-icon>cancel</mat-icon></button>
+            </mat-chip-row>
+          }
+          <input
+            placeholder="Add a differentiator..."
+            [matChipInputFor]="diffGrid"
+            [matChipInputSeparatorKeyCodes]="separatorKeyCodes"
+            (matChipInputTokenEnd)="addDifferentiator($event)"
+          />
+        </mat-chip-grid>
       </mat-form-field>
 
       <mat-slide-toggle

--- a/user-interface/src/app/components/branding-dashboard/brand-edit-panel/brand-edit-panel.component.html
+++ b/user-interface/src/app/components/branding-dashboard/brand-edit-panel/brand-edit-panel.component.html
@@ -41,6 +41,7 @@
             placeholder="Add a value..."
             [matChipInputFor]="valuesGrid"
             [matChipInputSeparatorKeyCodes]="separatorKeyCodes"
+            [matChipInputAddOnBlur]="true"
             (matChipInputTokenEnd)="addValue($event)"
           />
         </mat-chip-grid>
@@ -59,6 +60,7 @@
             placeholder="Add a differentiator..."
             [matChipInputFor]="diffGrid"
             [matChipInputSeparatorKeyCodes]="separatorKeyCodes"
+            [matChipInputAddOnBlur]="true"
             (matChipInputTokenEnd)="addDifferentiator($event)"
           />
         </mat-chip-grid>

--- a/user-interface/src/app/components/branding-dashboard/brand-edit-panel/brand-edit-panel.component.spec.ts
+++ b/user-interface/src/app/components/branding-dashboard/brand-edit-panel/brand-edit-panel.component.spec.ts
@@ -3,6 +3,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { vi } from 'vitest';
 import { BrandEditPanelComponent } from './brand-edit-panel.component';
 import type { BrandingMissionSnapshot, Brand } from '../../../models';
+import { MatChipInputEvent } from '@angular/material/chips';
 
 describe('BrandEditPanelComponent', () => {
   let component: BrandEditPanelComponent;
@@ -37,8 +38,8 @@ describe('BrandEditPanelComponent', () => {
       open: { currentValue: true, previousValue: false, firstChange: false, isFirstChange: () => false },
     });
     expect(component.form.value.company_name).toBe('Acme');
-    expect(component.form.value.values_csv).toBe('integrity, quality');
-    expect(component.form.value.differentiators_csv).toBe('speed');
+    expect(component.values).toEqual(['integrity', 'quality']);
+    expect(component.differentiators).toEqual(['speed']);
   });
 
   it('patches form from brand.mission when brand is provided', () => {
@@ -49,9 +50,10 @@ describe('BrandEditPanelComponent', () => {
       brand: { currentValue: component.brand, previousValue: null, firstChange: false, isFirstChange: () => false },
     });
     expect(component.form.value.company_name).toBe('Acme');
+    expect(component.values).toEqual(['integrity', 'quality']);
   });
 
-  it('onApply emits missionUpdate with parsed values', () => {
+  it('onApply emits missionUpdate with values and differentiators arrays', () => {
     const spy = vi.fn();
     component.missionUpdate.subscribe(spy);
     component.form.setValue({
@@ -59,9 +61,9 @@ describe('BrandEditPanelComponent', () => {
       company_description: 'New desc here',
       target_audience: 'developers',
       desired_voice: 'bold',
-      values_csv: 'honesty, trust',
-      differentiators_csv: 'reliability',
     });
+    component.values = ['honesty', 'trust'];
+    component.differentiators = ['reliability'];
     component.onApply();
     expect(spy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -72,7 +74,7 @@ describe('BrandEditPanelComponent', () => {
     );
   });
 
-  it('onApply emits empty arrays (not undefined) when values/differentiators are cleared', () => {
+  it('onApply emits empty arrays when values/differentiators are cleared', () => {
     const spy = vi.fn();
     component.missionUpdate.subscribe(spy);
     component.form.setValue({
@@ -80,9 +82,9 @@ describe('BrandEditPanelComponent', () => {
       company_description: 'Clearing values test',
       target_audience: 'testers',
       desired_voice: '',
-      values_csv: '',
-      differentiators_csv: '',
     });
+    component.values = [];
+    component.differentiators = [];
     component.onApply();
     expect(spy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -100,8 +102,6 @@ describe('BrandEditPanelComponent', () => {
       company_description: '',
       target_audience: '',
       desired_voice: '',
-      values_csv: '',
-      differentiators_csv: '',
     });
     component.onApply();
     expect(spy).not.toHaveBeenCalled();
@@ -145,6 +145,7 @@ describe('BrandEditPanelComponent', () => {
       open: { currentValue: true, previousValue: false, firstChange: false, isFirstChange: () => false },
     });
     expect(component.form.value.company_name).toBe('Acme');
+    expect(component.values).toEqual(['integrity', 'quality']);
 
     component.mission = null;
     component.brand = null;
@@ -152,6 +153,65 @@ describe('BrandEditPanelComponent', () => {
       mission: { currentValue: null, previousValue: mission, firstChange: false, isFirstChange: () => false },
     });
     expect(component.form.value.company_name).toBe('');
-    expect(component.form.value.values_csv).toBe('');
+    expect(component.values).toEqual([]);
+    expect(component.differentiators).toEqual([]);
+  });
+
+  describe('chip input methods', () => {
+    const makeChipEvent = (value: string): MatChipInputEvent => ({
+      value,
+      chipInput: { clear: vi.fn() } as unknown as MatChipInputEvent['chipInput'],
+      input: document.createElement('input'),
+    });
+
+    it('addValue adds a trimmed value and clears the input', () => {
+      const event = makeChipEvent('  innovation  ');
+      component.addValue(event);
+      expect(component.values).toEqual(['innovation']);
+      expect(event.chipInput.clear).toHaveBeenCalled();
+    });
+
+    it('addValue ignores empty strings', () => {
+      const event = makeChipEvent('   ');
+      component.addValue(event);
+      expect(component.values).toEqual([]);
+    });
+
+    it('removeValue removes the matching value', () => {
+      component.values = ['a', 'b', 'c'];
+      component.removeValue('b');
+      expect(component.values).toEqual(['a', 'c']);
+    });
+
+    it('removeValue does nothing for non-existent value', () => {
+      component.values = ['a', 'b'];
+      component.removeValue('z');
+      expect(component.values).toEqual(['a', 'b']);
+    });
+
+    it('addDifferentiator adds a trimmed value and clears the input', () => {
+      const event = makeChipEvent('scalability');
+      component.addDifferentiator(event);
+      expect(component.differentiators).toEqual(['scalability']);
+      expect(event.chipInput.clear).toHaveBeenCalled();
+    });
+
+    it('addDifferentiator ignores empty strings', () => {
+      const event = makeChipEvent('');
+      component.addDifferentiator(event);
+      expect(component.differentiators).toEqual([]);
+    });
+
+    it('removeDifferentiator removes the matching value', () => {
+      component.differentiators = ['fast', 'reliable'];
+      component.removeDifferentiator('fast');
+      expect(component.differentiators).toEqual(['reliable']);
+    });
+
+    it('removeDifferentiator does nothing for non-existent value', () => {
+      component.differentiators = ['fast'];
+      component.removeDifferentiator('slow');
+      expect(component.differentiators).toEqual(['fast']);
+    });
   });
 });

--- a/user-interface/src/app/components/branding-dashboard/brand-edit-panel/brand-edit-panel.component.ts
+++ b/user-interface/src/app/components/branding-dashboard/brand-edit-panel/brand-edit-panel.component.ts
@@ -1,11 +1,12 @@
 import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, inject } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
+import { MatChipsModule, MatChipInputEvent } from '@angular/material/chips';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
-import { MatExpansionModule } from '@angular/material/expansion';
+import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import type { Brand, BrandingMissionSnapshot } from '../../../models';
 
 @Component({
@@ -14,11 +15,11 @@ import type { Brand, BrandingMissionSnapshot } from '../../../models';
   imports: [
     ReactiveFormsModule,
     MatButtonModule,
+    MatChipsModule,
     MatFormFieldModule,
     MatIconModule,
     MatInputModule,
     MatSlideToggleModule,
-    MatExpansionModule,
   ],
   templateUrl: './brand-edit-panel.component.html',
   styleUrl: './brand-edit-panel.component.scss',
@@ -34,13 +35,15 @@ export class BrandEditPanelComponent implements OnChanges {
 
   private readonly fb = inject(FormBuilder);
 
+  readonly separatorKeyCodes = [ENTER, COMMA] as const;
+  values: string[] = [];
+  differentiators: string[] = [];
+
   form = this.fb.nonNullable.group({
     company_name: ['', [Validators.required, Validators.minLength(2)]],
     company_description: ['', [Validators.required, Validators.minLength(10)]],
     target_audience: ['', [Validators.required, Validators.minLength(3)]],
     desired_voice: [''],
-    values_csv: [''],
-    differentiators_csv: [''],
   });
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -51,6 +54,28 @@ export class BrandEditPanelComponent implements OnChanges {
     if (justOpened || brandSwitch || missionCleared || (!this.open && (changes['mission'] || changes['brand']))) {
       this.patchFormFromMission();
     }
+  }
+
+  addValue(event: MatChipInputEvent): void {
+    const val = (event.value ?? '').trim();
+    if (val) this.values.push(val);
+    event.chipInput.clear();
+  }
+
+  removeValue(val: string): void {
+    const idx = this.values.indexOf(val);
+    if (idx >= 0) this.values.splice(idx, 1);
+  }
+
+  addDifferentiator(event: MatChipInputEvent): void {
+    const val = (event.value ?? '').trim();
+    if (val) this.differentiators.push(val);
+    event.chipInput.clear();
+  }
+
+  removeDifferentiator(val: string): void {
+    const idx = this.differentiators.indexOf(val);
+    if (idx >= 0) this.differentiators.splice(idx, 1);
   }
 
   onApply(): void {
@@ -64,10 +89,8 @@ export class BrandEditPanelComponent implements OnChanges {
       company_description: raw.company_description,
       target_audience: raw.target_audience,
       desired_voice: raw.desired_voice,
-      values: raw.values_csv ? raw.values_csv.split(',').map((v: string) => v.trim()).filter(Boolean) : [],
-      differentiators: raw.differentiators_csv
-        ? raw.differentiators_csv.split(',').map((v: string) => v.trim()).filter(Boolean)
-        : [],
+      values: [...this.values],
+      differentiators: [...this.differentiators],
     };
     this.missionUpdate.emit(patch);
   }
@@ -83,7 +106,9 @@ export class BrandEditPanelComponent implements OnChanges {
   private patchFormFromMission(): void {
     const m = this.brand?.mission ?? this.mission;
     if (!m) {
-      this.form.reset({ company_name: '', company_description: '', target_audience: '', desired_voice: '', values_csv: '', differentiators_csv: '' });
+      this.form.reset({ company_name: '', company_description: '', target_audience: '', desired_voice: '' });
+      this.values = [];
+      this.differentiators = [];
       return;
     }
     this.form.patchValue({
@@ -91,8 +116,8 @@ export class BrandEditPanelComponent implements OnChanges {
       company_description: m.company_description || '',
       target_audience: m.target_audience || '',
       desired_voice: m.desired_voice || '',
-      values_csv: (m.values ?? []).join(', '),
-      differentiators_csv: (m.differentiators ?? []).join(', '),
     });
+    this.values = [...(m.values ?? [])];
+    this.differentiators = [...(m.differentiators ?? [])];
   }
 }

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard-extra.spec.ts
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard-extra.spec.ts
@@ -159,14 +159,12 @@ describe('BrandingDashboardComponent (extra coverage)', () => {
   // Save-as-brand modal
   // ---------------------------------------------------------------------
 
-  it('onOpenSaveAsBrand opens dialog with current client and reloads clients', async () => {
+  it('onOpenSaveAsBrand opens dialog', async () => {
     await buildModule({ snapshot: { queryParamMap: { get: () => null } } });
     fixture.detectChanges();
-    api.listClients.mockClear();
     component.onOpenSaveAsBrand();
     expect(component.showSaveAsBrandDialog).toBe(true);
-    expect(component.saveToAgencyClientId).toBe('w1');
-    expect(api.listClients).toHaveBeenCalled();
+    expect(component.saveToAgencyError).toBeNull();
   });
 
   it('closeSaveAsBrandDialog resets dialog state', async () => {
@@ -174,38 +172,9 @@ describe('BrandingDashboardComponent (extra coverage)', () => {
     fixture.detectChanges();
     component.showSaveAsBrandDialog = true;
     component.saveToAgencyBrandName = 'N';
-    component.saveToAgencyNewClientName = 'C';
     component.closeSaveAsBrandDialog();
     expect(component.showSaveAsBrandDialog).toBe(false);
     expect(component.saveToAgencyBrandName).toBe('');
-  });
-
-  it('createClientForSave creates a client and updates state', async () => {
-    await buildModule({ snapshot: { queryParamMap: { get: () => null } } });
-    fixture.detectChanges();
-    api.createClient.mockReturnValue(of({ ...workspaceClient, id: 'w2', name: 'New' }));
-    component.saveToAgencyNewClientName = 'New';
-    component.createClientForSave();
-    expect(api.createClient).toHaveBeenCalledWith({ name: 'New' });
-    expect(component.saveToAgencyClientId).toBe('w2');
-  });
-
-  it('createClientForSave skips empty name', async () => {
-    await buildModule({ snapshot: { queryParamMap: { get: () => null } } });
-    fixture.detectChanges();
-    api.createClient.mockClear();
-    component.saveToAgencyNewClientName = '   ';
-    component.createClientForSave();
-    expect(api.createClient).not.toHaveBeenCalled();
-  });
-
-  it('createClientForSave handles error', async () => {
-    await buildModule({ snapshot: { queryParamMap: { get: () => null } } });
-    fixture.detectChanges();
-    api.createClient.mockReturnValue(throwError(() => ({ message: 'err' })));
-    component.saveToAgencyNewClientName = 'x';
-    component.createClientForSave();
-    expect(component.saveToAgencyError).toBe('err');
   });
 
   it('saveConversationToAgency requires mission and client', async () => {
@@ -217,7 +186,6 @@ describe('BrandingDashboardComponent (extra coverage)', () => {
 
     component.conversationMission = { company_name: 'C', company_description: 'd', target_audience: 'a', values: [], differentiators: [], desired_voice: 'v' } as BrandingMissionSnapshot;
     component.selectedClient = null;
-    component.saveToAgencyClientId = null;
     component.saveConversationToAgency();
     expect(component.saveToAgencyError).toContain('Workspace');
   });

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard-extra.spec.ts
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard-extra.spec.ts
@@ -167,6 +167,23 @@ describe('BrandingDashboardComponent (extra coverage)', () => {
     expect(component.saveToAgencyError).toBeNull();
   });
 
+  it('changing workspace closes the save dialog', async () => {
+    await buildModule({ snapshot: { queryParamMap: { get: () => null } } });
+    fixture.detectChanges();
+    component.showSaveAsBrandDialog = true;
+    const otherClient = { ...workspaceClient, id: 'w2', name: 'Other' };
+    component.onWorkspaceChange(otherClient);
+    expect(component.showSaveAsBrandDialog).toBe(false);
+  });
+
+  it('changing brand closes the save dialog', async () => {
+    await buildModule({ snapshot: { queryParamMap: { get: () => null } } });
+    fixture.detectChanges();
+    component.showSaveAsBrandDialog = true;
+    component.onBrandChange(makeBrand('b2'));
+    expect(component.showSaveAsBrandDialog).toBe(false);
+  });
+
   it('closeSaveAsBrandDialog resets dialog state', async () => {
     await buildModule({ snapshot: { queryParamMap: { get: () => null } } });
     fixture.detectChanges();

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard-extra.spec.ts
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard-extra.spec.ts
@@ -181,10 +181,12 @@ describe('BrandingDashboardComponent (extra coverage)', () => {
     await buildModule({ snapshot: { queryParamMap: { get: () => null } } });
     fixture.detectChanges();
     component.conversationMission = null;
+    component.onOpenSaveAsBrand();
     component.saveConversationToAgency();
     expect(component.saveToAgencyError).toContain('No mission');
 
     component.conversationMission = { company_name: 'C', company_description: 'd', target_audience: 'a', values: [], differentiators: [], desired_voice: 'v' } as BrandingMissionSnapshot;
+    component.onOpenSaveAsBrand();
     component.selectedClient = null;
     component.saveConversationToAgency();
     expect(component.saveToAgencyError).toContain('Workspace');
@@ -195,6 +197,7 @@ describe('BrandingDashboardComponent (extra coverage)', () => {
     fixture.detectChanges();
     component.conversationMission = { company_name: 'C', company_description: 'd', target_audience: 'a', values: [], differentiators: [], desired_voice: 'v' } as BrandingMissionSnapshot;
     component.selectedClient = workspaceClient;
+    component.onOpenSaveAsBrand();
     api.createBrand.mockReturnValue(of(makeBrand('b-new', { name: 'My Brand' })));
     api.listBrands.mockReturnValue(of([makeBrand('b-new', { name: 'My Brand' })]));
     component.saveConversationToAgency();
@@ -207,10 +210,10 @@ describe('BrandingDashboardComponent (extra coverage)', () => {
     fixture.detectChanges();
     component.conversationMission = { company_name: 'C', company_description: 'd', target_audience: 'a', values: [], differentiators: [], desired_voice: 'v' } as BrandingMissionSnapshot;
     component.selectedClient = workspaceClient;
+    component.onOpenSaveAsBrand();
     api.runBrand.mockReturnValue(throwError(() => ({ message: 'fail' })));
     api.createBrand.mockReturnValue(of(makeBrand('b-new')));
     component.saveConversationToAgency();
-    // No assertion failure; run failure should be handled by the component
     expect(api.runBrand).toHaveBeenCalled();
   });
 
@@ -219,9 +222,24 @@ describe('BrandingDashboardComponent (extra coverage)', () => {
     fixture.detectChanges();
     component.conversationMission = { company_name: 'C', company_description: 'd', target_audience: 'a', values: [], differentiators: [], desired_voice: 'v' } as BrandingMissionSnapshot;
     component.selectedClient = workspaceClient;
+    component.onOpenSaveAsBrand();
     api.createBrand.mockReturnValue(throwError(() => ({ error: { detail: 'createbrand-fail' } })));
     component.saveConversationToAgency();
     expect(component.saveToAgencyError).toBe('createbrand-fail');
+  });
+
+  it('saveConversationToAgency preserves mission snapshot after workspace change', async () => {
+    await buildModule({ snapshot: { queryParamMap: { get: () => null } } });
+    fixture.detectChanges();
+    const originalMission = { company_name: 'Original', company_description: 'desc', target_audience: 'audience', values: ['v1'], differentiators: [], desired_voice: 'v' } as BrandingMissionSnapshot;
+    component.conversationMission = originalMission;
+    component.selectedClient = workspaceClient;
+    component.onOpenSaveAsBrand();
+    component.conversationMission = { company_name: 'Overwritten', company_description: 'other', target_audience: 'other', values: [], differentiators: [], desired_voice: '' } as BrandingMissionSnapshot;
+    api.createBrand.mockReturnValue(of(makeBrand('b-new', { name: 'Original' })));
+    api.listBrands.mockReturnValue(of([makeBrand('b-new', { name: 'Original' })]));
+    component.saveConversationToAgency();
+    expect(api.createBrand).toHaveBeenCalledWith('w1', expect.objectContaining({ company_name: 'Original' }));
   });
 
   // ---------------------------------------------------------------------

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.html
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.html
@@ -160,37 +160,6 @@
         <button mat-raised-button color="primary" type="button" (click)="saveConversationToAgency()">Save brand</button>
         <button mat-stroked-button type="button" (click)="closeSaveAsBrandDialog()">Cancel</button>
       </div>
-
-      <mat-expansion-panel [(expanded)]="saveModalAdvanced" class="save-advanced-panel">
-        <mat-expansion-panel-header>
-          <mat-panel-title>Advanced</mat-panel-title>
-        </mat-expansion-panel-header>
-        <div class="agency-actions">
-          <button mat-stroked-button type="button" (click)="loadClients()">Reload workspaces</button>
-          @if (clients.length > 0) {
-            <mat-form-field appearance="outline">
-              <mat-label>Workspace</mat-label>
-              <mat-select [(ngModel)]="saveToAgencyClientId" name="saveClient">
-                <mat-option [value]="null">-- Select workspace --</mat-option>
-                @for (c of clients; track c.id) {
-                  <mat-option [value]="c.id">{{ c.name }}</mat-option>
-                }
-              </mat-select>
-            </mat-form-field>
-          }
-        </div>
-        <p class="new-client-row">
-          <input
-            type="text"
-            [(ngModel)]="saveToAgencyNewClientName"
-            placeholder="New workspace name"
-            class="client-name-input"
-          />
-          <button mat-stroked-button type="button" (click)="createClientForSave()" [disabled]="!saveToAgencyNewClientName.trim()">
-            Add workspace
-          </button>
-        </p>
-      </mat-expansion-panel>
     </mat-card-content>
   </mat-card>
 }

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.scss
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.scss
@@ -61,7 +61,7 @@
 .save-as-brand-overlay {
   position: relative;
   margin-top: 16px;
-  border: 2px solid #58a6ff;
+  border: 2px solid var(--kh-accent);
   max-width: 480px;
 
   mat-card-header {
@@ -71,7 +71,7 @@
   }
 
   .success-message {
-    color: #3fb950;
+    color: var(--kh-success);
     margin-bottom: 8px;
   }
 
@@ -90,10 +90,6 @@
   }
 }
 
-.save-advanced-panel {
-  margin-top: 12px;
-}
-
 mat-form-field {
   width: 100%;
 }
@@ -102,29 +98,8 @@ mat-card {
   margin-bottom: 16px;
 }
 
-.agency-actions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 12px;
-  margin-bottom: 12px;
-}
-
-.new-client-row {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-}
-
-.client-name-input {
-  padding: 8px 12px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  min-width: 180px;
-}
-
 .brand-item--highlight {
-  background: rgba(88, 166, 255, 0.12);
+  background: var(--kh-accent-muted);
 }
 
 .split-button {
@@ -159,7 +134,7 @@ mat-card {
 .action-message {
   margin-top: 12px;
   padding: 8px;
-  background: #e8f5e9;
-  border-radius: 4px;
+  background: var(--kh-success-subtle);
+  border-radius: var(--kh-radius-sm);
   font-size: 0.9rem;
 }

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.ts
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.ts
@@ -168,10 +168,12 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
   }
 
   onWorkspaceChange(client: Client): void {
+    this.closeSaveAsBrandDialog();
     this.selectClient(client);
   }
 
   onBrandChange(brand: Brand): void {
+    this.closeSaveAsBrandDialog();
     this.resumeOrStartBrand(brand);
   }
 

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.ts
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.ts
@@ -182,6 +182,7 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
 
   onOpenSaveAsBrand(): void {
     this.showSaveAsBrandDialog = true;
+    this.saveToAgencyMission = this.conversationMission;
     this.saveToAgencyError = null;
   }
 
@@ -189,16 +190,18 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
   saveToAgencyBrandName = '';
   saveToAgencyError: string | null = null;
   saveToAgencySuccess: string | null = null;
+  private saveToAgencyMission: BrandingMissionSnapshot | null = null;
 
   closeSaveAsBrandDialog(): void {
     this.showSaveAsBrandDialog = false;
     this.saveToAgencyBrandName = '';
     this.saveToAgencyError = null;
     this.saveToAgencySuccess = null;
+    this.saveToAgencyMission = null;
   }
 
   saveConversationToAgency(): void {
-    const mission = this.conversationMission;
+    const mission = this.saveToAgencyMission;
     if (!mission) {
       this.saveToAgencyError = 'No mission to save.';
       return;

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.ts
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.ts
@@ -8,7 +8,6 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
-import { MatOption, MatSelectModule } from '@angular/material/select';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatExpansionModule } from '@angular/material/expansion';
@@ -47,8 +46,6 @@ const WORKSPACE_CLIENT_NAME = 'My brands';
     MatInputModule,
     MatButtonModule,
     MatIconModule,
-    MatSelectModule,
-    MatOption,
     MatMenuModule,
     MatSnackBarModule,
     MatExpansionModule,
@@ -185,43 +182,19 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
 
   onOpenSaveAsBrand(): void {
     this.showSaveAsBrandDialog = true;
-    this.saveToAgencyClientId = this.selectedClient?.id ?? null;
     this.saveToAgencyError = null;
-    this.loadClients();
   }
 
   showSaveAsBrandDialog = false;
-  saveToAgencyClientId: string | null = null;
   saveToAgencyBrandName = '';
-  saveToAgencyNewClientName = '';
   saveToAgencyError: string | null = null;
   saveToAgencySuccess: string | null = null;
-  saveModalAdvanced = false;
 
   closeSaveAsBrandDialog(): void {
     this.showSaveAsBrandDialog = false;
-    this.saveToAgencyClientId = null;
     this.saveToAgencyBrandName = '';
-    this.saveToAgencyNewClientName = '';
     this.saveToAgencyError = null;
     this.saveToAgencySuccess = null;
-    this.saveModalAdvanced = false;
-  }
-
-  createClientForSave(): void {
-    const name = this.saveToAgencyNewClientName.trim();
-    if (!name) return;
-    this.api.createClient({ name }).subscribe({
-      next: (client) => {
-        this.clients = [...this.clients, client];
-        this.saveToAgencyClientId = client.id;
-        this.saveToAgencyNewClientName = '';
-        this.loadClients();
-      },
-      error: (err) => {
-        this.saveToAgencyError = err?.error?.detail ?? err?.message ?? 'Failed to create workspace';
-      },
-    });
   }
 
   saveConversationToAgency(): void {
@@ -230,7 +203,7 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
       this.saveToAgencyError = 'No mission to save.';
       return;
     }
-    const clientId = this.saveToAgencyClientId ?? this.selectedClient?.id;
+    const clientId = this.selectedClient?.id;
     if (!clientId) {
       this.saveToAgencyError = 'Workspace is not ready. Refresh the page and try again.';
       return;


### PR DESCRIPTION
## Summary

- **Chip-grid inputs**: Replace CSV text fields for `values` and `differentiators` with `mat-chip-grid` (Enter/comma to add, backspace/X to remove) — matches the established pattern used across the app (e.g. accessibility-audit-form).
- **Remove buried workspace panel**: Remove the Advanced expansion panel from the save-as-brand dialog. Workspace selection now lives exclusively in the `branding-context-selector` at the top of the page, eliminating the duplicate.
- **Unified theme**: Migrate both `brand-preview` and `branding-chat` SCSS from hardcoded color values to the global `--kh-*` design tokens (`theme.scss`), so both panels share the same surface/text/accent treatment. Uses `color-mix()` for alpha-blended token variants.

**Note:** Palette selection (acceptance criterion #2) was already implemented — buttons, selected state, and event chain all exist. No changes needed there.

Closes #279

## Test plan
- [x] Build passes (`ng build` — no errors)
- [x] All 1684 tests pass (140 test files, 0 failures)
- [ ] Visual check: chip inputs accept Enter/comma to add, backspace/X to remove values
- [ ] Visual check: save dialog no longer shows Advanced panel; saving uses current workspace
- [ ] Visual check: chat and preview panels share consistent --kh-* theme tokens
- [ ] Accessibility: WCAG AA contrast verified across both panels (tokens document compliance)

https://claude.ai/code/session_016w5fcVSWtTvpgeHCTDpbCq

---
_Generated by [Claude Code](https://claude.ai/code/session_016w5fcVSWtTvpgeHCTDpbCq)_