### PR TITLE
Isolate mutable drift state at the design-attempt retry boundary

### DIFF
--- a/backend/agents/investment_team/strategy_lab/LOOK_AHEAD_DEFENCE.md
+++ b/backend/agents/investment_team/strategy_lab/LOOK_AHEAD_DEFENCE.md
@@ -85,3 +85,7 @@ Locked in by: `backend/agents/investment_team/tests/test_backtest_anomaly_realis
 | Static regex + AST | `strategy_lab/quality_gates/code_safety.py`, `strategy_lab/quality_gates/code_safety_ast.py` | `tests/test_code_safety.py` |
 | Post-hoc heuristic | `strategy_lab/quality_gates/backtest_anomaly.py` | `tests/test_backtest_anomaly_realism.py` |
 | Walk-forward fold purity | `execution/walk_forward.py` | `tests/test_walk_forward.py` |
+
+> Retry state isolation across the design / synthesis / alignment / repair loops
+> (copy-on-entry, commit-on-completion) is documented separately in
+> [`RETRY_STATE_ISOLATION.md`](RETRY_STATE_ISOLATION.md).

--- a/backend/agents/investment_team/strategy_lab/RETRY_STATE_ISOLATION.md
+++ b/backend/agents/investment_team/strategy_lab/RETRY_STATE_ISOLATION.md
@@ -1,0 +1,71 @@
+# Strategy Lab — Retry State Isolation
+
+The Strategy Lab retries work at several boundaries: the design phase re-enters on a
+`SpecImplementabilityError`, the synthesis loop refines code over multiple rounds, the trade
+alignment loop proposes fixes round over round, and the zero-trade repairer attempts a
+targeted patch. Long-lived mutable structures are threaded through these loops to build the
+final diagnostic record. Without discipline, state from a **failed** attempt leaks into the
+**next** attempt's reasoning — contaminating diagnostics, blocking safe parallelisation, and
+making a failed repair's partial mutations visible to the next agent.
+
+The contract is **copy-on-entry, commit-on-completion**: each retry attempt works on an
+isolated copy of the mutable state, and the parent's authoritative state is only updated once
+the attempt's fate is known.
+
+## Drift collection across design attempts
+
+`_DriftCollector` (`_orchestrator_helpers.py`) accumulates `SpecRevision` / `CodeRevision` /
+`GateEvent` records that are drained into `StrategyLabRecord` at record-build time. Its
+records are **append-only and immutable**, so isolating an attempt does not require deep-copying
+history — it means giving the attempt its own empty collector:
+
+- `snapshot()` returns a **fresh, empty** `_DriftCollector` sharing no list object with its
+  parent — the clean working copy for one attempt.
+- `merge(child)` folds a child's records into the parent in order, leaving the child intact.
+
+`run_cycle` owns a parent `drift_collector` that serves purely as the **commit log** for the
+short-circuit diagnostic record. The design re-entry loop:
+
+1. **Copy-on-entry** — `attempt_drift = drift_collector.snapshot()` before each attempt; the
+   attempt records only into `attempt_drift`.
+2. On **success**, `_run_design_attempt` builds the record from `attempt_drift`, so a converged
+   run's drift reflects only the successful attempt — prior failed attempts never leak in.
+3. On **failure** (`SpecImplementabilityError`), **commit-on-completion** —
+   `drift_collector.merge(attempt_drift)` folds the failed attempt's drift into the parent so
+   the short-circuit record retains it for diagnostics. The *next* attempt's `snapshot()` is
+   still a fresh empty child, so the merge never contaminates it.
+
+The parent collector is never appended to from inside an attempt; the only mutation of the
+parent is the explicit `merge` at the boundary.
+
+> Intentionally cumulative (not isolated): `cumulative_gate_results` in `run_cycle` spans all
+> attempts on purpose — it feeds the deflated-Sharpe multiple-testing burden, where each failed
+> attempt's gate work *should* count.
+
+## Zero-trade repair purity
+
+`ZeroTradeRepairer.try_repair()` (`zero_trade_repair.py`) is **pure with respect to the
+caller's `code` and `spec`**: it builds a fresh proposed spec/code internally and never mutates
+the inputs. It returns a `ZeroTradeRepairOutcome` that either commits (`committed=True`, new
+state on the outcome) or rejects (`committed=False`, empty/`None` outcome fields). On rejection
+the caller falls through to the generic `RefinementAgent` against the **original** code blob,
+not a half-repaired one. The `zero_trade_attempts` list is an audit log appended on both
+commit and rejection — analogous to the drift commit log, not part of the working code state.
+
+## Alignment round state
+
+`_AlignmentRoundOutcome` (`_orchestrator_helpers.py`) carries the spec/code/trades/metrics for
+one alignment round. On a rejected proposal (`terminate=True`) the outcome carries the **same
+pre-iteration spec/code objects** — the known-good state survives a failed attempt untouched;
+a committed proposal (`terminate=False`) carries the new known-good state. Issue lists are
+re-derived deterministically per round from the structured findings
+(`findings_to_issues(check_result.findings)`), never accumulated across rounds.
+
+## Locked in by
+
+| Contract | Tests |
+| --- | --- |
+| `_DriftCollector.snapshot()` / `merge()` semantics | `tests/test_strategy_lab_drift_observability.py` |
+| Failed design attempt does not poison the next; short-circuit record preserves failed-attempt drift | `tests/test_strategy_lab_phase_transitions.py` |
+| `ZeroTradeRepairer` purity w.r.t. input code/spec | `tests/test_strategy_lab_zero_trade_repair.py` |
+| Rejected alignment proposal preserves known-good state | `tests/test_strategy_lab_alignment.py` |

--- a/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
+++ b/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
@@ -202,11 +202,55 @@ class _DriftCollector:
     Invariants:
       - ``record_spec_change`` is a no-op when before/after hashes match
         (no-op mutation). Same for ``record_code_change``.
+
+    Retry isolation:
+      The records are append-only and immutable, so isolating one retry
+      attempt does not require deep-copying history — it means handing the
+      attempt its own empty collector (``snapshot``) and folding it back into
+      the parent commit log (``merge``) once the attempt's fate is known. A
+      failed attempt's drift can then be preserved for the diagnostic record
+      without poisoning the next attempt's working collector. See
+      ``RETRY_STATE_ISOLATION.md``.
     """
 
     spec_history: list = field(default_factory=list)
     code_history: list = field(default_factory=list)
     gate_timeline: list = field(default_factory=list)
+
+    def snapshot(self) -> "_DriftCollector":
+        """Return a fresh, empty collector for an isolated retry attempt.
+
+        Records are append-only and immutable, so a clean working copy is an
+        empty collector rather than a deep copy of this one's history. The
+        attempt records into the returned child; the caller folds it back in
+        with ``merge`` once the attempt succeeds or fails.
+
+        Postconditions:
+          - The returned collector's three lists are empty.
+          - It shares no list object with ``self`` (mutating the child never
+            mutates the parent, and vice versa).
+        """
+        return _DriftCollector()
+
+    def merge(self, child: "_DriftCollector") -> None:
+        """Fold a child collector's records into this one, in order.
+
+        Used at a retry boundary to commit an attempt's drift into the parent
+        commit log (on success, so the record reflects the converged attempt;
+        or on failure, so the short-circuit diagnostic record still shows what
+        every failed attempt tried).
+
+        Preconditions:
+          - ``child`` is a ``_DriftCollector``.
+        Postconditions:
+          - ``self``'s histories contain their prior entries followed by all
+            of ``child``'s, preserving order.
+          - ``child`` is left unmodified.
+        """
+        assert isinstance(child, _DriftCollector), "merge() requires a _DriftCollector"
+        self.spec_history.extend(child.spec_history)
+        self.code_history.extend(child.code_history)
+        self.gate_timeline.extend(child.gate_timeline)
 
     def record_spec_change(
         self,

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -765,6 +765,13 @@ class StrategyLabOrchestrator:
         # work on the same evaluation window and so contributes to the
         # multiple-testing burden that DSR deflation corrects for.
         phase_back_count: int = 0
+        # Parent commit log for drift across attempts. Each design attempt
+        # works on its own clean child collector (copy-on-entry); the child is
+        # merged back here only once the attempt's fate is known
+        # (commit-on-completion). This keeps a failed attempt's spec/code
+        # revisions out of the next attempt's working state while still
+        # preserving them for the short-circuit diagnostic record. See
+        # ``RETRY_STATE_ISOLATION.md``.
         drift_collector = _DriftCollector()
         cumulative_gate_results: List[QualityGateResult] = []
         # Per-cycle LLM-call budget. Bound once here via ``use_budget`` so it
@@ -775,6 +782,9 @@ class StrategyLabOrchestrator:
         llm_budget = LLMCallBudget(_design_max_llm_calls())
         with use_budget(llm_budget):
             for design_attempt in range(MAX_DESIGN_REENTRIES + 1):
+                # Copy-on-entry: hand this attempt a clean child collector so
+                # drift from a prior failed attempt cannot poison it.
+                attempt_drift = drift_collector.snapshot()
                 try:
                     return self._run_design_attempt(
                         prior_records=prior_records,
@@ -785,7 +795,7 @@ class StrategyLabOrchestrator:
                         directives=directives,
                         design_attempt=design_attempt,
                         phase_back_count=phase_back_count,
-                        drift_collector=drift_collector,
+                        drift_collector=attempt_drift,
                         cumulative_gate_results=cumulative_gate_results,
                     )
                 except SpecImplementabilityError as exc:
@@ -796,6 +806,11 @@ class StrategyLabOrchestrator:
                     last_design_context = exc.design_context
                     phase_back_count += 1
                     self.convergence_tracker.increment_trials(1)
+                    # Commit-on-completion: fold the failed attempt's drift into
+                    # the parent commit log so the short-circuit record retains
+                    # its diagnostics. The next attempt's ``snapshot`` is still a
+                    # fresh empty child, so this does not contaminate it.
+                    drift_collector.merge(attempt_drift)
                     if design_attempt >= MAX_DESIGN_REENTRIES:
                         break
                     emit(

--- a/backend/agents/investment_team/tests/test_strategy_lab_alignment.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_alignment.py
@@ -1078,6 +1078,64 @@ def test_run_alignment_round_rejects_unsafe_proposed_code(monkeypatch) -> None:
     )
 
 
+def test_run_alignment_round_rejected_proposal_preserves_known_good_state(monkeypatch) -> None:
+    """A rejected alignment proposal must leave the pre-iteration spec/code
+    intact: the outcome carries the same baseline objects (``terminate=True``)
+    and the input spec is not mutated in place. This is the snapshot/commit
+    contract for the alignment loop — known-good state survives a failed
+    attempt untouched."""
+    from investment_team.strategy_lab import orchestrator as orchestrator_module
+
+    unsafe_report = TradeAlignmentReport(
+        aligned=False,
+        rationale="off-spec",
+        issues=[AlignmentIssue(rule_type="entry_rules", description="x", severity="critical")],
+        proposed_code=(
+            "import os\n\n"
+            "from contract import Strategy\n\n"
+            "class S(Strategy):\n"
+            "    def on_bar(self, ctx, bar):\n"
+            "        os.system('rm -rf /')\n"
+        ),
+        predicted_aligned_after_fix=True,
+        changes_made="unsafe rewrite",
+    )
+    orch, _align_stub, _checker_stub = _make_orchestrator(
+        check_results=[_misaligned_check_result()],
+        propose_results=[unsafe_report],
+    )
+    monkeypatch.setattr(
+        orchestrator_module,
+        "run_strategy_code",
+        lambda *_a, **_kw: (_ for _ in ()).throw(AssertionError("must not re-execute")),
+    )
+
+    baseline_spec = _spec()
+    baseline_code = "baseline-code-v0"
+    spec_dump_before = baseline_spec.model_dump()
+    _events, emit = _collect_emit()
+
+    outcome = orch._run_alignment_round(
+        spec=baseline_spec,
+        code=baseline_code,
+        trades=_trade_records(),
+        metrics=_metrics(),
+        market_data=_market_data(),
+        config=_config(),
+        align_round=0,
+        all_gate_results=[],
+        alignment_attempts=[],
+        alignment_reports=[],
+        emit=emit,
+    )
+
+    assert outcome.terminate is True
+    # Same baseline objects flow back out — nothing was swapped or mutated.
+    assert outcome.spec is baseline_spec
+    assert outcome.code is baseline_code
+    assert baseline_spec.model_dump() == spec_dump_before
+
+
 def test_run_alignment_round_handles_re_execution_failure(monkeypatch) -> None:
     """Sandbox returns ``success=False`` on the post-fix re-execution →
     round emits ``re_execution_failed``, terminates, and appends a

--- a/backend/agents/investment_team/tests/test_strategy_lab_drift_observability.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_drift_observability.py
@@ -182,6 +182,68 @@ class TestDriftCollector:
         assert h1 == h2
         assert len(h1) == 64
 
+    def test_snapshot_returns_empty_isolated_collector(self):
+        parent = _DriftCollector()
+        parent.record_code_change(
+            phase="synthesis",
+            agent="RefinementAgent",
+            before_code="x = 1",
+            after_code="x = 2",
+            reason="seed parent",
+        )
+        child = parent.snapshot()
+        # Fresh and empty regardless of parent contents.
+        assert child.spec_history == []
+        assert child.code_history == []
+        assert child.gate_timeline == []
+        # Shares no list object with the parent — mutating one never touches
+        # the other.
+        assert child.spec_history is not parent.spec_history
+        assert child.code_history is not parent.code_history
+        assert child.gate_timeline is not parent.gate_timeline
+        child.record_code_change(
+            phase="synthesis",
+            agent="RefinementAgent",
+            before_code="a = 1",
+            after_code="a = 2",
+            reason="child only",
+        )
+        assert len(parent.code_history) == 1  # parent untouched by child
+
+    def test_merge_appends_child_in_order_and_leaves_child_intact(self):
+        parent = _DriftCollector()
+        parent.record_spec_change(
+            phase="design",
+            agent="DesignAgent",
+            before_spec=_minimal_spec(hypothesis="p0"),
+            after_spec=_minimal_spec(hypothesis="p1"),
+            reason="parent rev",
+        )
+        child = parent.snapshot()
+        child.record_spec_change(
+            phase="design_review",
+            agent="DesignAgent",
+            before_spec=_minimal_spec(hypothesis="c0"),
+            after_spec=_minimal_spec(hypothesis="c1"),
+            reason="child rev",
+        )
+        child.record_gate(
+            phase="design_review",
+            gate_name="spec_readiness",
+            passed=False,
+            severity="critical",
+            details="not ready",
+        )
+
+        parent.merge(child)
+
+        # Parent now holds its own entry followed by the child's, in order.
+        assert [r.reason for r in parent.spec_history] == ["parent rev", "child rev"]
+        assert len(parent.gate_timeline) == 1
+        # Child is left unmodified by the merge.
+        assert len(child.spec_history) == 1
+        assert len(child.gate_timeline) == 1
+
 
 # ---------------------------------------------------------------------------
 # Gate timeline conversion

--- a/backend/agents/investment_team/tests/test_strategy_lab_phase_transitions.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_phase_transitions.py
@@ -440,6 +440,106 @@ def test_phase_transition_attempt_increments_on_design_reentry(
     ]
 
 
+def _record_attempt_drift(orch: StrategyLabOrchestrator, collector: Any, attempt: int) -> None:
+    """Record one spec revision into ``collector`` tagged for ``attempt``.
+
+    Uses two specs with distinct ``strategy_id`` so the hashes differ and
+    ``record_spec_change`` actually appends (it is a no-op on equal hashes).
+    """
+    collector.record_spec_change(
+        phase="design",
+        agent="DesignAgent",
+        before_spec=orch._build_spec_from_dict(_spec_dict(), strategy_id=f"s-{attempt}-a"),
+        after_spec=orch._build_spec_from_dict(_spec_dict(), strategy_id=f"s-{attempt}-b"),
+        reason=f"attempt-{attempt} drift",
+    )
+
+
+def test_failed_design_attempt_does_not_poison_next_attempt_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each design attempt gets a clean, isolated ``_DriftCollector``.
+
+    Attempts 0 and 1 record drift then raise ``SpecImplementabilityError``;
+    attempt 2 succeeds. Every attempt must enter with an empty collector (a
+    distinct object), and the record produced by the successful attempt must
+    NOT contain the failed attempts' drift entries.
+    """
+    orch = StrategyLabOrchestrator()
+    _stub_pipeline_for_happy_path(monkeypatch, orch)
+
+    real_run_design_attempt = orch._run_design_attempt
+    # (attempt_index, collector_id, spec_history_len_on_entry)
+    entries: List[Tuple[int, int, int]] = []
+
+    def _flaky_run_design_attempt(**kwargs: Any) -> Any:
+        collector = kwargs["drift_collector"]
+        attempt = kwargs["design_attempt"]
+        entries.append((attempt, id(collector), len(collector.spec_history)))
+        if attempt < 2:
+            _record_attempt_drift(orch, collector, attempt)
+            raise SpecImplementabilityError(
+                f"forced fail attempt {attempt}",
+                failure_phase="refinement",
+                last_spec=orch._build_spec_from_dict(_spec_dict(), strategy_id=f"s-{attempt}"),
+                last_code="",
+            )
+        return real_run_design_attempt(**kwargs)
+
+    monkeypatch.setattr(orch, "_run_design_attempt", _flaky_run_design_attempt)
+
+    _events, _transitions, record = _drive_cycle_capturing_transitions(orch)
+
+    # Three attempts ran, each with a distinct collector object that was
+    # empty on entry (copy-on-entry isolation).
+    assert [a for a, _id, _n in entries] == [0, 1, 2]
+    assert len({_id for _a, _id, _n in entries}) == 3
+    assert all(n == 0 for _a, _id, n in entries)
+
+    # The successful attempt's record carries none of the failed attempts'
+    # drift — no cross-attempt contamination.
+    reasons = [r.reason for r in record.spec_history]
+    assert "attempt-0 drift" not in reasons
+    assert "attempt-1 drift" not in reasons
+
+
+def test_short_circuit_record_preserves_failed_attempt_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When every design attempt fails, the short-circuit record still
+    contains the drift each failed attempt produced.
+
+    The parent commit log accumulates each attempt's child collector on
+    failure (commit-on-completion), so diagnostics survive even though no
+    attempt poisoned its successor's working collector.
+    """
+    orch = StrategyLabOrchestrator()
+    _stub_pipeline_for_happy_path(monkeypatch, orch)
+
+    def _always_fail(**kwargs: Any) -> Any:
+        collector = kwargs["drift_collector"]
+        attempt = kwargs["design_attempt"]
+        # Each attempt entered clean.
+        assert collector.spec_history == []
+        _record_attempt_drift(orch, collector, attempt)
+        raise SpecImplementabilityError(
+            f"forced fail attempt {attempt}",
+            failure_phase="refinement",
+            last_spec=orch._build_spec_from_dict(_spec_dict(), strategy_id=f"s-{attempt}"),
+            last_code="",
+        )
+
+    monkeypatch.setattr(orch, "_run_design_attempt", _always_fail)
+
+    _events, _transitions, record = _drive_cycle_capturing_transitions(orch)
+
+    assert record.backtest.status == "failed: spec_unimplementable"
+    # All three failed attempts' drift is merged into the diagnostic record,
+    # in attempt order.
+    reasons = [r.reason for r in record.spec_history]
+    assert reasons == ["attempt-0 drift", "attempt-1 drift", "attempt-2 drift"]
+
+
 # ---------------------------------------------------------------------------
 # Pure helpers (no orchestrator wiring — small unit tests for phases.py)
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
@@ -402,6 +402,44 @@ def test_zero_trade_repair_failed_proposal_preserves_state(
     assert all(g.gate_name.startswith("zero_trade_repair_") for g in critical_gates)
 
 
+def test_zero_trade_repair_failed_proposal_is_pure_wrt_input_code_and_spec(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rejected repair leaves the caller's input ``code`` and ``spec``
+    untouched — ``try_repair`` is pure with respect to its inputs, so the
+    fallback ``RefinementAgent`` runs against the original known-good blob
+    rather than a half-mutated one."""
+    orch, repair_stub, sandbox_stub = _make_orchestrator_with_stubs(
+        monkeypatch,
+        repair_reports=[
+            ZeroTradeRepairReport(
+                root_cause_category="NO_ORDERS_EMITTED",
+                evidence="orders_emitted=0",
+                proposed_code=_REPAIRED_CODE,
+                changes_made="attempted RSI loosen",
+            ),
+        ],
+        sandbox_results=[
+            _code_exec(success=True, raw_trades=[]),  # zero trades again → reject
+        ],
+    )
+
+    input_spec = _spec()
+    input_code = "INPUT-CODE-BLOB"
+    spec_before = input_spec.model_dump()
+
+    outcome, _events, _attempts = _drive_repair(orch, spec=input_spec, code=input_code)
+
+    assert outcome.committed is False
+    # The input objects the caller still holds are unchanged.
+    assert input_code == "INPUT-CODE-BLOB"
+    assert input_spec.model_dump() == spec_before
+    # The repairer signals "no commit" via empty/None outcome fields rather
+    # than handing back a mutated blob.
+    assert outcome.new_code == ""
+    assert outcome.new_spec is None
+
+
 def test_zero_trade_repair_unsafe_code_rejected(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Closes #668.

## Problem

Long-lived mutable state threaded through the Strategy Lab design loop bled revisions from a *failed* attempt into the *next* one. `run_cycle` created a single `_DriftCollector` (`orchestrator.py`) and shared it unchanged across every design re-entry (`MAX_DESIGN_REENTRIES`), so a failed attempt-0's spec/code revisions poisoned attempt-1's reasoning and contaminated the resulting record.

While implementing, I confirmed (the issue's line numbers had drifted) that intervening refactors already satisfy two of the four sub-items — they're locked in with tests rather than re-fixed:
- `_AlignmentRoundOutcome` no longer has an `issues` field; the alignment path re-derives `report.issues` deterministically per round and carries pre/post state via the outcome.
- `ZeroTradeRepairer.try_repair()` already builds a fresh spec/code and never mutates the caller's `code`; the failed-repair fallback runs against the original blob.

## Change

Adopt a **copy-on-entry, commit-on-completion** contract:

- `_DriftCollector` gains `snapshot()` (returns a fresh, empty isolated child — records are append-only/immutable, so isolation is an empty collector, not a deep copy) and `merge(child)` (folds a child's records into the parent in order).
- `run_cycle` hands each design attempt its own `snapshot()`. On **success** the record reflects only that attempt; on **failure** the child is merged into the parent commit log so the short-circuit diagnostic record still shows what every failed attempt tried — while the next attempt always starts from a clean child.
- `cumulative_gate_results` stays deliberately cumulative across attempts (it feeds the deflated-Sharpe multiple-testing burden) and is documented as such.

## Tests

- `_DriftCollector.snapshot()`/`merge()` unit semantics (isolation, ordering, child untouched).
- A failed design attempt does not poison the next attempt's collector; the short-circuit record preserves all failed attempts' drift.
- `ZeroTradeRepairer` purity w.r.t. input code/spec on a rejected repair.
- A rejected alignment proposal preserves the known-good spec/code objects.

## Docs

New `RETRY_STATE_ISOLATION.md` describing the snapshot/commit contract across the design / synthesis / alignment / repair loops, cross-referenced from `LOOK_AHEAD_DEFENCE.md`.

## Acceptance criteria

- [x] No path in the orchestrator mutates state that survives a failed attempt.
- [x] `_DriftCollector` cannot accumulate entries from a failed design attempt into the next one.
- [x] `ZeroTradeRepairer` is pure with respect to its input code blob.
- [x] Regression test: deliberately fail attempt 0 in design, attempt 1 sees a clean `_DriftCollector` modulo what the parent explicitly merged.
- [x] Architecture doc updated.

## Verification

```
pytest agents/investment_team/tests/test_strategy_lab_drift_observability.py \
       agents/investment_team/tests/test_strategy_lab_phase_transitions.py \
       agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py \
       agents/investment_team/tests/test_strategy_lab_alignment.py
```
85 passed. Broader Strategy-Lab sweep (`-k "strategy_lab or orchestrator or design or drift or alignment or synthesis or zero_trade"`): 688 passed, 1 skipped — no regressions. `ruff check` clean on all changed files.

https://claude.ai/code/session_01Dw7dY94fjS9QHMEoUK4zZG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dw7dY94fjS9QHMEoUK4zZG)_