### PR TITLE
Fix LLM context resolution and non-poisoning /api/show fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,6 +246,7 @@ Environment variables for LLM: `LLM_PROVIDER`, `LLM_BASE_URL`, `LLM_MODEL`
 | `LLM_PROVIDER` | LLM provider selection |
 | `LLM_BASE_URL` | LLM server URL |
 | `LLM_MODEL` | Model name |
+| `LLM_NUM_CTX_FALLBACK_TTL_S` | TTL (seconds, default `300`) for the Ollama client's provisional `num_ctx` fallback. When a model's context size is not in `KNOWN_MODEL_CONTEXT` / `LLM_CONTEXT_SIZE` and `/api/show` fails, the client degrades to a 16384-token context but only caches it for this window before re-attempting — a transient `/api/show` outage can no longer poison the process into silently truncating large prompts for its whole lifetime. A successfully-resolved (or known/env) context size is still cached permanently. Garbage values fall back to the default; negative floors to `0` (retry on next call). |
 | `TEMPORAL_ADDRESS` | Enables Temporal mode when set |
 | `TEMPORAL_NAMESPACE` | Temporal namespace |
 | `TEMPORAL_TASK_QUEUE` | Temporal task queue name |

--- a/backend/agents/llm_service/clients/ollama.py
+++ b/backend/agents/llm_service/clients/ollama.py
@@ -50,6 +50,33 @@ def _caller_tag() -> str:
 # Default cap for max_tokens
 DEFAULT_MAX_OUTPUT_TOKENS = 32768
 
+# Provisional context size used only when num_ctx cannot be resolved from the
+# known-model table, env, or a successful /api/show call. Cached for at most
+# _FALLBACK_NUM_CTX_TTL_S seconds (never permanently) so a transient /api/show
+# outage cannot poison the process into silently truncating large prompts for
+# the rest of its lifetime.
+_FALLBACK_NUM_CTX = 16384
+_ENV_NUM_CTX_FALLBACK_TTL = "LLM_NUM_CTX_FALLBACK_TTL_S"
+_DEFAULT_NUM_CTX_FALLBACK_TTL_S = 300.0
+
+
+def _fallback_num_ctx_ttl_s() -> float:
+    """Return the provisional-fallback TTL in seconds (env override, defensive parse).
+
+    Preconditions: none.
+    Postconditions: returns a non-negative float; a missing or unparseable
+        ``LLM_NUM_CTX_FALLBACK_TTL_S`` yields ``_DEFAULT_NUM_CTX_FALLBACK_TTL_S``;
+        a negative value is floored to ``0.0`` (immediate retry on next call).
+    """
+    raw = os.environ.get(_ENV_NUM_CTX_FALLBACK_TTL)
+    if not raw:
+        return _DEFAULT_NUM_CTX_FALLBACK_TTL_S
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return _DEFAULT_NUM_CTX_FALLBACK_TTL_S
+
+
 # Continuation on truncation (same behavior as software_engineering_team)
 MAX_CONTINUATION_CYCLES = 10
 CONTINUATION_CONTEXT_CHARS = 150
@@ -146,6 +173,10 @@ class OllamaLLMClient(LLMClient):
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
         self._model_num_ctx: Optional[int] = None
+        # Provisional num_ctx fallback (set only when /api/show cannot be resolved),
+        # with the wall-clock time it was recorded. Never written to _model_num_ctx.
+        self._fallback_num_ctx: Optional[int] = None
+        self._fallback_num_ctx_ts: float = 0.0
         # Token usage from the last successful LLM call (populated by _ollama_post)
         self._last_usage: Optional[Dict[str, Any]] = None
         self._last_latency_ms: int = 0
@@ -193,7 +224,23 @@ class OllamaLLMClient(LLMClient):
         return {"Authorization": f"Bearer {key}"}
 
     def _fetch_model_num_ctx(self) -> int:
