### PR TITLE
Strategy Lab: remove obsolete stop-loss/take-profit conformance checks

### DIFF
--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_conformance.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_conformance.py
@@ -22,7 +22,7 @@ Scope choices (issue #541, v1):
   recognised and will fail. Recognising inline patterns is a future
   enhancement; the deterministic compiler track (#538) makes it
   unnecessary on the compiled path.
-* Check #7 (bar-counting exit rejection) scans generated code for
+* Check #5 (bar-counting exit rejection) scans generated code for
   bar-counting exit patterns (variables like ``bars_held``,
   ``hold_count``, ``days_held`` and ``if counter >= N: close``
   idioms). These implement the forbidden "time stop" concept and are
@@ -43,8 +43,6 @@ from ..spec_dsl import (
     IndicatorRef,
     Predicate,
     SignalExitRule,
-    StopLossRule,
-    TakeProfitRule,
 )
 from .code_safety_ast import (
     _find_strategy_subclasses,
@@ -450,8 +448,6 @@ class CodeConformanceGate(GateResultsMixin):
             results.extend(self._check_symbol_gate(spec, cls))
             results.extend(self._check_entry_coverage(cls, spec))
             results.extend(self._check_signal_exit_coverage(cls, spec))
-            results.extend(self._check_stop_loss_enforcement(cls, spec))
-            results.extend(self._check_take_profit_enforcement(cls, spec))
             results.extend(self._check_bar_counting_exit(cls))
             results.extend(self._check_sizing_math(cls, spec))
             results.extend(self._check_no_extra_side_effects(tree, cls))
@@ -617,62 +613,7 @@ class CodeConformanceGate(GateResultsMixin):
         return ()
 
     # ------------------------------------------------------------------
-    # Check 5 — stop-loss enforcement
-    # ------------------------------------------------------------------
-    def _check_stop_loss_enforcement(
-        self, cls: ast.ClassDef, spec: Any
-    ) -> Iterable[QualityGateResult]:
-        stop_rules = [
-            r for r in (getattr(spec, "exit_rules", []) or []) if isinstance(r, StopLossRule)
-        ]
-        if not stop_rules:
-            return ()
-        if self._class_references_position_entry_price(cls):
-            return ()
-        return (
-            self._critical(
-                "Spec has a StopLossRule but the Strategy class never "
-                "references ``position.entry_price`` (or ``pos.entry_price``) "
-                "— the stop-loss threshold cannot be computed against the "
-                "entry without it."
-            ),
-        )
-
-    # ------------------------------------------------------------------
-    # Check 6 — take-profit enforcement
-    # ------------------------------------------------------------------
-    def _check_take_profit_enforcement(
-        self, cls: ast.ClassDef, spec: Any
-    ) -> Iterable[QualityGateResult]:
-        tp_rules = [
-            r for r in (getattr(spec, "exit_rules", []) or []) if isinstance(r, TakeProfitRule)
-        ]
-        if not tp_rules:
-            return ()
-        if self._class_references_position_entry_price(cls):
-            return ()
-        return (
-            self._critical(
-                "Spec has a TakeProfitRule but the Strategy class never "
-                "references ``position.entry_price`` (or ``pos.entry_price``) "
-                "— the take-profit threshold cannot be computed against the "
-                "entry without it."
-            ),
-        )
-
-    def _class_references_position_entry_price(self, cls: ast.ClassDef) -> bool:
-        for node in ast.walk(cls):
-            if (
-                isinstance(node, ast.Attribute)
-                and node.attr == "entry_price"
-                and isinstance(node.value, ast.Name)
-                and node.value.id in _POSITION_RECEIVER_NAMES
-            ):
-                return True
-        return False
-
-    # ------------------------------------------------------------------
-    # Check 7 — bar-counting exit rejection
+    # Check 5 — bar-counting exit rejection
     # ------------------------------------------------------------------
 
     _BAR_COUNTER_NAMES: ClassVar[frozenset] = frozenset({
@@ -710,7 +651,7 @@ class CodeConformanceGate(GateResultsMixin):
         )
 
     # ------------------------------------------------------------------
-    # Check 8 — sizing math present
+    # Check 6 — sizing math present
     # ------------------------------------------------------------------
     def _check_sizing_math(self, cls: ast.ClassDef, spec: Any = None) -> Iterable[QualityGateResult]:
         all_submit_calls = [
@@ -753,7 +694,7 @@ class CodeConformanceGate(GateResultsMixin):
         )
 
     # ------------------------------------------------------------------
-    # Check 9 — no submit_order calls outside hook/helper methods
+    # Check 7 — no submit_order calls outside hook/helper methods
     # ------------------------------------------------------------------
     def _check_no_extra_side_effects(
         self, tree: ast.AST, cls: ast.ClassDef

--- a/backend/agents/investment_team/tests/test_code_conformance_gate.py
+++ b/backend/agents/investment_team/tests/test_code_conformance_gate.py
@@ -383,57 +383,40 @@ def test_signal_exit_coverage_fails_when_no_position_qty_close() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Check 5: stop-loss enforcement
+# Engine-delegated exits: the gate must NOT require the strategy to reference
+# ``entry_price``. Stop-loss / take-profit thresholds are enforced
+# deterministically by ``executor/rule_compiler.py`` against the engine-owned
+# ``PositionState.entry_price``; conformant strategies delegate to the engine
+# and never compute the threshold themselves.
 # ---------------------------------------------------------------------------
 
+# ``_HAPPY_CODE`` with its only ``pos.entry_price`` reference removed — the
+# canonical shape of an engine-delegated strategy.
+_NO_ENTRY_PRICE_CODE = _HAPPY_CODE.replace("pos.entry_price * 0.95", "0.0")
 
-def test_stop_loss_passes_when_entry_price_referenced() -> None:
-    results = CodeConformanceGate().check(_HAPPY_CODE, _happy_spec())
-    assert not any("StopLossRule" in d for d in _critical_details(results))
 
-
-def test_stop_loss_fails_when_entry_price_never_referenced() -> None:
-    # Strip both `pos.entry_price` references → check #5 fires.
-    code = _HAPPY_CODE.replace("pos.entry_price * 0.95", "0.0")
+def test_stop_loss_passes_without_entry_price_reference() -> None:
     spec = _spec(
         entry_rules=[_sma_cross_entry()],
         exit_rules=[StopLossRule(pct=0.05)],
         target_symbols=["QQQ"],
     )
-    results = CodeConformanceGate().check(code, spec)
-    crits = _critical_details(results)
-    assert any("StopLossRule" in c and "entry_price" in c for c in crits), crits
+    results = CodeConformanceGate().check(_NO_ENTRY_PRICE_CODE, spec)
+    assert not any("StopLossRule" in d for d in _critical_details(results))
 
 
-# ---------------------------------------------------------------------------
-# Check 6: take-profit enforcement
-# ---------------------------------------------------------------------------
-
-
-def test_take_profit_passes_when_entry_price_referenced() -> None:
+def test_take_profit_passes_without_entry_price_reference() -> None:
     spec = _spec(
         entry_rules=[_sma_cross_entry()],
         exit_rules=[TakeProfitRule(pct=0.10)],
         target_symbols=["QQQ"],
     )
-    results = CodeConformanceGate().check(_HAPPY_CODE, spec)
+    results = CodeConformanceGate().check(_NO_ENTRY_PRICE_CODE, spec)
     assert not any("TakeProfitRule" in d for d in _critical_details(results))
 
 
-def test_take_profit_fails_when_entry_price_never_referenced() -> None:
-    code = _HAPPY_CODE.replace("pos.entry_price * 0.95", "0.0")
-    spec = _spec(
-        entry_rules=[_sma_cross_entry()],
-        exit_rules=[TakeProfitRule(pct=0.10)],
-        target_symbols=["QQQ"],
-    )
-    results = CodeConformanceGate().check(code, spec)
-    crits = _critical_details(results)
-    assert any("TakeProfitRule" in c and "entry_price" in c for c in crits), crits
-
-
 # ---------------------------------------------------------------------------
-# Check 7: bar-counting exit rejection
+# Check 5: bar-counting exit rejection
 # ---------------------------------------------------------------------------
 
 
@@ -557,7 +540,7 @@ def test_no_bar_counting_false_positive_on_local_variable() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Check 8: sizing math
+# Check 6: sizing math
 # ---------------------------------------------------------------------------
 
 
@@ -593,7 +576,7 @@ def test_sizing_fails_when_qty_is_inline_literal_int() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Check 9: no side-effects outside hooks/helpers
+# Check 7: no side-effects outside hooks/helpers
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

`CodeConformanceGate` was rejecting **valid** strategies with a P0 critical whenever a `StopLossRule`/`TakeProfitRule` existed but the Strategy class never referenced `position.entry_price`:

> Spec has a StopLossRule but the Strategy class never references `position.entry_price` (or `pos.entry_price`) — the stop-loss threshold cannot be computed against the entry without it.

That premise is obsolete. After the migration that made the engine the single source of truth for structural exits, `executor/rule_compiler.py` enforces both rules **deterministically** — `evaluate_exit_rules` → `_stop_loss_triggers` / `_take_profit_triggers` compute thresholds directly from the engine-owned `PositionState.entry_price`, with no dependency on strategy code. Conformant strategies correctly delegate to the engine and never reference `entry_price`, so the gate was an active regression rejecting strategies that use the new architecture.

## Changes

- Delete `_check_stop_loss_enforcement`, `_check_take_profit_enforcement`, and the `_class_references_position_entry_price` helper, plus their `check()` invocations and the now-unused `StopLossRule`/`TakeProfitRule` imports.
- Renumber the remaining check section headers (and the docstring reference) to stay consecutive.
- Replace the two tests that asserted the criticals fire with acceptance tests confirming an engine-delegated strategy (a `StopLossRule`/`TakeProfitRule` spec with **no** `entry_price` reference) passes the gate.

Removing the checks cannot regress any path the engine already enforces (which is every path the gate currently rejects). Engine-side enforcement in `executor/rule_compiler.py` is unchanged.

## Testing

- `python -m pytest agents/investment_team/tests/test_code_conformance_gate.py` → **32 passed**.
- `ruff check` on both files → clean (no unused imports).

Closes #706

https://claude.ai/code/session_01WPesHQwQJSUiuAXe1A9u6o

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPesHQwQJSUiuAXe1A9u6o)_