### PR TITLE
Strategy Lab: build a fresh design Agent per parse-retry attempt

### DIFF
--- a/backend/agents/investment_team/strategy_lab/agents/design.py
+++ b/backend/agents/investment_team/strategy_lab/agents/design.py
@@ -232,16 +232,26 @@ class DesignAgent:
         literal in an IndicatorRef, or naming an indicator in ``source``).
         Budget is set by ``STRATEGY_LAB_DESIGN_PARSE_RETRIES`` (default 2
         retries → 3 attempts total; ``0`` disables retry).
+
+        Each attempt builds a fresh ``Agent``: the correction re-prompt must
+        be read as "reissue the whole object correctly given this guidance",
+        not "fix what you just emitted". ``strands.Agent`` accumulates
+        conversation history in ``self.messages``, so reusing one instance
+        would feed the model its own rejected JSON back as context and bias
+        it toward defending the malformed shape it just produced.
         """
         retries = _design_parse_retries()
-        agent = Agent(
-            model=get_strands_model("strategy_design"),
-            system_prompt=system_prompt,
-            tools=[],
-        )
 
         prompt = user_prompt
         for attempt in range(retries + 1):
+            # A history-free agent per attempt (see method docstring). Strands
+            # Agent construction is cheap — no I/O, just env reads + object
+            # init via get_strands_model — so building one per attempt is safe.
+            agent = Agent(
+                model=get_strands_model("strategy_design"),
+                system_prompt=system_prompt,
+                tools=[],
+            )
             # Charge before the call so the cycle stops *before* exceeding
             # the per-cycle budget. Each parse-retry is a real LLM call and
             # so counts individually.

--- a/backend/agents/investment_team/tests/test_strategy_lab_design_agent.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_design_agent.py
@@ -552,6 +552,55 @@ def test_revise_also_retries_on_parse_error(monkeypatch: pytest.MonkeyPatch) -> 
     assert parsed["asset_class"] == "stocks"
 
 
+def test_parse_retry_builds_fresh_agent_per_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each parse-retry attempt must use a freshly constructed, history-free
+    agent — never one instance reused across attempts.
+
+    ``strands.Agent`` accumulates conversation history in ``self.messages``;
+    reusing one instance would feed the model its own rejected JSON back as
+    context on the correction re-prompt, biasing it toward defending the
+    malformed shape. We assert (a) the factory is invoked once per LLM call
+    and (b) every constructed agent saw exactly one prompt (no cross-attempt
+    carryover).
+    """
+    monkeypatch.delenv("STRATEGY_LAB_DESIGN_PARSE_RETRIES", raising=False)
+
+    payloads = [_bar_close_as_indicator_ref_payload(), _good_payload()]
+    built: List[_CapturingAgent] = []
+
+    def _factory(**_kwargs: Any) -> _CapturingAgent:
+        # Hand each freshly constructed agent the single payload it is
+        # expected to emit, by construction order, so attempt 1 slips the
+        # DSL and attempt 2 recovers.
+        idx = min(len(built), len(payloads) - 1)
+        agent = _CapturingAgent(payloads[idx])
+        built.append(agent)
+        return agent
+
+    monkeypatch.setattr(
+        "investment_team.strategy_lab.agents.design.Agent",
+        _factory,
+    )
+    monkeypatch.setattr(
+        "investment_team.strategy_lab.agents.design.get_strands_model",
+        lambda role: object(),
+    )
+    monkeypatch.setenv("STRATEGY_LAB_DESIGN_SELF_REVIEW_ENABLED", "false")
+
+    parsed, _ = DesignAgent().run(prior_records=[])
+
+    assert parsed["asset_class"] == "stocks"
+    # One construction per attempt (here: initial slip + one recovery).
+    assert len(built) == 2
+    # No conversation carryover: each agent fielded exactly one prompt.
+    assert all(len(agent.calls) == 1 for agent in built)
+    # The recovery agent — not the slipping one — saw the correction context.
+    assert "bar.close" in built[1].calls[0]
+    assert "entry_rules[0]" in built[1].calls[0]
+
+
 # ---------------------------------------------------------------------------
 # Self-review pass — catch prose↔predicate + risk-math contradictions
 # inside DesignAgent before they reach the external review loop.


### PR DESCRIPTION
## Problem

`DesignAgent._invoke_and_parse` constructed a single `strands.Agent` **outside** the parse-retry loop and reused it across every attempt. `strands.Agent` accumulates conversation history in `self.messages`, appending each call's prompt and response. So on a correction re-prompt the model saw its own previously-rejected JSON as conversation context, and chat-tuned models tend to anchor to / defend their prior turn — undermining the retry's purpose, which is to *reissue the whole object correctly given the validator feedback*, not "fix what you just emitted."

## Fix

Move the `Agent(...)` construction **inside** the `for attempt in range(retries + 1):` loop so each attempt is stateless and history-free. Agent construction is cheap (env reads + object init via `get_strands_model`, no I/O). Budget charging (`charge_active_budget()`, once per loop iteration) and the LLM fault-tolerance envelope are unaffected — `invoke_agent`'s transport retries still operate on the single agent instance handed to that call.

This is the foundational fix of the cluster of follow-ups that all touch the design retry/self-review machinery; doing it first means later fixes are tuned against a retry loop that behaves correctly.

## Tests

Adds `test_parse_retry_builds_fresh_agent_per_attempt`, which patches the in-module `Agent` with a construction-counting factory and asserts:
- one agent is constructed per attempt (== number of LLM calls), and
- each constructed agent fielded **exactly one** prompt (no cross-attempt conversation carryover), with the correction context landing on the recovery agent.

Pre-fix this fails (one construction; one reused stub sees both prompts); post-fix it passes. All 27 design-agent tests pass; ruff check + format clean on the changed lines.

Closes #679


---
_Generated by [Claude Code](https://claude.ai/code/session_01122HQBFwF5juZGHkCt7ovm)_