-        """Fetch model's num_ctx from config known table, env, or Ollama /api/show. Cached. Fallback 16384."""
+        """Resolve the model's num_ctx from the known-model table, env, or Ollama /api/show.
+
+        An authoritatively-resolved value (known table, env override, or a
+        successful /api/show parse) is cached for the process lifetime. When
+        /api/show cannot be resolved we degrade to ``_FALLBACK_NUM_CTX`` but cache
+        it only provisionally — for at most ``_fallback_num_ctx_ttl_s()`` — so a
+        transient outage is retried on a later call instead of poisoning the
+        process into silently truncating large prompts forever.
+
+        Preconditions: none.
+        Postconditions: returns ``>= 2048``; an authoritative result is cached in
+            ``self._model_num_ctx`` permanently; a fallback result is returned
+            without writing ``self._model_num_ctx`` and is reused (skipping
+            /api/show) only until its TTL elapses.
+        Invariants: ``self._model_num_ctx``, once set, is only ever set to an
+            authoritatively-resolved value — never ``_FALLBACK_NUM_CTX``.
+        """
         if self._model_num_ctx is not None:
             return self._model_num_ctx
         ctx = llm_config.resolve_context_size_for_model(self.model)
@@ -203,6 +250,12 @@ class OllamaLLMClient(LLMClient):
                 "LLM model %s: using known/context size %s", self.model, self._model_num_ctx
             )
             return self._model_num_ctx
+        # Reuse a recent provisional fallback instead of hammering a down /api/show.
+        if (
+            self._fallback_num_ctx is not None
+            and time.time() - self._fallback_num_ctx_ts < _fallback_num_ctx_ttl_s()
+        ):
+            return self._fallback_num_ctx
         try:
             url = f"{self.base_url}/api/show"
             headers = self._ollama_auth_headers()
@@ -210,12 +263,13 @@ class OllamaLLMClient(LLMClient):
                 resp = client.post(url, json={"model": self.model}, headers=headers)
             if resp.status_code != 200:
                 logger.warning(
-                    "Ollama /api/show returned %s for model %s; using 16384",
+                    "Ollama /api/show returned %s for model %s; using %s (retry after %ss)",
                     resp.status_code,
                     self.model,
+                    _FALLBACK_NUM_CTX,
+                    _fallback_num_ctx_ttl_s(),
                 )
-                self._model_num_ctx = 16384
-                return self._model_num_ctx
+                return self._record_fallback_num_ctx()
             data = resp.json()
             params_str = data.get("parameters") or ""
             match = re.search(r"num_ctx\s+(\d+)", params_str, re.IGNORECASE)
@@ -232,10 +286,24 @@ class OllamaLLMClient(LLMClient):
                         return self._model_num_ctx
         except (httpx.HTTPError, KeyError, ValueError, TypeError) as e:
             logger.warning(
-                "Could not fetch Ollama model info for %s: %s; using 16384", self.model, e
+                "Could not fetch Ollama model info for %s: %s; using %s (retry after %ss)",
+                self.model,
+                e,
+                _FALLBACK_NUM_CTX,
+                _fallback_num_ctx_ttl_s(),
             )
-        self._model_num_ctx = 16384
-        return self._model_num_ctx
+        return self._record_fallback_num_ctx()
+
+    def _record_fallback_num_ctx(self) -> int:
+        """Record the provisional num_ctx fallback with the current time and return it.
+
+        Postconditions: ``self._fallback_num_ctx == _FALLBACK_NUM_CTX``,
+            ``self._fallback_num_ctx_ts`` is the current wall-clock time, and
+            ``self._model_num_ctx`` is left untouched (still ``None``).
+        """
+        self._fallback_num_ctx = _FALLBACK_NUM_CTX
+        self._fallback_num_ctx_ts = time.time()
+        return _FALLBACK_NUM_CTX
 
     def get_max_context_tokens(self) -> int:
         """Return model's num_ctx (cached)."""
