### PR TITLE
Strip inline predicate logic from compiled code — engine as single source of truth

### DIFF
--- a/backend/agents/investment_team/strategy_lab/prompts/code_synthesis_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/code_synthesis_system.md
@@ -1,5 +1,10 @@
 You are an expert Python developer implementing a trading strategy from a frozen specification.
 
+> **Note:** When `requires_custom_code=false` (the default), a deterministic
+> compiler handles code generation and the engine dispatchers manage all
+> entry/exit decisions — this prompt is only reached for specs that need
+> custom logic the compiler cannot express.
+
 You receive a `StrategySpec` that has already passed design review. The spec is **read-only** — you implement it, you do not redesign it. If the spec expresses something the indicator catalogue cannot literally support, the operator has flagged `requires_custom_code=true`; your job is to write the code that realises the thesis using the rules described.
 
 You target the **event-driven `contract.Strategy`** interface. Output is a single Python module — no JSON, no prose around the code, no extra files.

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_conformance.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_conformance.py
@@ -384,6 +384,23 @@ def _find_enclosing_funcdef(
     return enclosing
 
 
+def _is_engine_managed(spec: Any) -> bool:
+    """True when the engine dispatchers own entry and exit decisions for this spec.
+
+    Pre:  ``spec`` is a ``StrategySpec`` or ``None``.
+    Post: True when entry rules exist AND ``requires_custom_code`` is False —
+    the compiled output is a thin indicator shim with zero ``submit_order``
+    calls, and all orders come from ``_EngineEntryDispatcher`` /
+    ``_EngineExitDispatcher``.
+    """
+    if spec is None:
+        return False
+    if getattr(spec, "requires_custom_code", False):
+        return False
+    entry_rules = getattr(spec, "entry_rules", None)
+    return bool(entry_rules)
+
+
 class CodeConformanceGate(GateResultsMixin):
     """Deterministic gate that checks generated code implements ``spec``.
 
@@ -436,7 +453,7 @@ class CodeConformanceGate(GateResultsMixin):
             results.extend(self._check_stop_loss_enforcement(cls, spec))
             results.extend(self._check_take_profit_enforcement(cls, spec))
             results.extend(self._check_bar_counting_exit(cls))
-            results.extend(self._check_sizing_math(cls))
+            results.extend(self._check_sizing_math(cls, spec))
             results.extend(self._check_no_extra_side_effects(tree, cls))
 
             return results or [self._info("Code conforms to spec across all conformance checks.")]
@@ -507,15 +524,19 @@ class CodeConformanceGate(GateResultsMixin):
         if not entry_rules:
             return ()
 
+        if _is_engine_managed(spec):
+            return (
+                self._info(
+                    f"Spec declares {len(entry_rules)} entry rule(s); entries are "
+                    "engine-managed via _EngineEntryDispatcher — no inline "
+                    "submit_order entry branches required."
+                ),
+            )
+
         reachable = _methods_reachable_from_on_bar(cls)
         branches = _find_if_branches_with_submit_order(cls, reachable_method_names=reachable)
         entry_branches: List[tuple[ast.If, List[ast.Call]]] = []
         for if_node, calls in branches:
-            # A branch counts as an entry path when it contains either:
-            # - an explicit ``side=`` literal that isn't a position close, OR
-            # - a ``**kwargs`` spread whose contents we can't statically
-            #   resolve (treat optimistically — same lenient stance the
-            #   CodeSafetyChecker order-flow gate takes on unknown sides).
             if any(
                 _submit_order_is_kwargs_spread(c)
                 or (_submit_order_has_side_literal(c) and not _submit_order_closes_position(c))
@@ -558,14 +579,20 @@ class CodeConformanceGate(GateResultsMixin):
         if not signal_exits:
             return ()
 
+        if _is_engine_managed(spec):
+            return (
+                self._info(
+                    f"Spec declares {len(signal_exits)} signal-exit rule(s); "
+                    "signal exits are engine-managed via _EngineExitDispatcher "
+                    "— no inline submit_order exit branches required."
+                ),
+            )
+
         reachable = _methods_reachable_from_on_bar(cls)
         branches = _find_if_branches_with_submit_order(cls, reachable_method_names=reachable)
         exit_branches = [
             (if_node, calls)
             for if_node, calls in branches
-            # Same lenient stance as entry coverage: a ``**kwargs`` spread
-            # may dynamically carry ``qty=position.qty`` so we can't fail
-            # closed on it.
             if any(
                 _submit_order_closes_position(c) or _submit_order_is_kwargs_spread(c) for c in calls
             )
@@ -685,7 +712,7 @@ class CodeConformanceGate(GateResultsMixin):
     # ------------------------------------------------------------------
     # Check 8 — sizing math present
     # ------------------------------------------------------------------
-    def _check_sizing_math(self, cls: ast.ClassDef) -> Iterable[QualityGateResult]:
+    def _check_sizing_math(self, cls: ast.ClassDef, spec: Any = None) -> Iterable[QualityGateResult]:
         all_submit_calls = [
             sub
             for method in _iter_strategy_methods(cls)
@@ -694,8 +721,6 @@ class CodeConformanceGate(GateResultsMixin):
         ]
         entry_submit_calls = [c for c in all_submit_calls if not _submit_order_closes_position(c)]
         if not entry_submit_calls:
-            # No entry submit_orders to size — Check #3 will already have
-            # fired, so silence this one to avoid noisy double-failure.
             return ()
 
         # Hardcoded-int qty on every entry is an immediate fail regardless

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -6,7 +6,7 @@ import ast
 from dataclasses import dataclass
 from typing import Any, ClassVar, Iterable, List
 
-from ..spec_dsl import StopLossRule, TakeProfitRule
+from ..spec_dsl import SignalExitRule, StopLossRule, TakeProfitRule
 from .code_safety_ast import (
     _BANNED_CALL_PATTERNS,
     _LOOKAHEAD_PATTERNS,
@@ -90,10 +90,10 @@ def _spec_has_engine_handled_exit(spec: Any) -> bool:
     """True iff ``spec.exit_rules`` contains a rule the engine enforces.
 
     Pre:  ``spec`` is a ``StrategySpec`` or ``None``.
-    Post: True only when ``spec.exit_rules`` contains at least one
-          ``StopLossRule`` or ``TakeProfitRule`` (rule kinds enforced
-          engine-side via ``evaluate_exit_rules``). ``SignalExitRule``
-          is a no-op in the evaluator and never satisfies this check.
+    Post: True when ``spec.exit_rules`` contains at least one
+          ``StopLossRule``, ``TakeProfitRule``, or ``SignalExitRule``
+          (all enforced engine-side via ``evaluate_exit_rules`` /
+          ``_EngineExitDispatcher``).
     Invariant: stop-loss/take-profit basis-vs-side coverage is NOT
           checked here — callers must additionally invoke
           :func:`_engine_exits_cover_sides` against the relevant
@@ -104,7 +104,26 @@ def _spec_has_engine_handled_exit(spec: Any) -> bool:
     exit_rules = getattr(spec, "exit_rules", None)
     if not exit_rules:
         return False
-    return any(isinstance(r, (StopLossRule, TakeProfitRule)) for r in exit_rules)
+    return any(isinstance(r, (StopLossRule, TakeProfitRule, SignalExitRule)) for r in exit_rules)
+
+
+def _spec_is_fully_engine_managed(spec: Any) -> bool:
+    """True when both entries and exits are engine-managed for this spec.
+
+    Pre:  ``spec`` is a ``StrategySpec`` or ``None``.
+    Post: True when entry rules exist, at least one exit rule is
+          engine-handled, and the spec is NOT custom-code. The compiled
+          strategy is a pure indicator shim with zero ``submit_order``
+          calls — all orders come from the engine dispatchers.
+    """
+    if spec is None:
+        return False
+    if getattr(spec, "requires_custom_code", False):
+        return False
+    entry_rules = getattr(spec, "entry_rules", None)
+    if not entry_rules:
+        return False
+    return _spec_has_engine_handled_exit(spec)
 
 
 def _hook_calls_include_entry(cls: ast.ClassDef, calls: List[ast.Call]) -> bool:
@@ -698,11 +717,14 @@ class CodeSafetyChecker(GateResultsMixin):
         #   - a single entry with an ``attached_stop_loss`` /
         #     ``attached_take_profit`` bracket leg;
         #   - an entries-only flow whose missing exit is supplied by
-        #     ``spec.exit_rules`` (engine-handled relaxation below).
+        #     ``spec.exit_rules`` (engine-handled relaxation below);
+        #   - zero calls when the spec is fully engine-managed.
         if len(ctx.strategy_classes) != 1:
             return ()
         hook_calls = _collect_hook_submit_calls(ctx.strategy_classes[0])
         if not hook_calls:
+            if _spec_is_fully_engine_managed(ctx.spec):
+                return ()
             return (
                 self._critical(
                     "No ctx.submit_order call reachable from on_bar — strategy "

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -443,10 +443,11 @@ def _engine_exits_cover_sides(spec: Any, sides: set[str]) -> bool:
     Post: False if ``spec`` is None or ``sides`` is empty. Otherwise
           True iff for every side ∈ ``sides`` there exists a rule
           in ``spec.exit_rules`` that triggers on that side per the
-          basis-vs-side compatibility map: ``TakeProfitRule`` and
-          ``StopLossRule(basis="entry_price")`` cover both sides;
-          ``StopLossRule(basis="trailing_high")`` covers only long;
-          ``StopLossRule(basis="trailing_low")`` covers only short.
+          basis-vs-side compatibility map: ``TakeProfitRule``,
+          ``SignalExitRule``, and ``StopLossRule(basis="entry_price")``
+          cover both sides; ``StopLossRule(basis="trailing_high")``
+          covers only long; ``StopLossRule(basis="trailing_low")``
+          covers only short.
     """
     if spec is None or not sides:
         return False
@@ -463,6 +464,8 @@ def _engine_exits_cover_sides(spec: Any, sides: set[str]) -> bool:
                 return side == "long"
             if basis == "trailing_low":
                 return side == "short"
+        if isinstance(rule, SignalExitRule):
+            return True
         return False
 
     for side in sides:

--- a/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
@@ -94,13 +94,33 @@ class ExitRuleConformanceGate(GateResultsMixin):
             for rule in take_profits:
                 results.append(self._check_take_profit(rule, trades, exit_rules, firings))
 
-            # ---- SignalExitRule — not yet engine-enforced ----
+            # ---- SignalExitRule — engine-enforced via _EngineExitDispatcher ----
             signal_exits = [r for r in exit_rules if isinstance(r, SignalExitRule)]
             if signal_exits:
-                results.append(
-                    self._info(f"{len(signal_exits)} SignalExitRule(s) present but not yet "
-                            "engine-enforced (see rule_compiler module docstring).")
-                )
+                engine_signal_firings = firings.get("signal_exit", 0)
+                if trades and engine_signal_firings > 0:
+                    results.append(
+                        self._info(
+                            f"{len(signal_exits)} SignalExitRule(s) — "
+                            f"{engine_signal_firings} engine signal_exit firing(s) "
+                            f"recorded across {len(trades)} trade(s)."
+                        )
+                    )
+                elif trades:
+                    results.append(
+                        self._info(
+                            f"{len(signal_exits)} SignalExitRule(s) — zero engine "
+                            f"signal_exit firings across {len(trades)} trade(s); "
+                            "other exit rules may have closed positions first."
+                        )
+                    )
+                else:
+                    results.append(
+                        self._info(
+                            f"{len(signal_exits)} SignalExitRule(s) — zero trades; "
+                            "no firings to verify."
+                        )
+                    )
 
             # ---- Aggregate: engine emitted at least one exit when expected ----
             if diagnostics is not None:

--- a/backend/agents/investment_team/strategy_lab/quality_gates/realism/rule_firing.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/realism/rule_firing.py
@@ -2,23 +2,27 @@
 
 A strategy whose entry rules never fire in the backtest is one where
 the rule was dead code — the predicate was unreachable given the data,
-or the compiler emitted it but the runtime conditions never aligned.
-Such a strategy is less than what the spec describes and should not be
-published as implementing the full spec.
+or the conditions never aligned at runtime. Such a strategy is less
+than what the spec describes and should not be published as implementing
+the full spec.
 
-This gate reads ``TradeRecord.entry_reason`` (populated by the fill
-simulator from the compiler's ``reason="compiled_entry:entry[{idx}]"``
-annotation) and counts how many trades cite each spec entry rule.
+This gate reads ``TradeRecord.entry_reason`` and ``exit_reason``
+(populated by the fill simulator from the engine dispatchers' reason
+annotations) and counts how many trades cite each spec rule.
+
+Reason prefixes matched:
+  - Entries: ``engine_entry:entry[N]`` (engine-managed) or
+    ``compiled_entry:entry[N]`` (legacy/custom-code).
+  - Signal exits: ``engine_exit:signal_exit[N]`` (engine-managed) or
+    ``compiled_signal_exit:exit[N]`` (legacy/custom-code).
+
 Rules with zero citations are flagged:
 
-* **critical** — an entry rule that never fired. The strategy didn't
-  exercise a signal the spec declared. Dead-code entry rules are the
-  clearest indicator that the compiled code doesn't match the spec.
-* **warning** — a ``SignalExitRule`` that never fired. Signal exits
-  compete with stop-loss and take-profit (which take priority in the
-  engine), so a zero count is suspicious but not always dead code.
+* **critical** — an entry rule that never fired.
+* **warning** — a ``SignalExitRule`` that never fired (signal exits
+  compete with stop-loss/take-profit which fire first in the engine).
 * **info-skip** — when ``spec.requires_custom_code=True`` (LLM-authored
-  code path), the compiler's ``reason`` annotation is absent, so the
+  code path), the reason annotation format is unpredictable, so the
   gate has no signal to evaluate.
 
 Wired from
@@ -35,8 +39,8 @@ from ..models import GateResultsMixin, QualityGateResult, StrategyLabPhase
 
 GATE = "rule_firing_rate_realism"
 
-_ENTRY_REASON_RE = re.compile(r"^compiled_entry:entry\[(\d+)]$")
-_EXIT_REASON_RE = re.compile(r"^compiled_signal_exit:exit\[(\d+)]$")
+_ENTRY_REASON_RE = re.compile(r"^(?:compiled_entry|engine_entry):entry\[(\d+)]$")
+_EXIT_REASON_RE = re.compile(r"^(?:compiled_signal_exit:exit|engine_exit:signal_exit)\[(\d+)]$")
 
 
 class RuleFiringRateGate(GateResultsMixin):
@@ -150,9 +154,10 @@ def _count_exit_hits(trades: List[TradeRecord]) -> dict:
     """Return ``{rule_index: count}`` from ``exit_reason`` annotations.
 
     Postconditions:
-      - Only ``compiled_signal_exit:exit[N]`` patterns are matched;
-        engine-fired exits (``engine_exit:stop_loss``, etc.) are
-        ignored — they're not spec signal-exit rules.
+      - Matches ``engine_exit:signal_exit[N]`` (engine-managed) and
+        ``compiled_signal_exit:exit[N]`` (legacy/custom-code). Other
+        engine exits (``engine_exit:stop_loss[N]``, etc.) are ignored
+        — they're not signal-exit rules.
     """
     hits: dict = {}
     for t in trades:

--- a/backend/agents/investment_team/strategy_lab/synthesis/compiler.py
+++ b/backend/agents/investment_team/strategy_lab/synthesis/compiler.py
@@ -8,23 +8,22 @@ Module contract:
     The header carries a SHA-256 content hash of a canonical DSL dump
     for traceability; no other source of variation is admitted (no
     ``datetime.now()``, no ``uuid``, no ``id()``).
-  Static gates: emitted output is shaped to pass ``CodeSafetyChecker``
-    and ``CodeConformanceGate`` by construction.
-  Engine contract: ``on_bar`` covers universe guard, warm-up gate,
-    bar-close validity, indicator binds, entries, and signal-exits.
-    Stop-loss / take-profit (including trailing variants) are NOT
-    inlined — they are enforced engine-side by ``evaluate_exit_rules``
-    against the post-fill ``position.entry_price``, which alone has
-    the correct basis semantics.
+  Engine-only ordering: the compiled ``on_bar`` is a thin shim —
+    universe guard, warm-up gate, bar-close validity, indicator
+    computation, and a position/entry_price read for conformance
+    checks. **No entry or exit orders are submitted from the compiled
+    code.** All entry decisions are made by ``_EngineEntryDispatcher``
+    (via ``evaluate_entry_rules``), all exit decisions by
+    ``_EngineExitDispatcher`` (via ``evaluate_exit_rules``), both
+    using the shared ``predicate_evaluator`` module. This eliminates
+    the dual-path conflict where strategy-side and engine-side
+    predicate evaluation could diverge.
   Indicator math: helper bodies are inlined as class methods, not
     imported, because the sandbox's ``indicators`` module uses
     pandas-Series signatures incompatible with the per-bar call shape.
     Method names match ``CodeConformanceGate._INDICATOR_ALLOWED_CALL_NAMES``.
   Tuple indicators: MACD / Bollinger / Stochastic thread the DSL's
     ``output`` / ``band`` selector into the helper and return a scalar.
-  Cross predicates: ``cross_above`` / ``cross_below`` compare current
-    against ``self._cross_prev[symbol][sigid]`` — "previous" means the
-    previous successful ``on_bar`` for the same symbol.
   ``volatility_target`` sizing requires an ``atr`` indicator in the
     spec; absent or ambiguous ATR raises :class:`CompilerError`.
   Empty ``spec.target_symbols`` is supported (no universe guard emitted).
@@ -39,10 +38,7 @@ from typing import Any, List, Tuple
 
 from ..spec_dsl import (
     EntryRule,
-    FixedFractionSizing,
-    FixedNotionalSizing,
     IndicatorRef,
-    Predicate,
     SignalExitRule,
     StopLossRule,
     TakeProfitRule,
@@ -72,13 +68,6 @@ _INDICATOR_METHOD_NAME: dict[str, str] = {
     "adx": "adx",
     "stochastic": "stochastic",
     "vwap": "vwap",
-}
-
-_BAR_FIELD_EXPR: dict[str, str] = {
-    "bar.close": "bar.close",
-    "bar.high": "bar.high",
-    "bar.low": "bar.low",
-    "bar.volume": "bar.volume",
 }
 
 _MIN_WINDOW: int = 20
@@ -147,7 +136,6 @@ def compile_strategy(spec: Any) -> str:
             )
 
     indicator_bindings = _build_indicator_bindings(indicator_refs)
-    cross_sides = _collect_cross_sides(entry_rules, signal_exit_rules, indicator_bindings)
     used_helper_names = sorted({_INDICATOR_METHOD_NAME[ref.name] for ref in indicator_refs})
     needs_source_helper = any(
         ref.name in ("sma", "ema", "rsi", "macd", "bollinger") for ref in indicator_refs
@@ -169,11 +157,8 @@ def compile_strategy(spec: Any) -> str:
             target_symbols=target_symbols,
             history_depth=history_depth,
             warmup_min=warmup_min,
-            cross_sides=cross_sides,
             indicator_bindings=indicator_bindings,
-            entry_rules=entry_rules,
             exit_rules=exit_rules,
-            sizing=sizing,
             used_helper_names=used_helper_names,
             needs_source_helper=needs_source_helper,
         )
@@ -345,156 +330,8 @@ def _emit_indicator_call(ref: IndicatorRef) -> str:
     raise CompilerError(f"unsupported indicator: {ref.name!r}")
 
 
-def _collect_cross_sides(
-    entry_rules: List[EntryRule],
-    signal_exit_rules: List[SignalExitRule],
-    indicator_bindings: List[Tuple[str, IndicatorRef, str, str]],
-) -> List[Tuple[str, str, str]]:
-    """Return ``(sigid, prev_var, current_expr)`` for every cross-predicate side.
-
-    Pre:  ``indicator_bindings`` covers every indicator referenced by
-          a cross predicate in the rules.
-    Post: result is de-duplicated by sigid and sigid-sorted. Each
-          tuple supplies the names needed by ``on_bar`` to read the
-          previous bar's value (``self._cross_prev[symbol][sigid]``)
-          and emit the current bar's value.
-    """
-    binding_by_sigid = {sigid: varname for varname, _ref, _call, sigid in indicator_bindings}
-    out: dict[str, Tuple[str, str, str]] = {}
-
-    def _record(side: Any) -> None:
-        sigid = _sigid_for_side(side)
-        if sigid in out:
-            return
-        prev_var = f"prev_{sigid}"
-        current_expr = _render_side(side, binding_by_sigid)
-        out[sigid] = (sigid, prev_var, current_expr)
-
-    for rule in entry_rules:
-        if rule.when.op in ("cross_above", "cross_below"):
-            _record(rule.when.lhs)
-            _record(rule.when.rhs)
-    for rule in signal_exit_rules:
-        if rule.when.op in ("cross_above", "cross_below"):
-            _record(rule.when.lhs)
-            _record(rule.when.rhs)
-    return [out[sigid] for sigid in sorted(out)]
 
 
-def _render_side(side: Any, binding_by_sigid: dict[str, str]) -> str:
-    """Render one predicate side as a Python expression.
-
-    Pre:  ``side`` is ``IndicatorRef`` / bar-field literal / numeric;
-          every ``IndicatorRef`` side has a binding in ``binding_by_sigid``.
-    Post: ``IndicatorRef`` → the binding variable; bar-field literal
-          → the corresponding bar attribute expression; numeric →
-          ``repr(float(value))``.
-    Raises: :class:`CompilerError` for missing bindings, unsupported
-          price-ref literals, or unsupported side types.
-    """
-    if isinstance(side, IndicatorRef):
-        sigid = _sigid_for_side(side)
-        varname = binding_by_sigid.get(sigid)
-        if varname is None:
-            raise CompilerError(
-                "internal: indicator ref missing from bindings — "
-                f"sigid={sigid!r} name={side.name!r}"
-            )
-        return varname
-    if isinstance(side, str):
-        if side not in _BAR_FIELD_EXPR:
-            raise CompilerError(f"unsupported price-ref literal: {side!r}")
-        return _BAR_FIELD_EXPR[side]
-    if isinstance(side, (int, float)) and not isinstance(side, bool):
-        return repr(float(side))
-    raise CompilerError(f"unsupported predicate side type: {type(side).__name__}")
-
-
-def _render_predicate(
-    pred: Predicate, binding_by_sigid: dict[str, str], cross_sides: List[Tuple[str, str, str]]
-) -> str:
-    """Render one predicate as a boolean expression.
-
-    Pre:  ``pred.op`` ∈ ``{"<", ">", "<=", ">=", "==", "cross_above", "cross_below"}``;
-          for cross ops, both sides have entries in ``cross_sides``.
-    Post: returned expression is parenthesised and safe to evaluate
-          during warm-up: indicator-ref sides are guarded with
-          ``is not None`` (bar-field and numeric literals are never
-          None, so guarding them would emit a literal SyntaxWarning).
-          Cross ops additionally require both previous snapshots to
-          be non-None and the inequality to have flipped at this bar.
-    Raises: :class:`CompilerError` for unsupported ops.
-    """
-    lhs_expr = _render_side(pred.lhs, binding_by_sigid)
-    rhs_expr = _render_side(pred.rhs, binding_by_sigid)
-    guards: List[str] = []
-    if isinstance(pred.lhs, IndicatorRef):
-        guards.append(f"{lhs_expr} is not None")
-    if isinstance(pred.rhs, IndicatorRef):
-        guards.append(f"{rhs_expr} is not None")
-
-    if pred.op in ("<", ">", "<=", ">=", "=="):
-        clauses = guards + [f"{lhs_expr} {pred.op} {rhs_expr}"]
-        return "(" + " and ".join(clauses) + ")"
-
-    prev_by_sigid = {sigid: prev_var for sigid, prev_var, _cur in cross_sides}
-    lhs_prev = prev_by_sigid[_sigid_for_side(pred.lhs)]
-    rhs_prev = prev_by_sigid[_sigid_for_side(pred.rhs)]
-    cross_clauses = guards + [
-        f"{lhs_prev} is not None",
-        f"{rhs_prev} is not None",
-    ]
-    if pred.op == "cross_above":
-        cross_clauses.append(f"{lhs_prev} <= {rhs_prev}")
-        cross_clauses.append(f"{lhs_expr} > {rhs_expr}")
-        return "(" + " and ".join(cross_clauses) + ")"
-    if pred.op == "cross_below":
-        cross_clauses.append(f"{lhs_prev} >= {rhs_prev}")
-        cross_clauses.append(f"{lhs_expr} < {rhs_expr}")
-        return "(" + " and ".join(cross_clauses) + ")"
-    raise CompilerError(f"unsupported predicate op: {pred.op!r}")
-
-
-# ---------------------------------------------------------------------------
-# Sizing.
-# ---------------------------------------------------------------------------
-
-
-def _render_sizing(
-    sizing: Any, indicator_bindings: List[Tuple[str, IndicatorRef, str, str]]
-) -> str:
-    """Return a Python statement that assigns ``qty`` from the sizing rule.
-
-    Pre:  ``sizing`` is a known sizing variant; for
-          ``VolatilityTargetSizing``, an ``atr`` binding exists in
-          ``indicator_bindings`` (caller-side gate in
-          :func:`compile_strategy`).
-    Post: emitted ``qty`` is always a positive integer
-          (``max(1, int(...))``). The caller guarantees ``bar.close``
-          is non-None, finite, and positive at the point the emitted
-          statement executes — see the validity guard at the top of
-          ``on_bar``.
-    Raises: :class:`CompilerError` for unsupported variants, or
-          internally if an ATR binding is unexpectedly missing.
-    """
-    if isinstance(sizing, FixedFractionSizing):
-        return f"qty = max(1, int((ctx.equity * {float(sizing.fraction)!r}) / bar.close))"
-    if isinstance(sizing, FixedNotionalSizing):
-        return f"qty = max(1, int({float(sizing.notional_usd)!r} / bar.close))"
-    if isinstance(sizing, VolatilityTargetSizing):
-        atr_var = next(
-            (varname for varname, ref, _call, _sigid in indicator_bindings if ref.name == "atr"),
-            None,
-        )
-        if atr_var is None:
-            raise CompilerError(
-                "internal: volatility_target sizing reached emit step without an ATR binding"
-            )
-        return (
-            f"qty = max(1, int((ctx.equity * {float(sizing.target_annual_vol)!r}) "
-            f"/ (bar.close * {atr_var}))) if {atr_var} and {atr_var} > 0 else 1"
-        )
-    raise CompilerError(f"unsupported sizing variant: {type(sizing).__name__}")
 
 
 # ---------------------------------------------------------------------------
@@ -779,7 +616,10 @@ def _emit_imports() -> str:
     # incompatible with the compiled per-bar call shape, so it is
     # deliberately NOT imported — helper bodies are inlined as class
     # methods instead.
-    return "import math\nfrom contract import Strategy, OrderSide, OrderType, TimeInForce\n"
+    # No ``OrderSide`` / ``OrderType`` / ``TimeInForce`` — the compiled
+    # shim emits zero ``submit_order`` calls; all orders come from the
+    # engine dispatchers.
+    return "import math\nfrom contract import Strategy\n"
 
 
 def _indent_method(body: str, spaces: int = 4) -> str:
@@ -791,25 +631,23 @@ def _emit_class(
     target_symbols: List[str],
     history_depth: int,
     warmup_min: int,
-    cross_sides: List[Tuple[str, str, str]],
     indicator_bindings: List[Tuple[str, IndicatorRef, str, str]],
-    entry_rules: List[EntryRule],
     exit_rules: List[Any],
-    sizing: Any,
     used_helper_names: List[str],
     needs_source_helper: bool,
 ) -> str:
     """Emit the ``CompiledStrategy`` class source.
 
     Pre:  inputs are produced by :func:`compile_strategy` after its
-          gating checks; ``indicator_bindings`` and ``cross_sides`` are
-          sigid-sorted.
+          gating checks; ``indicator_bindings`` are sigid-sorted.
     Post: returned source defines exactly one ``class
           CompiledStrategy(Strategy)`` with constants, ``__init__``,
           ``on_bar``, and (when needed) indicator helper methods. The
-          body shape satisfies ``CodeSafetyChecker`` (universe guard,
-          order-flow shape) and ``CodeConformanceGate`` (indicator
-          name match, sizing-math hooks).
+          ``on_bar`` is a thin shim: universe guard, warm-up gate,
+          bar-close validity, indicator binds, and a position/entry_price
+          read for conformance checks. No ``ctx.submit_order`` calls are
+          emitted — all entries and exits are handled engine-side by
+          ``_EngineEntryDispatcher`` and ``_EngineExitDispatcher``.
     """
     universe_literal = (
         "frozenset({" + ", ".join(repr(s) for s in target_symbols) + "})"
@@ -819,16 +657,7 @@ def _emit_class(
 
     init_lines: List[str] = ["    def __init__(self):"]
     init_lines.append("        super().__init__()")
-    if cross_sides:
-        # Per-symbol scope: keyed by ``bar.symbol`` so multi-symbol
-        # runs don't leak previous-bar state across tickers (which
-        # would forge false cross triggers).
-        init_lines.append("        self._cross_prev = {}")
-    else:
-        init_lines.append("        # No cross-* predicates — no prior-bar state.")
-        init_lines.append("        pass")
-
-    binding_by_sigid = {sigid: varname for varname, _ref, _call, sigid in indicator_bindings}
+    init_lines.append("        pass")
 
     on_bar_lines: List[str] = ["    def on_bar(self, ctx, bar):"]
     on_bar_lines.append("        if ctx.is_warmup:")
@@ -839,99 +668,22 @@ def _emit_class(
     on_bar_lines.append(f"        history = ctx.history(bar.symbol, {history_depth})")
     on_bar_lines.append(f"        if len(history) < {warmup_min}:")
     on_bar_lines.append("            return")
-    # Bar-close validity guard. Every sizing variant divides by
-    # ``bar.close``; a single bad tick (zero, negative, NaN, missing)
-    # would otherwise raise ``ZeroDivisionError`` or propagate
-    # non-finite values into ``submit_order`` and terminate the run.
     on_bar_lines.append(
         "        if bar.close is None or not math.isfinite(bar.close) or bar.close <= 0:"
     )
     on_bar_lines.append("            return")
-    # ``CodeConformanceGate`` requires a top-of-on_bar ``ctx.equity``
-    # reference; sizing variants that ignore equity (e.g. fixed_notional)
-    # still need it to satisfy the static sizing-math check.
-    on_bar_lines.append("        _ = ctx.equity")
     for varname, _ref, call_expr, _sigid in indicator_bindings:
         on_bar_lines.append(f"        {varname} = {call_expr}")
-    if cross_sides:
-        on_bar_lines.append("        _prev_for_symbol = self._cross_prev.get(bar.symbol, {})")
-        for sigid, prev_var, _cur in cross_sides:
-            on_bar_lines.append(f"        {prev_var} = _prev_for_symbol.get({sigid!r})")
     on_bar_lines.append("        position = ctx.position(bar.symbol)")
 
-    # ``CodeConformanceGate`` requires the class to reference
-    # ``position.entry_price`` whenever the spec contains a stop-loss
-    # or take-profit rule (runtime enforcement is engine-side). Emit
-    # a benign read so the static check passes without re-implementing
-    # the exit math.
+    # Conformance gate checks #5/#6 require ``position.entry_price``
+    # when stop-loss or take-profit rules exist.
     has_engine_handled_exit = any(isinstance(r, (StopLossRule, TakeProfitRule)) for r in exit_rules)
     if has_engine_handled_exit:
         on_bar_lines.append(
             "        _entry_ref = position.entry_price if position is not None else None"
         )
         on_bar_lines.append("        _ = _entry_ref  # engine enforces stop/take-profit thresholds")
-
-    signal_exits_in_order = [
-        (idx, r) for idx, r in enumerate(exit_rules) if isinstance(r, SignalExitRule)
-    ]
-    if signal_exits_in_order:
-        # Per-bar guard: multiple signal-exit predicates firing on the
-        # same candle emit one close order, not several.
-        on_bar_lines.append("        exit_submitted = False")
-    for exit_idx, rule in signal_exits_in_order:
-        pred_src = _render_predicate(rule.when, binding_by_sigid, cross_sides)
-        exit_reason = f"compiled_signal_exit:exit[{exit_idx}]"
-        on_bar_lines.append(
-            f"        if not exit_submitted and position is not None and {pred_src}:"
-        )
-        on_bar_lines.append(
-            "            exit_side = OrderSide.SHORT if position.side == OrderSide.LONG "
-            "else OrderSide.LONG"
-        )
-        on_bar_lines.append("            ctx.submit_order(")
-        on_bar_lines.append("                symbol=bar.symbol,")
-        on_bar_lines.append("                side=exit_side,")
-        on_bar_lines.append("                qty=position.qty,")
-        on_bar_lines.append("                order_type=OrderType.MARKET,")
-        on_bar_lines.append("                tif=TimeInForce.DAY,")
-        on_bar_lines.append(f'                reason="{exit_reason}",')
-        on_bar_lines.append("            )")
-        on_bar_lines.append("            exit_submitted = True")
-
-    if entry_rules:
-        # Per-bar guard: short-circuits multi-entry-rule specs so two
-        # predicates true on the same bar don't double-up entry orders.
-        on_bar_lines.append("        entry_submitted = False")
-    # Entry calls carry no bracket attachments. Bracket prices derived
-    # from signal-bar close are wrong on gap opens (market orders fill
-    # on the next bar's open), and a static StopAttachment silently
-    # downgrades trailing-basis stop-losses. The engine's
-    # ``_EngineExitDispatcher`` enforces every stop/take rule with the
-    # correct basis against the post-fill ``position.entry_price``.
-    for idx, rule in enumerate(entry_rules):
-        pred_src = _render_predicate(rule.when, binding_by_sigid, cross_sides)
-        side_literal = "OrderSide.LONG" if rule.side == "long" else "OrderSide.SHORT"
-        sizing_stmt = _render_sizing(sizing, indicator_bindings)
-        rule_reason = f"compiled_entry:entry[{idx}]"
-        on_bar_lines.append(f"        if not entry_submitted and position is None and {pred_src}:")
-        on_bar_lines.append(f"            {sizing_stmt}")
-        on_bar_lines.append("            ctx.submit_order(")
-        on_bar_lines.append("                symbol=bar.symbol,")
-        on_bar_lines.append(f"                side={side_literal},")
-        on_bar_lines.append("                qty=qty,")
-        on_bar_lines.append("                order_type=OrderType.MARKET,")
-        on_bar_lines.append("                tif=TimeInForce.DAY,")
-        on_bar_lines.append(f'                reason="{rule_reason}",')
-        on_bar_lines.append("            )")
-        on_bar_lines.append("            entry_submitted = True")
-
-    # Cross-state update MUST come after all branches so the current
-    # bar's value is preserved for the next ``on_bar`` invocation on
-    # this symbol.
-    if cross_sides:
-        on_bar_lines.append("        _new_prev = self._cross_prev.setdefault(bar.symbol, {})")
-        for sigid, _prev_var, current_expr in cross_sides:
-            on_bar_lines.append(f"        _new_prev[{sigid!r}] = {current_expr}")
 
     helper_method_blocks: List[str] = []
     if needs_source_helper:

--- a/backend/agents/investment_team/tests/test_code_conformance_gate.py
+++ b/backend/agents/investment_team/tests/test_code_conformance_gate.py
@@ -283,12 +283,15 @@ def test_entry_coverage_passes_when_entry_branch_present() -> None:
 
 def test_entry_coverage_fails_when_entry_submit_order_dropped() -> None:
     """Mandatory acceptance test from the issue: drop the entry
-    submit_order from a working strategy → critical failure on check #3."""
+    submit_order from a working strategy → critical failure on check #3.
+    Uses requires_custom_code=True so the gate applies (engine-managed
+    specs skip check #3)."""
     code = _HAPPY_CODE.replace(
         'ctx.submit_order(symbol=bar.symbol, qty=qty, side="LONG")',
         "pass  # entry submit_order removed",
     )
-    results = CodeConformanceGate().check(code, _happy_spec())
+    spec = _happy_spec().model_copy(update={"requires_custom_code": True})
+    results = CodeConformanceGate().check(code, spec)
     crits = _critical_details(results)
     assert any("entry rule" in c.lower() for c in crits), crits
 
@@ -327,6 +330,7 @@ def test_entry_coverage_ignores_unreachable_helper_branches() -> None:
         exit_rules=[StopLossRule(pct=0.05)],
         target_symbols=["QQQ"],
     )
+    spec = spec.model_copy(update={"requires_custom_code": True})
     results = CodeConformanceGate().check(code, spec)
     crits = _critical_details(results)
     assert any("entry rule" in c.lower() and "reachable" in c.lower() for c in crits), crits
@@ -343,9 +347,8 @@ def test_signal_exit_coverage_passes_with_position_qty_close() -> None:
 
 
 def test_signal_exit_coverage_fails_when_no_position_qty_close() -> None:
-    # Spec declares a signal-exit but the code only closes via stop-loss
-    # (qty=pos.qty kept, but every exit happens in the stop-loss branch
-    # — fine in isolation, but we drop the rsi branch entirely).
+    # Spec declares a signal-exit but the code only closes via stop-loss.
+    # Uses requires_custom_code=True so the gate applies.
     code = textwrap.dedent(
         """
         from contract import Strategy
@@ -365,8 +368,6 @@ def test_signal_exit_coverage_fails_when_no_position_qty_close() -> None:
                 if pos is None and fast > slow:
                     ctx.submit_order(symbol=bar.symbol, qty=qty, side="LONG")
                 elif pos is not None and bar.close < pos.entry_price * 0.95:
-                    # Closes via a constant qty instead of pos.qty — does
-                    # not satisfy the signal-exit shape.
                     ctx.submit_order(symbol=bar.symbol, qty=1, side="SHORT")
         """
     )
@@ -375,6 +376,7 @@ def test_signal_exit_coverage_fails_when_no_position_qty_close() -> None:
         exit_rules=[_rsi_signal_exit(), StopLossRule(pct=0.05)],
         target_symbols=["QQQ"],
     )
+    spec = spec.model_copy(update={"requires_custom_code": True})
     results = CodeConformanceGate().check(code, spec)
     crits = _critical_details(results)
     assert any("signal-exit" in c.lower() for c in crits), crits
@@ -753,6 +755,7 @@ def test_branch_coverage_does_not_double_count_nested_branches() -> None:
         exit_rules=[StopLossRule(pct=0.05)],
         target_symbols=["QQQ"],
     )
+    spec = spec.model_copy(update={"requires_custom_code": True})
     results = CodeConformanceGate().check(code, spec)
     crits = _critical_details(results)
     assert any("2 entry rule" in c and "only 1" in c for c in crits), crits

--- a/backend/agents/investment_team/tests/test_strategy_compiler.py
+++ b/backend/agents/investment_team/tests/test_strategy_compiler.py
@@ -104,8 +104,8 @@ def test_entry_only_rsi() -> None:
     spec = _spec(entry_rules=[_rsi_lt_30_entry()])
     code = compile_strategy(spec)
     assert "_ind_rsi_" in code
-    assert "OrderSide.LONG" in code
-    assert "ctx.submit_order" in code
+    assert "ctx.submit_order" not in code
+    assert "OrderSide" not in code
     assert _strategy_subclass_count(code) == 1
 
 
@@ -115,8 +115,7 @@ def test_signal_exit_only() -> None:
         exit_rules=[_rsi_gt_70_exit()],
     )
     code = compile_strategy(spec)
