### PR TITLE
Fix Strategy Lab ticker canonicalization crash on compound provider suffixes

### DIFF
--- a/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
@@ -175,14 +175,23 @@ def _canonicalize_ticker(symbol: str) -> str:
     # ``-USD`` strip, a hypothesis that names ``BTC`` would false-critical
     # against a correctly populated ``target_symbols=["BTC-USD"]`` in
     # Rule 1's set-membership check.
+    #
+    # Suffixes are stripped iteratively so a compound input like ``BTC-USD-USD``
+    # (an LLM hallucination, double-normalization, or operator typo) reduces to
+    # ``BTC`` rather than leaving a residual suffix. The loop is bounded by the
+    # string length and terminates because every iteration shortens ``s``. This
+    # keeps the post-condition a true invariant — and the canonical form correct
+    # even when assertions are stripped under ``python -O``.
     # Post: returns an upper-cased string with no `=F` / `=X` / `-USD` suffix.
     assert isinstance(symbol, str), "symbol must be a str"
     s = symbol.upper()
-    for suffix in ("=F", "=X", "-USD"):
-        if s.endswith(suffix):
-            s = s[: -len(suffix)]
-            break
-    assert not s.endswith(("=F", "=X", "-USD")), "canonical form must not retain a provider suffix"
+    suffixes = ("=F", "=X", "-USD")
+    while s.endswith(suffixes):
+        for suffix in suffixes:
+            if s.endswith(suffix):
+                s = s[: -len(suffix)]
+                break
+    assert not s.endswith(suffixes), "canonical form must not retain a provider suffix"
     return s
 
 

--- a/backend/agents/investment_team/tests/test_spec_readiness.py
+++ b/backend/agents/investment_team/tests/test_spec_readiness.py
@@ -13,6 +13,7 @@ from investment_team.models import BacktestConfig, StrategySpec
 from investment_team.strategy_lab.quality_gates.spec_readiness import (
     GATE,
     SpecReadinessGate,
+    _canonicalize_ticker,
 )
 from investment_team.strategy_lab.spec_dsl import (
     EntryRule,
@@ -200,6 +201,44 @@ def test_rule1_canonicalizes_multiple_crypto_against_usd_suffix() -> None:
         c for c in _critical(results) if "target_symbols" in c or "Hypothesis names symbol" in c
     ]
     assert not rule1_failures, rule1_failures
+
+
+def test_canonicalize_ticker_single_suffixes() -> None:
+    """Single provider suffixes strip to the bare, upper-cased symbol."""
+    assert _canonicalize_ticker("ES=F") == "ES"
+    assert _canonicalize_ticker("EURUSD=X") == "EURUSD"
+    assert _canonicalize_ticker("BTC-USD") == "BTC"
+    assert _canonicalize_ticker("aapl") == "AAPL"
+    assert _canonicalize_ticker("AAPL") == "AAPL"
+
+
+def test_canonicalize_ticker_compound_suffix_does_not_crash() -> None:
+    """Compound suffixes strip iteratively instead of raising AssertionError.
+
+    A double-quoted crypto ticker like ``BTC-USD-USD`` (LLM hallucination,
+    double-normalization, or operator typo) must reduce to the bare symbol
+    rather than leaving a residual suffix that trips the post-condition.
+    """
+    assert _canonicalize_ticker("BTC-USD-USD") == "BTC"
+    assert _canonicalize_ticker("ETH-USD-USD") == "ETH"
+    # Mixed compound suffixes also fully strip.
+    assert _canonicalize_ticker("EURUSD=X=X") == "EURUSD"
+
+
+def test_rule1_compound_suffix_target_symbol_does_not_crash() -> None:
+    """A compound-suffix target symbol yields gate results, never a crash.
+
+    Before the fix, ``_canonicalize_ticker`` raised an ``AssertionError`` for
+    ``BTC-USD-USD`` that propagated out of ``validate()`` and crashed the entire
+    gate run. The gate must instead produce ordinary results.
+    """
+    spec = _spec(
+        hypothesis="BTC momentum after a volatility-contraction regime.",
+        target_symbols=["BTC-USD-USD"],
+        asset_class="crypto",
+    )
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    assert results, "gate must return results rather than raising"
 
 
 def test_rule1_passes_when_no_symbols_in_hypothesis_and_no_targets() -> None:


### PR DESCRIPTION
## Problem

`_canonicalize_ticker` in `SpecReadinessGate` stripped a **single** provider
suffix (`=F` / `=X` / `-USD`) and `break`d, then asserted no suffix remained. A
compound input like `BTC-USD-USD` (LLM hallucination, double-normalization, or
operator typo) stripped one `-USD`, leaving `BTC-USD`, so the post-condition
assert fired. None of the six call sites (all in `_check_universe_set`) catch
the exception, so the `AssertionError` propagated out of
`SpecReadinessGate.validate()` into the orchestrator and **crashed the entire
gate run** instead of producing a clean Rule 1 critical. Under `python -O` the
assert is stripped, so a malformed symbol would instead silently slip
downstream.

## Fix

Strip suffixes iteratively in a length-bounded `while` loop so the canonical
form is correct for any string input. This makes the existing post-condition a
true invariant rather than a reachable crash, and is correct even when
assertions are disabled under `python -O`. No caller changes are needed — every
call site already consumes the canonical string.

## Tests

- Direct unit coverage of `_canonicalize_ticker` for single suffixes, compound
  suffixes (`BTC-USD-USD` → `BTC`, `EURUSD=X=X` → `EURUSD`), case-folding, and
  no-suffix passthrough.
- End-to-end test that `SpecReadinessGate().validate(...)` returns results
  rather than raising for a spec whose `target_symbols` contains a
  compound-suffix ticker.

Verified passing under both normal and `python -O` (assertions-stripped) runs;
`ruff check` and `ruff format --check` clean. (The 3 unrelated
`test_orchestrator_wires_readiness_price_provider`-style failures in this file
are pre-existing in the sandbox — they fail to import the optional `strands`
package and are independent of this change.)

Closes #672


---
_Generated by [Claude Code](https://claude.ai/code/session_015b86uipFCVTrBGr5tzFAfG)_