@@ -1261,9 +1329,7 @@ class OllamaLLMClient(LLMClient):
         both modes.
         """
         if response_format not in ("json", "text"):
-            raise ValueError(
-                f"response_format must be 'json' or 'text', got {response_format!r}"
-            )
+            raise ValueError(f"response_format must be 'json' or 'text', got {response_format!r}")
         max_retries, backoff_base, backoff_max = _parse_retry_config()
         sem = _get_ollama_semaphore()
         self._current_caller = _caller_tag()

--- a/backend/agents/llm_service/config.py
+++ b/backend/agents/llm_service/config.py
@@ -43,8 +43,7 @@ KNOWN_MODEL_CONTEXT: dict[str, int] = {
     "qwen3.5:cloud": 262144,
     "qwen3-coder:480b-cloud": 262144,
     "qwen3-coder:480b": 262144,
-    # deepseek-v4-pro:cloud is intentionally omitted — context size is
-    # resolved at runtime via the Ollama /api/show call on first use.
+    "deepseek-v4-pro:cloud": 262144,
 }
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/llm_service/tests/test_config.py
+++ b/backend/agents/llm_service/tests/test_config.py
@@ -48,6 +48,12 @@ def test_resolve_context_size_for_model_known(monkeypatch: pytest.MonkeyPatch) -
     assert config.resolve_context_size_for_model("qwen3.5:397b-cloud") == 262144
 
 
+def test_resolve_context_size_for_default_deepseek_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default agent model resolves deterministically (no /api/show dependency)."""
+    monkeypatch.delenv("LLM_CONTEXT_SIZE", raising=False)
+    assert config.resolve_context_size_for_model("deepseek-v4-pro:cloud") == 262144
+
+
 def test_resolve_context_size_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LLM_CONTEXT_SIZE", "100000")
     assert config.resolve_context_size_for_model("unknown-model") == 100000