-    assert "qty=position.qty" in code
-    assert code.count("ctx.submit_order") == 2  # one entry, one signal exit
+    assert "ctx.submit_order" not in code
 
 
 def test_stop_loss_present_no_inline_or_bracket() -> None:
@@ -174,24 +173,24 @@ def test_trailing_stop_loss_compiles_without_inline_emission() -> None:
 
 
 def test_fixed_fraction_sizing() -> None:
+    """Sizing is engine-managed — compiled code does NOT inline qty math."""
     spec = _spec(
         entry_rules=[_rsi_lt_30_entry()],
         sizing=FixedFractionSizing(fraction=0.05),
     )
     code = compile_strategy(spec)
-    assert "ctx.equity * 0.05" in code
-    assert "max(1, int(" in code
+    assert "ctx.submit_order" not in code
+    assert _strategy_subclass_count(code) == 1
 
 
 def test_fixed_notional_sizing() -> None:
+    """Sizing is engine-managed — compiled code does NOT inline qty math."""
     spec = _spec(
         entry_rules=[_rsi_lt_30_entry()],
         sizing=FixedNotionalSizing(notional_usd=10_000.0),
     )
     code = compile_strategy(spec)
-    assert "10000.0 / bar.close" in code
-    # Sizing gate also requires *somewhere* in the class to read ctx.equity.
-    assert "ctx.equity" in code
+    assert "ctx.submit_order" not in code
 
 
 def test_volatility_target_with_atr() -> None:
@@ -209,7 +208,7 @@ def test_volatility_target_with_atr() -> None:
     )
     code = compile_strategy(spec)
     assert "_ind_atr_" in code
-    assert "ctx.equity * 0.2" in code
+    assert "ctx.submit_order" not in code
 
 
 def test_volatility_target_without_atr_raises_compiler_error() -> None:
@@ -249,15 +248,16 @@ def test_multi_rule_full_spec() -> None:
     )
     code = compile_strategy(spec)
     assert _strategy_subclass_count(code) == 1
-    assert "self._cross_prev" in code  # per-symbol cross_* state dict present
+    assert "ctx.submit_order" not in code
     assert "position.entry_price" in code  # stop/take-profit gate compliance
 
 
-def test_cross_above_emits_per_symbol_prev_state() -> None:
-    """Cross state must be keyed by ``bar.symbol``.
+def test_cross_above_no_inline_state() -> None:
+    """Cross predicates are evaluated engine-side by the predicate evaluator.
 
-    Otherwise a multi-symbol run would compare this bar's value against
-    a different symbol's previous bar and forge false cross triggers.
+    The compiled code no longer maintains ``_cross_prev`` state — the
+    engine's ``StreamingHistoryView`` handles cross semantics via
+    ``i`` vs ``i-1`` bar indices.
     """
     entry = EntryRule(
         side="long",
@@ -269,23 +269,9 @@ def test_cross_above_emits_per_symbol_prev_state() -> None:
     )
     spec = _spec(entry_rules=[entry])
     code = compile_strategy(spec)
-    # __init__ creates the per-symbol dict.
-    tree = ast.parse(code)
-    init_methods = [
-        n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == "__init__"
-    ]
-    assert init_methods, "compiled class must define __init__ for cross-state"
-    cross_prev_assignments = [
-        node
-        for method in init_methods
-        for node in ast.walk(method)
-        if isinstance(node, ast.Assign)
-        and any(isinstance(t, ast.Attribute) and t.attr == "_cross_prev" for t in node.targets)
-    ]
-    assert len(cross_prev_assignments) == 1, "expected `self._cross_prev = {}` in __init__"
-    # on_bar reads the per-symbol slice and writes back.
-    assert "self._cross_prev.get(bar.symbol" in code
-    assert "self._cross_prev.setdefault(bar.symbol" in code
+    assert "_cross_prev" not in code
+    assert "ctx.submit_order" not in code
+    assert "_ind_ema_" in code
 
 
 # ---------------------------------------------------------------------------
@@ -684,20 +670,19 @@ def test_stop_and_take_profit_do_not_emit_inline_exits() -> None:
     assert ctx.orders == [], "stop/take-profit closes should come from the engine, not the strategy"
 
 
-def test_entry_only_with_no_exits_is_pre_safety_gate_concern() -> None:
-    """Entry-only specs are valid input to the compiler; the safety
-    gate is what rejects them (no exit path). This test pins that
-    expectation so the compiler doesn't grow a silent reject.
+def test_entry_only_with_no_exits_safety_gate_rejects() -> None:
+    """Entry-only specs with no exit rules: safety gate rejects because
+    neither the strategy nor the engine has an exit path. The compiled
+    code has zero submit_order calls (engine-managed entries), but the
+    engine needs at least one exit rule to close positions.
     """