--- a/backend/agents/llm_service/tests/test_ollama_client.py
+++ b/backend/agents/llm_service/tests/test_ollama_client.py
@@ -23,6 +23,71 @@ def test_ollama_get_max_context_tokens_env_override(monkeypatch: pytest.MonkeyPa
     assert client.get_max_context_tokens() == 50000
 
 
+def _make_show_response(status_code: int, num_ctx: int | None = None) -> MagicMock:
+    """Build a mocked /api/show response: 200 with `parameters: "num_ctx N"`, or an error."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = {"parameters": f"num_ctx {num_ctx}"} if num_ctx is not None else {}
+    return resp
+
+
+def _patch_show(responses: list[MagicMock]) -> tuple[MagicMock, MagicMock]:
+    """Return (httpx.Client class mock, shared client instance) whose .post yields `responses` in order."""
+    mock_client = MagicMock()
+    mock_client.__enter__.return_value.post.side_effect = responses
+    mock_cls = MagicMock(return_value=mock_client)
+    return mock_cls, mock_client
+
+
+def test_ollama_known_default_model_skips_api_show(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default deepseek model resolves from the known table and never calls /api/show."""
+    monkeypatch.delenv("LLM_CONTEXT_SIZE", raising=False)
+    with patch("httpx.Client") as mock_client_cls:
+        client = OllamaLLMClient(
+            model="deepseek-v4-pro:cloud", base_url="http://localhost:9999", timeout=5
+        )
+        assert client.get_max_context_tokens() == 262144
+    mock_client_cls.assert_not_called()
+
+
+def test_ollama_api_show_transient_failure_does_not_poison(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Core regression: a transient /api/show failure must not cache 16384 forever.
+
+    With the fallback TTL at 0s, the next call re-attempts /api/show and, on
+    success, resolves the model's real context size instead of staying truncated.
+    """
+    monkeypatch.delenv("LLM_CONTEXT_SIZE", raising=False)
+    monkeypatch.setenv("LLM_NUM_CTX_FALLBACK_TTL_S", "0")
+    mock_cls, _ = _patch_show([_make_show_response(500), _make_show_response(200, 262144)])
+    with patch("httpx.Client", mock_cls):
+        client = OllamaLLMClient(model="unknown-model", base_url="http://localhost:9999", timeout=5)
+        assert client.get_max_context_tokens() == 16384  # transient blip → provisional fallback
+        assert client.get_max_context_tokens() == 262144  # retried, resolved authoritatively
+
+
+def test_ollama_api_show_fallback_cached_within_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Within the TTL, the provisional fallback is reused without re-hammering /api/show."""
+    monkeypatch.delenv("LLM_CONTEXT_SIZE", raising=False)
+    monkeypatch.delenv("LLM_NUM_CTX_FALLBACK_TTL_S", raising=False)  # default 300s
+    mock_cls, mock_client = _patch_show([_make_show_response(500)])
+    with patch("httpx.Client", mock_cls):
+        client = OllamaLLMClient(model="unknown-model", base_url="http://localhost:9999", timeout=5)
+        assert client.get_max_context_tokens() == 16384
+        assert client.get_max_context_tokens() == 16384
+    assert mock_client.__enter__.return_value.post.call_count == 1
+
+
+def test_ollama_api_show_success_is_cached_permanently(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A resolved num_ctx is cached for the process lifetime — no repeat /api/show calls."""
+    monkeypatch.delenv("LLM_CONTEXT_SIZE", raising=False)
+    mock_cls, mock_client = _patch_show([_make_show_response(200, 262144)])
+    with patch("httpx.Client", mock_cls):
+        client = OllamaLLMClient(model="unknown-model", base_url="http://localhost:9999", timeout=5)
+        assert client.get_max_context_tokens() == 262144
+        assert client.get_max_context_tokens() == 262144
+    assert mock_client.__enter__.return_value.post.call_count == 1
+
+
 def _make_streaming_mock(
     status_code: int, sse_lines: list[str] | None = None, body_text: str = ""
 ) -> tuple:


### PR DESCRIPTION
## Summary

The default agent model (`deepseek-v4-pro:cloud`) had no entry in `KNOWN_MODEL_CONTEXT`, so its context size was resolved at runtime via an Ollama `/api/show` call. When that call failed (a transient Cloud incident or cold-start network blip), the client fell back to **16384 tokens** and cached that for the **entire process lifetime** — silently truncating every prompt larger than 16k tokens thereafter (blogging long-form drafts, SE planning sessions, full strategy-lab context windows), with only a single one-time warning.

The old hard-coded default never made an `/api/show` call, so it had no equivalent failure mode. This PR restores that safety for the current default model **and** hardens the fallback path so a transient blip can no longer poison the process.

## Changes

- **Register `deepseek-v4-pro:cloud` in `KNOWN_MODEL_CONTEXT` (262144)**, matching the existing cloud-model entries. The default model now resolves its context deterministically and never touches `/api/show`.
- **Make the 16384 fallback provisional rather than permanent.** A genuinely resolved value (known table, env override, or a successful `/api/show` parse) is still cached for the process lifetime, but a fallback is cached only for a TTL (`LLM_NUM_CTX_FALLBACK_TTL_S`, default 300s) before `/api/show` is re-attempted. Within the TTL the fallback is reused so a down endpoint isn't hammered every call. The fallback never overwrites the authoritative cache.
- Updated `_fetch_model_num_ctx` docstring with explicit Design-by-Contract **Preconditions / Postconditions / Invariants**.
- Documented the new env var in `CLAUDE.md`.

## Tests

Added to `test_ollama_client.py` / `test_config.py`:

1. Known default model resolves to 262144 and **never** calls `/api/show`.
2. **Core regression guard:** a transient `/api/show` 500 falls back to 16384, then (after the TTL) re-attempts and resolves the real context size — proving an outage no longer silently truncates forever.
3. Within the TTL the fallback is reused without a second `/api/show` call.
4. A resolved `num_ctx` is cached permanently (no repeat `/api/show`).

Targeted suite: `test_ollama_client.py` + `test_config.py` pass (28). Full `llm_service` suite passes (87), excluding one pre-existing collection error in `test_strands_provider.py` (an installed-`strands`-version mismatch unrelated to this change). `ruff check` + `ruff format` clean.

Closes #677

---
_Generated by [Claude Code](https://claude.ai/code/session_015ZsZKQ6Xn3mcLr8Kikdsdj)_