-    spec = _spec(entry_rules=[_rsi_lt_30_entry()])
+    spec = _spec(entry_rules=[_rsi_lt_30_entry()], exit_rules=[])
     code = compile_strategy(spec)
-    # Compilation succeeds — module is valid Python.
     ns, *_ = _exec_module(code)
     assert "CompiledStrategy" in ns
-    # But CodeSafetyChecker rejects because there's no exit submit_order.
     safety = CodeSafetyChecker().check(code, spec)
     criticals = _critical_details(safety)
-    assert any("exit" in c.lower() for c in criticals), criticals
+    assert any("submit_order" in c.lower() or "exit" in c.lower() for c in criticals), criticals
 
 
 def test_no_indicators_import_in_emitted_code() -> None:
@@ -778,9 +763,9 @@ def test_macd_helper_defensive_fast_slow_returns_none() -> None:
     assert strat.macd(bars, fast=30, slow=10, signal=9) is None
 
 
-def test_cross_state_isolated_per_symbol() -> None:
-    """Run on_bar for two different symbols and verify the second
-    symbol's first bar doesn't pick up the first symbol's prev value.
+def test_cross_predicates_no_inline_state() -> None:
+    """Cross predicates are fully engine-managed. The compiled code no
+    longer maintains ``_cross_prev`` state.
     """
     entry = EntryRule(
         side="long",
@@ -792,34 +777,20 @@ def test_cross_state_isolated_per_symbol() -> None:
     )
     spec = _spec(
         entry_rules=[entry],
-        # Two-symbol universe so the universe guard accepts both.
         target_symbols=["AAA", "BBB"],
     )
     code = compile_strategy(spec)
+    assert "_cross_prev" not in code
+    assert "ctx.submit_order" not in code
     ns, *_ = _exec_module(code)
     strat = ns["CompiledStrategy"]()
-
-    # Symbol A: descending closes — fast SMA below slow SMA on the
-    # latest bar. After on_bar, A's _cross_prev has its own values.
-    bars_a = [_SyntheticBar(symbol="AAA", close=100.0 - i) for i in range(30)]
-    ctx = _SyntheticContext(history=bars_a)
-    strat.on_bar(ctx, bars_a[-1])
-    # Symbol B's first bar should not see symbol A's previous values.
-    assert "AAA" in strat._cross_prev
-    assert "BBB" not in strat._cross_prev
-
-    bars_b = [_SyntheticBar(symbol="BBB", close=100.0 + i) for i in range(30)]
-    ctx_b = _SyntheticContext(history=bars_b)
-    strat.on_bar(ctx_b, bars_b[-1])
-    # Now both symbols have their own slots — no overlap.
-    assert "BBB" in strat._cross_prev
-    assert strat._cross_prev["AAA"] != strat._cross_prev["BBB"]
+    assert not hasattr(strat, "_cross_prev")
 
 
-def test_multiple_entry_rules_one_bar_emits_one_entry() -> None:
-    """Two entry predicates true on the same bar must emit one entry, not two."""
-    # Two entry rules; both will fire on a flat-history bar because
-    # each predicate threshold is generous.
+def test_multiple_entry_rules_no_inline_orders() -> None:
+    """Multi-entry specs compile to a thin shim with zero submit_order calls.
+    Entry dedup is handled by the engine's _EngineEntryDispatcher.
+    """
     rule_a = EntryRule(
         side="long",
         when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op="<", rhs=99.0),
@@ -830,14 +801,8 @@ def test_multiple_entry_rules_one_bar_emits_one_entry() -> None:
     )
     spec = _spec(entry_rules=[rule_a, rule_b])
     code = compile_strategy(spec)
-    assert "entry_submitted" in code
-    ns, _OrderSide, *_ = _exec_module(code)
-    strat = ns["CompiledStrategy"]()
-    history = [_SyntheticBar(close=100.0) for _ in range(25)]
-    ctx = _SyntheticContext(history=history, position=None)
-    strat.on_bar(ctx, history[-1])
-    # Exactly ONE entry submission, not two.
-    assert len(ctx.orders) == 1, ctx.orders
+    assert "entry_submitted" not in code
+    assert "ctx.submit_order" not in code
 
 
 def test_spec_hash_ignores_non_dsl_fields() -> None:
@@ -861,12 +826,12 @@ def test_spec_hash_ignores_non_dsl_fields() -> None:
     )
 
 
-def test_exit_rules_emitted_in_author_order() -> None:
-    """Multiple signal-exit rules are emitted in author-declared order.
+def test_signal_exit_rules_not_inlined() -> None:
+    """Signal-exit rules are engine-enforced via _EngineExitDispatcher.
 
-    Stop-loss and take-profit are engine-enforced and not inlined;
-    only signal-exit rules appear in the emitted ``on_bar``. They
-    must execute in spec order, guarded by ``exit_submitted``.
+    The compiled code does NOT inline signal-exit predicate checks or
+    submit_order calls. The engine evaluates SignalExitRule predicates
+    deterministically using the shared predicate_evaluator.
     """
     spec = _spec(
         entry_rules=[_rsi_lt_30_entry()],
@@ -890,13 +855,9 @@ def test_exit_rules_emitted_in_author_order() -> None:
         ],
     )
     code = compile_strategy(spec)
-    # Both signal-exit branches emit ``compiled_signal_exit`` reasons.
-    # The first branch's predicate (rsi > 70) must appear before the
-    # second's (bar.close > 200) in the emitted source.
-    rsi_pred_pos = code.find("> 70.0")
-    bar_pred_pos = code.find("bar.close > 200.0")
-    assert rsi_pred_pos != -1 and bar_pred_pos != -1
-    assert rsi_pred_pos < bar_pred_pos
+    assert "compiled_signal_exit" not in code
+    assert "exit_submitted" not in code
+    assert "ctx.submit_order" not in code
 
 
 def test_compiled_code_flows_into_orchestrator_local_variable() -> None:
@@ -1201,9 +1162,9 @@ def test_volatility_target_with_single_atr_period_used_twice_compiles() -> None:
 def test_no_inline_or_bracket_engine_exits_when_stop_loss_present() -> None:
     """Stop-loss / take-profit emit no inline close and no bracket leg.
 
-    Bracket prices computed at signal time are wrong on gap opens
-    (market orders fill on the next bar's open). The engine uses the
-    post-fill ``position.entry_price``.
+    The compiled code is a pure indicator shim — zero submit_order
+    calls. Engine's evaluate_exit_rules handles stop/take-profit;
+    engine's _EngineEntryDispatcher handles entries.
     """
     spec = _spec(
         entry_rules=[_rsi_lt_30_entry()],
@@ -1212,9 +1173,7 @@ def test_no_inline_or_bracket_engine_exits_when_stop_loss_present() -> None:
     code = compile_strategy(spec)
     assert 'reason="compiled_stop_loss"' not in code
     assert 'reason="compiled_take_profit"' not in code
-    # The ONLY strategy-emitted submit_order is the entry — no bracket
-    # legs, no inline closes. Engine's evaluate_exit_rules handles both.
-    assert code.count("ctx.submit_order") == 1
+    assert code.count("ctx.submit_order") == 0
     assert "attached_stop_loss" not in code
     assert "attached_take_profit" not in code
     assert "StopAttachment" not in code
@@ -1251,14 +1210,16 @@ def test_safety_gate_accepts_entries_only_when_spec_has_stop_loss() -> None:
 
 
 def test_safety_gate_rejects_entries_only_without_engine_handled_exit() -> None:
-    """Sanity check: an entry-only spec with no engine-handled exit
-    rules (and no signal_exit) must still fail the safety gate.
+    """Spec with entry rules but no exit rules: safety gate rejects because
+    the spec is NOT fully engine-managed (no exit rules). The compiled code
+    has zero submit_order calls but with no exit rules, the engine can't
+    close positions, so the gate fires.
     """
     spec = _spec(entry_rules=[_rsi_lt_30_entry()], exit_rules=[])
     code = compile_strategy(spec)
     results = CodeSafetyChecker().check(code, spec)
     criticals = _critical_details(results)
-    assert any("exit" in c.lower() for c in criticals), criticals
+    assert criticals, "expected at least one critical for entry-only spec with no exits"
 
 
 def test_requires_custom_code_defensive_on_malformed_string() -> None:

--- a/backend/agents/investment_team/trading_service/modes/backtest.py
+++ b/backend/agents/investment_team/trading_service/modes/backtest.py
@@ -185,6 +185,7 @@ def run_backtest(
             exit_rules=list(strategy.exit_rules),
             entry_rules=list(strategy.entry_rules) if not strategy.requires_custom_code else None,
             sizing=strategy.sizing if not strategy.requires_custom_code else None,
+            target_symbols=list(strategy.target_symbols) if not strategy.requires_custom_code else None,
         )
         outcome = service.run(stream)
         run_metrics = compute_metrics(

--- a/backend/agents/investment_team/trading_service/modes/paper_trade.py
+++ b/backend/agents/investment_team/trading_service/modes/paper_trade.py
@@ -245,6 +245,7 @@ def run_paper_trade(
         # handle entries in the strategy subprocess.
         entry_rules=list(strategy.entry_rules) if not strategy.requires_custom_code else None,
         sizing=strategy.sizing if not strategy.requires_custom_code else None,
+        target_symbols=list(strategy.target_symbols) if not strategy.requires_custom_code else None,
     )
 
     # First attempt: primary provider.

--- a/backend/agents/investment_team/trading_service/modes/paper_trade.py
+++ b/backend/agents/investment_team/trading_service/modes/paper_trade.py
@@ -239,6 +239,12 @@ def run_paper_trade(
         # leak open positions when ``strategy_code`` is purely entry-driven.
         # Empty list is a no-op.
         exit_rules=list(strategy.exit_rules),
+        # Engine-managed entries: for non-custom specs, the compiled code
+        # emits zero submit_order calls — _EngineEntryDispatcher evaluates
+        # entry predicates deterministically. Custom-code specs continue to
+        # handle entries in the strategy subprocess.
+        entry_rules=list(strategy.entry_rules) if not strategy.requires_custom_code else None,
+        sizing=strategy.sizing if not strategy.requires_custom_code else None,
     )
 
     # First attempt: primary provider.

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -529,6 +529,7 @@ class _EngineEntryDispatcher:
     entry_rules: Sequence[EntryRule]
     sizing: Any
     exit_rules: Sequence[Any] = ()
+    target_symbols: frozenset[str] = frozenset()
     _next_seq: int = 0
 
     def maybe_emit(
@@ -541,6 +542,8 @@ class _EngineEntryDispatcher:
         result: "TradingServiceResult",
     ) -> None:
         if not self.entry_rules or self.sizing is None:
+            return
+        if self.target_symbols and cur_bar.symbol not in self.target_symbols:
             return
         sym = cur_bar.symbol
         if portfolio.positions.get(sym) is not None:
@@ -1002,6 +1005,7 @@ class TradingService:
         exit_rules: Optional[List[ExitRule]] = None,
         entry_rules: Optional[List[EntryRule]] = None,
         sizing: Optional[Any] = None,
+        target_symbols: Optional[List[str]] = None,
     ) -> None:
         self.strategy_code = strategy_code
         self.config = config
@@ -1024,6 +1028,7 @@ class TradingService:
         self._exit_rules: List[ExitRule] = list(exit_rules or [])
         self._entry_rules: List[EntryRule] = list(entry_rules or [])
         self._sizing = sizing
+        self._target_symbols: frozenset[str] = frozenset(target_symbols or ())
         # Issue #377: when set, overrides ``BAR_CHUNK_SIZE`` env. Paper-trade
         # mode pins this to 1 so live-bar handling never buffers. Reject
         # zero/negative or non-int explicitly so a future caller passing
@@ -1071,6 +1076,7 @@ class TradingService:
             entry_rules=self._entry_rules,
             sizing=self._sizing,
             exit_rules=self._exit_rules,
+            target_symbols=self._target_symbols,
         )
         execution_model = build_execution_model(
             self.config.execution_model,

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -528,6 +528,7 @@ class _EngineEntryDispatcher:
 
     entry_rules: Sequence[EntryRule]
     sizing: Any
+    exit_rules: Sequence[Any] = ()
     _next_seq: int = 0
 
     def maybe_emit(
@@ -621,16 +622,23 @@ class _EngineEntryDispatcher:
         return 1
 
     def _find_atr_ref(self):
-        """Find an ATR IndicatorRef from the spec's entry rules.
+        """Find an ATR IndicatorRef from the spec's entry or exit rules.
 
-        Scans entry-rule predicates for an ATR indicator and returns it
-        so vol-target sizing uses the spec's configured period.  Falls
-        back to the default ATR(14) when no ATR appears in the rules.
+        Scans entry-rule predicates first, then signal-exit predicates,
+        and returns the first ATR indicator so vol-target sizing uses the
+        spec's configured period. Falls back to default ATR(14) when no
+        ATR appears in any rule.
         """
-        from ..strategy_lab.spec_dsl import IndicatorRef
+        from ..strategy_lab.spec_dsl import IndicatorRef, SignalExitRule
 
         for rule in self.entry_rules:
             if not isinstance(rule, EntryRule):
+                continue
+            for side in (rule.when.lhs, rule.when.rhs):
+                if isinstance(side, IndicatorRef) and side.name == "atr":
+                    return side
+        for rule in self.exit_rules:
+            if not isinstance(rule, SignalExitRule):
                 continue
             for side in (rule.when.lhs, rule.when.rhs):
                 if isinstance(side, IndicatorRef) and side.name == "atr":
@@ -1062,6 +1070,7 @@ class TradingService:
         engine_entries = _EngineEntryDispatcher(
             entry_rules=self._entry_rules,
             sizing=self._sizing,
+            exit_rules=self._exit_rules,
         )
         execution_model = build_execution_model(
             self.config.execution_model,

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -373,7 +373,11 @@ class _EngineExitDispatcher:
             qty=pos.qty + scale_in_qty,
             order_type=OrderType.MARKET,
             tif=TimeInForce.DAY,
-            reason=f"{ENGINE_EXIT_REASON_PREFIX}{intent.rule_kind}",
+            reason=(
+                f"{ENGINE_EXIT_REASON_PREFIX}{intent.rule_kind}[{intent.rule_index}]"
+                if intent.rule_kind == "signal_exit"
+                else f"{ENGINE_EXIT_REASON_PREFIX}{intent.rule_kind}"
+            ),
         )
         try:
             req.validate_prices()


### PR DESCRIPTION
## Summary

- **Compiler rewrite**: The deterministic compiler (`synthesis/compiler.py`) no longer emits entry predicates, signal-exit predicates, cross-state tracking, or sizing math in the generated `on_bar`. The compiled code is now a thin shim: universe guard, warmup check, indicator computation, and a `position.entry_price` read for conformance checks. Zero `ctx.submit_order` calls are emitted — all entry/exit orders come from the engine's `_EngineEntryDispatcher` and `_EngineExitDispatcher`, which evaluate predicates deterministically via the shared `predicate_evaluator` module.

- **Quality gate updates**: `CodeConformanceGate` checks #3/#4/#8 skip for engine-managed specs (`requires_custom_code=False` with entry rules), still enforce for custom-code specs. `CodeSafetyChecker` now includes `SignalExitRule` in engine-handled exit detection and accepts zero `submit_order` calls for fully engine-managed specs. `ExitRuleConformanceGate` replaces the "not yet engine-enforced" placeholder with actual `SignalExitRule` conformance checking.

- **Dead code removed**: `_render_predicate`, `_render_side`, `_collect_cross_sides`, `_render_sizing`, `_BAR_FIELD_EXPR` removed from the compiler. Emitted imports reduced to just `Strategy` (no `OrderSide`/`OrderType`/`TimeInForce`). Net -212 lines.

## Test plan

- [x] All 72 compiler tests pass (`test_strategy_compiler.py`)
- [x] All 34 conformance gate tests pass (`test_code_conformance_gate.py`)
- [x] All 75 safety gate tests pass (`test_code_safety.py`)
- [x] All 88 engine/rule/predicate tests pass (rule_compiler, predicate_evaluator, engine_entry_dispatch, engine_exit_helpers, engine_exit_enforcement)
- [x] All 46 alignment check tests pass (`test_alignment_checks.py`)
- [x] 348 total tests pass across the core strategy-lab test suite
- [x] Ruff lint passes on all modified files
- [ ] CI pipeline green

Closes #654

https://claude.ai/code/session_01CUvNSeBUHwDbcYhuwevgav

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUvNSeBUHwDbcYhuwevgav)_