### PR TITLE
Strategy Lab: targeted predicate-conformance repair + flag non-conforming backtests

### DIFF
--- a/backend/agents/investment_team/models.py
+++ b/backend/agents/investment_team/models.py
@@ -1125,6 +1125,16 @@ class StrategyLabRecord(BaseModel):
             "rows and on paths that bypass the design loop."
         ),
     )
+    ran_on_non_conforming_code: bool = Field(
+        default=False,
+        description=(
+            "True when the cycle's backtest executed custom code that failed "
+            "the predicate-conformance gate and was demoted to a warning past "
+            "the configured retry budget rather than being repaired. False on "
+            "legacy rows, compiled-path rows, and conforming custom-code rows. "
+            "Mirrors loop_telemetry['ran_on_non_conforming_code']."
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
+++ b/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
@@ -110,6 +110,13 @@ class _AlignmentLoopOutcome:
     alignment_reports: List[Any] = field(default_factory=list)
     trades_aligned: bool = False
     rejection_reason: Optional[str] = None
+    # True when the persisted backtest ran on custom code whose
+    # predicate-conformance check is non-conforming. Initialised from the
+    # synthesis-loop value and re-derived whenever an alignment round commits
+    # new code (which replaces the persisted trades but is not otherwise
+    # conformance-gated), so it always tracks the code that produced the
+    # returned ``trades``/``metrics``.
+    ran_on_non_conforming_code: bool = False
 
     @property
     def alignment_rounds(self) -> int:
@@ -139,6 +146,10 @@ class _AlignmentRoundOutcome:
     trades: List[TradeRecord]
     metrics: BacktestResult
     terminate: bool
+    # Set on a committing round (``terminate=False``) to the conformance
+    # verdict of the just-committed code; ignored on terminate rounds (which
+    # carry the unchanged pre-iteration state).
+    ran_on_non_conforming_code: bool = False
 
 
 @dataclass

--- a/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
+++ b/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
@@ -177,6 +177,12 @@ class _AnomalyRecoveryOutcome:
     metrics: BacktestResult
     exec_result: StrategyRunResult
     exhausted: bool
+    # Set only when a zero-trade repair commits new code (which replaces the
+    # persisted trades but is not otherwise conformance-gated): the conformance
+    # verdict of the committed repair code. ``None`` on the generic-refinement
+    # path, which leaves ``trades`` unchanged so the round's existing verdict
+    # still applies and must not be overwritten.
+    ran_on_non_conforming_code: Optional[bool] = None
 
 
 @dataclass(frozen=True)

--- a/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
+++ b/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
@@ -605,6 +605,13 @@ class _SynthesisLoopOutcome:
     # round, even when intermediate rounds tripped the trap and were
     # repaired by refinement.
     runtime_lookahead_violation: bool = False
+    # True iff the round that produced the persisted ``trades``/``metrics`` ran
+    # custom code whose predicate-conformance check was demoted (warning) past
+    # the retry budget. Captured at trade-collection time so it tracks the
+    # backtest that is actually persisted — a later round that passes
+    # conformance but fails execution before collecting new trades leaves this
+    # reflecting the earlier demoted round whose backtest still stands.
+    ran_on_non_conforming_code: bool = False
 
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -464,6 +464,35 @@ def _design_loop_telemetry_summary(
     }
 
 
+def _settled_ran_on_non_conforming(all_gate_results: List[QualityGateResult]) -> bool:
+    """Whether the *settled* round's backtest ran on demoted custom code.
+
+    Pre: ``all_gate_results`` is the cycle's full gate timeline; each
+    ``predicate_conformance`` result carries the ``refinement_round`` stamped by
+    :meth:`StrategyLabOrchestrator.record_gates`.
+    Post: returns ``True`` iff a ``predicate_conformance`` result from the
+    highest round that ran the gate did not pass and is a *demotion* warning
+    (``severity == "warning"``, excluding the ``"Fixture unsynthesizable:"``
+    "could-not-check" warning). The synthesis loop re-runs validation — and thus
+    the conformance gate — at the top of every round, so the highest-round
+    conformance result reflects the code that actually reached the persisted
+    backtest; an earlier demoted warning that a later round repaired does not
+    flag the record. Returns ``False`` when no conformance gate ran (compiled
+    path / no predicate rules).
+    """
+    pc = [g for g in all_gate_results if g.gate_name == "predicate_conformance"]
+    if not pc:
+        return False
+    final_round = max(g.refinement_round for g in pc)
+    return any(
+        g.refinement_round == final_round
+        and not g.passed
+        and g.severity == "warning"
+        and not (g.details or "").startswith("Fixture unsynthesizable:")
+        for g in pc
+    )
+
+
 def _finalize_loop_telemetry(
     design_context: "_DesignPersistContext",
     all_gate_results: List[QualityGateResult],
@@ -493,32 +522,22 @@ def _finalize_loop_telemetry(
     verbatim for backward compatibility, but it is only meaningful when
     ``code_path != "not_synthesized"``.
 
-    ``ran_on_non_conforming_code`` is ``True`` iff the gate timeline contains a
-    *demoted* predicate-conformance failure — a ``predicate_conformance`` result
-    that did not pass and carries ``severity == "warning"`` — which is exactly
-    the state reached when the conformance gate exhausted its retry budget and
-    let semantically-divergent custom code proceed to backtest. The
-    ``"Fixture unsynthesizable:"`` warning is excluded: it means the gate could
-    not *check* the rule, not that the code was checked and drifted, so it must
-    not mark the backtest non-conforming.
+    ``ran_on_non_conforming_code`` reflects the *settled* round only — see
+    :func:`_settled_ran_on_non_conforming`. The synthesis loop accumulates gate
+    results across every refinement round, so an early demoted warning may have
+    been repaired by a later round whose conforming code ran the persisted
+    backtest; deriving the flag from the highest-round conformance result avoids
+    a stale-True from a since-repaired round.
     """
     telemetry: Dict[str, Any] = dict(design_context.loop_telemetry)
     pass_counts: Dict[str, int] = {}
     fail_counts: Dict[str, int] = {}
-    ran_on_non_conforming = False
     for g in all_gate_results:
         bucket = pass_counts if g.passed else fail_counts
         bucket[g.gate_name] = bucket.get(g.gate_name, 0) + 1
-        if (
-            g.gate_name == "predicate_conformance"
-            and not g.passed
-            and g.severity == "warning"
-            and not (g.details or "").startswith("Fixture unsynthesizable:")
-        ):
-            ran_on_non_conforming = True
     telemetry["gate_pass_counts"] = pass_counts
     telemetry["gate_fail_counts"] = fail_counts
-    telemetry["ran_on_non_conforming_code"] = ran_on_non_conforming
+    telemetry["ran_on_non_conforming_code"] = _settled_ran_on_non_conforming(all_gate_results)
     requires_custom = bool(getattr(spec, "requires_custom_code", False))
     if not (code or "").strip():
         telemetry["code_path"] = "not_synthesized"

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -1832,6 +1832,12 @@ class StrategyLabOrchestrator:
                 )
                 spec, code = recovery.spec, recovery.code
                 trades, metrics = recovery.trades, recovery.metrics
+                # A committed zero-trade repair replaced the persisted trades
+                # with new code; adopt its conformance verdict. The generic
+                # refine path leaves the trades (and so the verdict) unchanged
+                # and signals that with ``None``.
+                if recovery.ran_on_non_conforming_code is not None:
+                    ran_on_non_conforming_code = recovery.ran_on_non_conforming_code
                 exec_result = recovery.exec_result
                 runtime_lookahead_violation = exec_result.error_type == "lookahead_violation"
                 if recovery.exhausted:
@@ -1971,6 +1977,26 @@ class StrategyLabOrchestrator:
                         "via": "zero_trade_repair",
                     },
                 )
+                # The committed repair replaces the persisted trades/code, but
+                # the repairer does not re-run the predicate-conformance gate.
+                # Re-check it on the committed repair code (at the demotion
+                # threshold — there is no further repair round to fix drift) so
+                # the non-conforming flag describes the repaired backtest. The
+                # caller adopts this value only on commit; the generic-refine
+                # path below leaves it ``None`` (trades unchanged).
+                ztr_conformance = self.predicate_conformance_gate.check(
+                    zt_outcome.new_code,
+                    zt_outcome.new_spec,
+                    phase="verification",
+                    attempt=_code_conformance_retries(),
+                )
+                ztr_non_conforming = _round_demoted_conformance(ztr_conformance)
+                self.record_gates(
+                    ztr_conformance,
+                    all_gate_results,
+                    refinement_round=round_num,
+                    gate_name_prefix="zero_trade_repair_",
+                )
                 return _AnomalyRecoveryOutcome(
                     spec=zt_outcome.new_spec,
                     code=zt_outcome.new_code,
@@ -1978,6 +2004,7 @@ class StrategyLabOrchestrator:
                     metrics=zt_outcome.new_metrics,
                     exec_result=zt_outcome.new_exec_result,
                     exhausted=False,
+                    ran_on_non_conforming_code=ztr_non_conforming,
                 )
 
         # ── 3: Generic refinement (or exhaust the round budget) ──

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -464,32 +464,22 @@ def _design_loop_telemetry_summary(
     }
 
 
-def _settled_ran_on_non_conforming(all_gate_results: List[QualityGateResult]) -> bool:
-    """Whether the *settled* round's backtest ran on demoted custom code.
+def _round_demoted_conformance(round_gate_results: List[QualityGateResult]) -> bool:
+    """Whether a single round's predicate-conformance check was demoted.
 
-    Pre: ``all_gate_results`` is the cycle's full gate timeline; each
-    ``predicate_conformance`` result carries the ``refinement_round`` stamped by
-    :meth:`StrategyLabOrchestrator.record_gates`.
-    Post: returns ``True`` iff a ``predicate_conformance`` result from the
-    highest round that ran the gate did not pass and is a *demotion* warning
-    (``severity == "warning"``, excluding the ``"Fixture unsynthesizable:"``
-    "could-not-check" warning). The synthesis loop re-runs validation — and thus
-    the conformance gate — at the top of every round, so the highest-round
-    conformance result reflects the code that actually reached the persisted
-    backtest; an earlier demoted warning that a later round repaired does not
-    flag the record. Returns ``False`` when no conformance gate ran (compiled
-    path / no predicate rules).
+    Pre: ``round_gate_results`` are the gate results for one synthesis round.
+    Post: returns ``True`` iff the round contains a ``predicate_conformance``
+    result that did not pass and is a *demotion* warning (``severity ==
+    "warning"``, excluding the ``"Fixture unsynthesizable:"`` "could-not-check"
+    warning). Evaluated per round so the caller can attribute the verdict to the
+    round whose backtest is persisted, rather than to any historical round.
     """
-    pc = [g for g in all_gate_results if g.gate_name == "predicate_conformance"]
-    if not pc:
-        return False
-    final_round = max(g.refinement_round for g in pc)
     return any(
-        g.refinement_round == final_round
+        g.gate_name == "predicate_conformance"
         and not g.passed
         and g.severity == "warning"
         and not (g.details or "").startswith("Fixture unsynthesizable:")
-        for g in pc
+        for g in round_gate_results
     )
 
 
@@ -498,6 +488,8 @@ def _finalize_loop_telemetry(
     all_gate_results: List[QualityGateResult],
     spec: StrategySpec,
     code: str,
+    *,
+    ran_on_non_conforming_code: bool = False,
 ) -> Dict[str, Any]:
     """Merge the design-loop telemetry with whole-funnel gate counters.
 
@@ -505,6 +497,9 @@ def _finalize_loop_telemetry(
     ``all_gate_results`` is the cycle's full gate timeline; ``spec`` is the
     settled spec; ``code`` is the synthesized strategy code (empty string when
     the cycle short-circuited before code synthesis was attempted).
+    ``ran_on_non_conforming_code`` is the authoritative flag captured by
+    ``_run_synthesis_loop`` for the round whose backtest is persisted (defaults
+    ``False`` for short-circuit records that never executed a backtest).
     Post: returns the persisted ``loop_telemetry`` summary — the design-loop
     slice plus per-gate pass/fail histograms (keyed on ``gate_name``) and a
     three-state ``code_path`` (the compiled-vs-custom share signal other
@@ -522,12 +517,13 @@ def _finalize_loop_telemetry(
     verbatim for backward compatibility, but it is only meaningful when
     ``code_path != "not_synthesized"``.
 
-    ``ran_on_non_conforming_code`` reflects the *settled* round only — see
-    :func:`_settled_ran_on_non_conforming`. The synthesis loop accumulates gate
-    results across every refinement round, so an early demoted warning may have
-    been repaired by a later round whose conforming code ran the persisted
-    backtest; deriving the flag from the highest-round conformance result avoids
-    a stale-True from a since-repaired round.
+    ``ran_on_non_conforming_code`` is stored verbatim from the loop-captured
+    flag rather than re-derived from ``all_gate_results``: the loop accumulates
+    gate results across every refinement round, and the persisted backtest
+    belongs to the last round that *executed and collected trades* — which is
+    not necessarily the last round that ran the conformance gate (a later round
+    can pass conformance yet fail execution, leaving an earlier demoted round's
+    backtest in place). Only the loop knows which round's trades survived.
     """
     telemetry: Dict[str, Any] = dict(design_context.loop_telemetry)
     pass_counts: Dict[str, int] = {}
@@ -537,7 +533,7 @@ def _finalize_loop_telemetry(
         bucket[g.gate_name] = bucket.get(g.gate_name, 0) + 1
     telemetry["gate_pass_counts"] = pass_counts
     telemetry["gate_fail_counts"] = fail_counts
-    telemetry["ran_on_non_conforming_code"] = _settled_ran_on_non_conforming(all_gate_results)
+    telemetry["ran_on_non_conforming_code"] = ran_on_non_conforming_code
     requires_custom = bool(getattr(spec, "requires_custom_code", False))
     if not (code or "").strip():
         telemetry["code_path"] = "not_synthesized"
@@ -1606,6 +1602,12 @@ class StrategyLabOrchestrator:
         # generic ``publication_disabled`` message.
         runtime_lookahead_violation = False
         predicate_conformance_attempts = 0
+        # Captured at trade-collection time for the round whose backtest is
+        # persisted: True when that round ran custom code whose
+        # predicate-conformance check was demoted (warning) past the retry
+        # budget. A later round that passes conformance but fails before
+        # collecting trades does not clear an earlier demoted round's value.
+        ran_on_non_conforming_code = False
 
         for round_num in range(MAX_CODE_REFINEMENT_ROUNDS):
             round_gate_results: List[QualityGateResult] = []
@@ -1761,6 +1763,10 @@ class StrategyLabOrchestrator:
 
             # ── 2d: COLLECT TRADES + target-symbol coverage on trades ─
             trades = exec_result.trades
+            # This round's executed code is what produced the persisted trades;
+            # attribute the conformance verdict to it (overwriting any earlier
+            # round's value) so the flag tracks the backtest that survives.
+            ran_on_non_conforming_code = _round_demoted_conformance(round_gate_results)
             open_position_entry_reasons = getattr(exec_result, "open_position_entry_reasons", [])
 
             trade_coverage_gates = self.target_symbol_coverage_gate.check_trades(spec, trades)
@@ -1859,6 +1865,7 @@ class StrategyLabOrchestrator:
             provider_used=provider_used,
             open_position_entry_reasons=open_position_entry_reasons,
             runtime_lookahead_violation=runtime_lookahead_violation,
+            ran_on_non_conforming_code=ran_on_non_conforming_code,
         )
 
     def _handle_critical_anomalies(
@@ -2885,6 +2892,7 @@ class StrategyLabOrchestrator:
         alignment_rounds: int,
         all_gate_results: List[QualityGateResult],
         emit: PhaseCallback,
+        ran_on_non_conforming_code: bool = False,
         design_context: Optional[_DesignPersistContext] = None,
         alignment_findings: Optional[List[AlignmentFinding]] = None,
         phase_back_count: int = 0,
@@ -2967,7 +2975,13 @@ class StrategyLabOrchestrator:
         ]
         rule_impl_map = _build_rule_implementation_map(spec, list(alignment_findings or []), code)
         lab_record_id = f"lab-{uuid.uuid4().hex[:8]}"
-        loop_telemetry = _finalize_loop_telemetry(design_context, all_gate_results, spec, code)
+        loop_telemetry = _finalize_loop_telemetry(
+            design_context,
+            all_gate_results,
+            spec,
+            code,
+            ran_on_non_conforming_code=ran_on_non_conforming_code,
+        )
         record = StrategyLabRecord(
             lab_record_id=lab_record_id,
             strategy=spec,
@@ -2989,9 +3003,7 @@ class StrategyLabOrchestrator:
             gate_timeline=gate_timeline,
             rule_implementation_map=rule_impl_map,
             loop_telemetry=loop_telemetry,
-            ran_on_non_conforming_code=bool(
-                loop_telemetry.get("ran_on_non_conforming_code", False)
-            ),
+            ran_on_non_conforming_code=ran_on_non_conforming_code,
         )
 
         self.convergence_tracker.record(spec, all_gate_results)
@@ -3466,6 +3478,7 @@ class StrategyLabOrchestrator:
             alignment_rounds=alignment_rounds,
             all_gate_results=all_gate_results,
             emit=emit,
+            ran_on_non_conforming_code=synthesis.ran_on_non_conforming_code,
             design_context=design_context,
             alignment_findings=alignment_findings,
             phase_back_count=phase_back_count,
@@ -3827,6 +3840,9 @@ class StrategyLabOrchestrator:
             for g in all_gate_results
         ]
         lab_record_id = f"lab-{uuid.uuid4().hex[:8]}"
+        # A short-circuit record never executed a backtest, so it never ran on
+        # non-conforming code (the flag defaults False on both telemetry and
+        # the record field).
         loop_telemetry = _finalize_loop_telemetry(design_context, all_gate_results, spec, code)
         record = StrategyLabRecord(
             lab_record_id=lab_record_id,
@@ -3848,9 +3864,7 @@ class StrategyLabOrchestrator:
             code_history=list(dc.code_history),
             gate_timeline=gate_timeline,
             loop_telemetry=loop_telemetry,
-            ran_on_non_conforming_code=bool(
-                loop_telemetry.get("ran_on_non_conforming_code", False)
-            ),
+            ran_on_non_conforming_code=False,
         )
 
         # Short-circuited cycles never reached a backtest, and ``spec`` may

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -492,15 +492,33 @@ def _finalize_loop_telemetry(
     telemetry exists to explain. ``requires_custom_code`` is also retained
     verbatim for backward compatibility, but it is only meaningful when
     ``code_path != "not_synthesized"``.
+
+    ``ran_on_non_conforming_code`` is ``True`` iff the gate timeline contains a
+    *demoted* predicate-conformance failure — a ``predicate_conformance`` result
+    that did not pass and carries ``severity == "warning"`` — which is exactly
+    the state reached when the conformance gate exhausted its retry budget and
+    let semantically-divergent custom code proceed to backtest. The
+    ``"Fixture unsynthesizable:"`` warning is excluded: it means the gate could
+    not *check* the rule, not that the code was checked and drifted, so it must
+    not mark the backtest non-conforming.
     """
     telemetry: Dict[str, Any] = dict(design_context.loop_telemetry)
     pass_counts: Dict[str, int] = {}
     fail_counts: Dict[str, int] = {}
+    ran_on_non_conforming = False
     for g in all_gate_results:
         bucket = pass_counts if g.passed else fail_counts
         bucket[g.gate_name] = bucket.get(g.gate_name, 0) + 1
+        if (
+            g.gate_name == "predicate_conformance"
+            and not g.passed
+            and g.severity == "warning"
+            and not (g.details or "").startswith("Fixture unsynthesizable:")
+        ):
+            ran_on_non_conforming = True
     telemetry["gate_pass_counts"] = pass_counts
     telemetry["gate_fail_counts"] = fail_counts
+    telemetry["ran_on_non_conforming_code"] = ran_on_non_conforming
     requires_custom = bool(getattr(spec, "requires_custom_code", False))
     if not (code or "").strip():
         telemetry["code_path"] = "not_synthesized"
@@ -2930,6 +2948,7 @@ class StrategyLabOrchestrator:
         ]
         rule_impl_map = _build_rule_implementation_map(spec, list(alignment_findings or []), code)
         lab_record_id = f"lab-{uuid.uuid4().hex[:8]}"
+        loop_telemetry = _finalize_loop_telemetry(design_context, all_gate_results, spec, code)
         record = StrategyLabRecord(
             lab_record_id=lab_record_id,
             strategy=spec,
@@ -2950,7 +2969,10 @@ class StrategyLabOrchestrator:
             code_history=list(dc.code_history),
             gate_timeline=gate_timeline,
             rule_implementation_map=rule_impl_map,
-            loop_telemetry=_finalize_loop_telemetry(design_context, all_gate_results, spec, code),
+            loop_telemetry=loop_telemetry,
+            ran_on_non_conforming_code=bool(
+                loop_telemetry.get("ran_on_non_conforming_code", False)
+            ),
         )
 
         self.convergence_tracker.record(spec, all_gate_results)
@@ -3786,6 +3808,7 @@ class StrategyLabOrchestrator:
             for g in all_gate_results
         ]
         lab_record_id = f"lab-{uuid.uuid4().hex[:8]}"
+        loop_telemetry = _finalize_loop_telemetry(design_context, all_gate_results, spec, code)
         record = StrategyLabRecord(
             lab_record_id=lab_record_id,
             strategy=spec,
@@ -3805,7 +3828,10 @@ class StrategyLabOrchestrator:
             spec_history=list(dc.spec_history),
             code_history=list(dc.code_history),
             gate_timeline=gate_timeline,
-            loop_telemetry=_finalize_loop_telemetry(design_context, all_gate_results, spec, code),
+            loop_telemetry=loop_telemetry,
+            ran_on_non_conforming_code=bool(
+                loop_telemetry.get("ran_on_non_conforming_code", False)
+            ),
         )
 
         # Short-circuited cycles never reached a backtest, and ``spec`` may

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -710,6 +710,48 @@ class StrategyLabOrchestrator:
             all_gate_results.extend(results)
         return results
 
+    def _committed_code_conformance_verdict(
+        self,
+        code: str,
+        spec: StrategySpec,
+        *,
+        all_gate_results: List[QualityGateResult],
+        refinement_round: int,
+        gate_name_prefix: str,
+    ) -> bool:
+        """Re-check predicate conformance on code committed *after* synthesis.
+
+        The post-synthesis commit paths — trade-alignment fixes
+        (``_run_alignment_round``) and zero-trade repair
+        (``_handle_critical_anomalies``) — replace the persisted ``code`` /
+        ``trades`` but do not otherwise re-run the predicate-conformance gate.
+        This re-runs it on the committed ``code`` / ``spec`` so the
+        ``ran_on_non_conforming_code`` flag describes the code that produced the
+        persisted backtest.
+
+        Pre: ``code`` / ``spec`` are a committed proposal that already executed
+        a real backtest; there is no further refinement round to repair drift,
+        so the gate runs at the demotion threshold (``attempt =
+        _code_conformance_retries()``) — any drift surfaces as a warning.
+        Post: appends the gate results to ``all_gate_results`` (with
+        ``gate_name_prefix``) and returns ``True`` iff the committed code is a
+        demotion-warning non-conformance. The verdict is computed *before*
+        ``record_gates`` prefixes ``gate_name`` (``_round_demoted_conformance``
+        matches the unprefixed ``"predicate_conformance"``). Compiled /
+        no-predicate specs return a passing "skipped" result and never flag.
+        """
+        results = self.predicate_conformance_gate.check(
+            code, spec, phase="verification", attempt=_code_conformance_retries()
+        )
+        verdict = _round_demoted_conformance(results)
+        self.record_gates(
+            results,
+            all_gate_results,
+            refinement_round=refinement_round,
+            gate_name_prefix=gate_name_prefix,
+        )
+        return verdict
+
     def build_orchestrator_gate(
         self,
         name: str,
@@ -1977,23 +2019,15 @@ class StrategyLabOrchestrator:
                         "via": "zero_trade_repair",
                     },
                 )
-                # The committed repair replaces the persisted trades/code, but
-                # the repairer does not re-run the predicate-conformance gate.
-                # Re-check it on the committed repair code (at the demotion
-                # threshold — there is no further repair round to fix drift) so
-                # the non-conforming flag describes the repaired backtest. The
-                # caller adopts this value only on commit; the generic-refine
-                # path below leaves it ``None`` (trades unchanged).
-                ztr_conformance = self.predicate_conformance_gate.check(
+                # The committed repair replaces the persisted trades/code;
+                # re-check predicate conformance on it so the non-conforming flag
+                # describes the repaired backtest (the repairer does not re-run
+                # the gate). The caller adopts this value only on commit; the
+                # generic-refine path below leaves it ``None`` (trades unchanged).
+                ztr_non_conforming = self._committed_code_conformance_verdict(
                     zt_outcome.new_code,
                     zt_outcome.new_spec,
-                    phase="verification",
-                    attempt=_code_conformance_retries(),
-                )
-                ztr_non_conforming = _round_demoted_conformance(ztr_conformance)
-                self.record_gates(
-                    ztr_conformance,
-                    all_gate_results,
+                    all_gate_results=all_gate_results,
                     refinement_round=round_num,
                     gate_name_prefix="zero_trade_repair_",
                 )
@@ -2446,25 +2480,13 @@ class StrategyLabOrchestrator:
                 )
             return _terminate()
 
-        # The committed proposal becomes the persisted backtest, but the
-        # alignment path does not otherwise re-run predicate conformance. Re-run
-        # it here on the proposed code so the non-conforming flag tracks the
-        # code that produced the persisted trades. There is no further
-        # refinement round to repair drift at this point, so the gate runs at
-        # the demotion threshold: any drift on the committed code surfaces as a
-        # warning and flags the record (compiled / no-predicate specs return a
-        # passing "skipped" result and never flag). The flag is computed before
-        # ``record_gates`` prefixes ``gate_name`` with ``alignment_``.
-        conformance_gates = self.predicate_conformance_gate.check(
+        # The committed proposal becomes the persisted backtest; re-check
+        # predicate conformance on it so the non-conforming flag tracks the
+        # committed code (the alignment path does not otherwise re-run the gate).
+        committed_non_conforming = self._committed_code_conformance_verdict(
             proposed_code,
             proposed_spec,
-            phase="verification",
-            attempt=_code_conformance_retries(),
-        )
-        committed_non_conforming = _round_demoted_conformance(conformance_gates)
-        self.record_gates(
-            conformance_gates,
-            all_gate_results,
+            all_gate_results=all_gate_results,
             refinement_round=align_round,
             gate_name_prefix="alignment_",
         )

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -94,7 +94,7 @@ from .quality_gates.convergence_tracker import ConvergenceTracker
 from .quality_gates.cost_stress_realism import CostStressRealismGate
 from .quality_gates.exit_rule_conformance import ExitRuleConformanceGate
 from .quality_gates.models import QualityGateResult, StrategyLabPhase
-from .quality_gates.predicate_conformance import PredicateConformanceGate
+from .quality_gates.predicate_conformance import PredicateConformanceGate, _code_conformance_retries
 from .quality_gates.realism import (
     LiquidityRealismGate,
     RegimeCoverageGate,
@@ -2015,6 +2015,7 @@ class StrategyLabOrchestrator:
         execution_succeeded: bool,
         all_gate_results: List[QualityGateResult],
         emit: PhaseCallback,
+        ran_on_non_conforming_code: bool = False,
         drift_collector: Optional[_DriftCollector] = None,
     ) -> _AlignmentLoopOutcome:
         """Run the trade-alignment audit loop after the synthesis loop settles.
@@ -2022,10 +2023,15 @@ class StrategyLabOrchestrator:
         Pre: synthesis loop has produced (``code``, ``spec``, ``trades``,
         ``metrics``) plus ``market_data`` was fetched at least once and
         ``execution_succeeded`` tracks whether the last execution cleared
-        the anomaly gates.
+        the anomaly gates. ``ran_on_non_conforming_code`` is the synthesis
+        loop's verdict for the incoming ``trades``.
         Post: returns an ``_AlignmentLoopOutcome`` carrying the (possibly
         updated) ``spec`` / ``code`` / ``trades`` / ``metrics`` plus the
         attempt-string history and per-round reports the caller persists.
+        ``ran_on_non_conforming_code`` is carried through unchanged when no
+        round commits, and re-derived from each committed round's code (which
+        replaces the persisted trades) so it always describes the returned
+        ``trades``.
         Mutates ``all_gate_results`` in place (gates appended with
         ``alignment_`` prefix on each commit / failure).
 
@@ -2055,6 +2061,7 @@ class StrategyLabOrchestrator:
                 alignment_attempts=alignment_attempts,
                 alignment_reports=alignment_reports,
                 trades_aligned=False,
+                ran_on_non_conforming_code=ran_on_non_conforming_code,
             )
 
         for align_round in range(MAX_ALIGNMENT_ROUNDS):
@@ -2074,6 +2081,12 @@ class StrategyLabOrchestrator:
             )
             spec, code = round_outcome.spec, round_outcome.code
             trades, metrics = round_outcome.trades, round_outcome.metrics
+            # A committing round (``terminate=False``) replaced the persisted
+            # trades with its proposed code; adopt that code's conformance
+            # verdict. Terminate rounds carry the unchanged prior state, so the
+            # flag is left as-is.
+            if not round_outcome.terminate:
+                ran_on_non_conforming_code = round_outcome.ran_on_non_conforming_code
             if round_outcome.terminate:
                 break
 
@@ -2122,6 +2135,7 @@ class StrategyLabOrchestrator:
             alignment_reports=alignment_reports,
             trades_aligned=trades_aligned_final,
             rejection_reason=rejection_reason,
+            ran_on_non_conforming_code=ran_on_non_conforming_code,
         )
 
     def _run_alignment_round(
@@ -2405,6 +2419,29 @@ class StrategyLabOrchestrator:
                 )
             return _terminate()
 
+        # The committed proposal becomes the persisted backtest, but the
+        # alignment path does not otherwise re-run predicate conformance. Re-run
+        # it here on the proposed code so the non-conforming flag tracks the
+        # code that produced the persisted trades. There is no further
+        # refinement round to repair drift at this point, so the gate runs at
+        # the demotion threshold: any drift on the committed code surfaces as a
+        # warning and flags the record (compiled / no-predicate specs return a
+        # passing "skipped" result and never flag). The flag is computed before
+        # ``record_gates`` prefixes ``gate_name`` with ``alignment_``.
+        conformance_gates = self.predicate_conformance_gate.check(
+            proposed_code,
+            proposed_spec,
+            phase="verification",
+            attempt=_code_conformance_retries(),
+        )
+        committed_non_conforming = _round_demoted_conformance(conformance_gates)
+        self.record_gates(
+            conformance_gates,
+            all_gate_results,
+            refinement_round=align_round,
+            gate_name_prefix="alignment_",
+        )
+
         # All gates passed — commit the proposal as the new known-good state.
         alignment_attempts.append(change_summary)
         if drift_collector is not None:
@@ -2437,6 +2474,7 @@ class StrategyLabOrchestrator:
             trades=new_trades,
             metrics=new_metrics,
             terminate=False,
+            ran_on_non_conforming_code=committed_non_conforming,
         )
 
     def _run_verification_phase(
@@ -3345,12 +3383,16 @@ class StrategyLabOrchestrator:
             execution_succeeded=execution_succeeded,
             all_gate_results=all_gate_results,
             emit=emit,
+            ran_on_non_conforming_code=synthesis.ran_on_non_conforming_code,
             drift_collector=drift_collector,
         )
         spec = alignment_outcome.spec
         code = alignment_outcome.code
         trades = alignment_outcome.trades
         metrics = alignment_outcome.metrics
+        # Tracks the code that produced the persisted trades — re-derived by the
+        # alignment loop whenever it committed new code.
+        ran_on_non_conforming_code = alignment_outcome.ran_on_non_conforming_code
         alignment_rounds = alignment_outcome.alignment_rounds
         trades_aligned = alignment_outcome.trades_aligned
         alignment_rejection_reason = alignment_outcome.rejection_reason
@@ -3478,7 +3520,7 @@ class StrategyLabOrchestrator:
             alignment_rounds=alignment_rounds,
             all_gate_results=all_gate_results,
             emit=emit,
-            ran_on_non_conforming_code=synthesis.ran_on_non_conforming_code,
+            ran_on_non_conforming_code=ran_on_non_conforming_code,
             design_context=design_context,
             alignment_findings=alignment_findings,
             phase_back_count=phase_back_count,

--- a/backend/agents/investment_team/strategy_lab/prompts/design_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/design_system.md
@@ -185,7 +185,9 @@ Whenever your hypothesis or signal definition names specific tickers (e.g. "QQQ 
 
 **Absent / `false` is the strong default. Setting it `true` is rare.**
 
-The deterministic compiler covers the **entire** indicator catalogue, **all** comparison operators (`<`, `>`, `<=`, `>=`, `==`, `cross_above`, `cross_below`), and **all** sources above. Any strategy whose entry and exit triggers are each a single `Predicate` is **always** compilable — custom code buys you nothing there, and it does NOT unlock indicator-of-indicator, arithmetic, or multi-condition predicates (the DSL has no such forms regardless of this flag).
+The deterministic compiler covers the **entire** indicator catalogue, **all** comparison operators (`<`, `>`, `<=`, `>=`, `==`, `cross_above`, `cross_below`), and **all** sources above, so a strategy whose entry and exit triggers are each a single `Predicate` is almost always compilable — custom code buys you nothing there, and it does NOT unlock indicator-of-indicator, arithmetic, or multi-condition predicates (the DSL has no such forms regardless of this flag).
+
+A few coherence constraints still can't be compiled even with single-predicate rules — `volatility_target` sizing requires exactly one referenced `atr` indicator, and `macd` requires `fast < slow`. **You do not set `requires_custom_code` for these:** keep the spec honest and well-formed (give `volatility_target` its ATR; keep MACD `fast < slow`). If a spec is otherwise un-compilable the pipeline detects it and falls back to synthesis on its own — so never flip this flag just to dodge a sizing/parameter-coherence fix.
 
 Set `requires_custom_code: true` ONLY for a genuine capability gap the single-predicate DSL cannot express even after applying resolution steps 1–2 above, namely:
 

--- a/backend/agents/investment_team/strategy_lab/prompts/design_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/design_system.md
@@ -183,7 +183,19 @@ Whenever your hypothesis or signal definition names specific tickers (e.g. "QQQ 
 
 ## `requires_custom_code`
 
-By default leave `requires_custom_code` absent or `false`. The deterministic compiler can synthesise code for any spec expressed entirely in the indicator catalogue + rule kinds above. Set `requires_custom_code: true` ONLY when your hypothesis genuinely cannot be expressed in the DSL (e.g. it needs cross-asset state the compiler does not yet model). When you set it, a separate code-synthesis step generates the Python — you still do not write code.
+**Absent / `false` is the strong default. Setting it `true` is rare.**
+
+The deterministic compiler covers the **entire** indicator catalogue, **all** comparison operators (`<`, `>`, `<=`, `>=`, `==`, `cross_above`, `cross_below`), and **all** sources above. Any strategy whose entry and exit triggers are each a single `Predicate` is **always** compilable — custom code buys you nothing there, and it does NOT unlock indicator-of-indicator, arithmetic, or multi-condition predicates (the DSL has no such forms regardless of this flag).
+
+Set `requires_custom_code: true` ONLY for a genuine capability gap the single-predicate DSL cannot express even after applying resolution steps 1–2 above, namely:
+
+- Multi-leg `AND` / `OR` entry logic that is the real, irreducible signal (not "I want a second filter" — that is steps 1–2, not custom code).
+- Cross-asset / pairs state (e.g. "long GLD only while USO is below its 50-day SMA").
+- Path-dependent state the engine does not model (custom trailing logic, bar-count regimes, etc.).
+
+"I want indicator-of-indicator" or "I want one more confirmation filter" is **not** a trigger — restructure per steps 1–2 instead.
+
+**Cost of choosing it:** custom code skips the deterministic compiler and must instead pass the predicate-conformance shadow gate, which shadow-runs your `on_bar` against the engine's own verdicts. If the generated code drifts from the spec, it is refined and — if it still drifts after the retry budget — demoted and the backtest is flagged as having run on non-conforming code. A compilable single-predicate spec avoids that entire failure surface. When you do set it, a separate code-synthesis step generates the Python — you still do not write code.
 
 ## Required output shape
 

--- a/backend/agents/investment_team/strategy_lab/quality_gates/predicate_conformance.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/predicate_conformance.py
@@ -34,13 +34,16 @@ from __future__ import annotations
 import builtins
 import logging
 import math
+import re
 import statistics
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, ClassVar, Dict, List, Optional, Type
 
 from ..spec_dsl import EntryRule as _EntryRule
+from ..spec_dsl import Predicate as _Predicate
 from ..spec_dsl import SignalExitRule as _SignalExitRule
+from ..spec_dsl import _format_predicate
 from .models import GateResultsMixin, QualityGateResult, StrategyLabPhase
 from .predicate_conformance_fixtures import ConformanceFixture, generate_conformance_fixtures
 
@@ -295,6 +298,20 @@ class PredicateConformanceGate(GateResultsMixin):
         spec: Any = None,
         demote: bool = False,
     ) -> QualityGateResult:
+        """Shadow-run one fixture and classify the result.
+
+        Preconditions:
+          ``fixture`` describes a single predicate-bearing rule; ``spec`` is
+          the owning ``StrategySpec`` (or ``None`` in narrow unit tests).
+        Postconditions:
+          Returns exactly one ``QualityGateResult`` with ``rule_id`` set.
+          When the strategy's per-bar orders diverge from the engine
+          verdicts, the failure detail names the rendered predicate and a
+          bounded per-bar ``lhs``/``rhs``/verdict trace for the offending
+          bars (see :func:`_build_conformance_detail`). The critical→warning
+          demotion is governed solely by ``demote`` and is unchanged by the
+          enriched detail.
+        """
         if not fixture.synthesizable:
             return self._warning(
                 f"Fixture unsynthesizable: {fixture.unsynthesizable_reason}",
@@ -381,20 +398,152 @@ class PredicateConformanceGate(GateResultsMixin):
                 rule_id=fixture.rule_id,
             )
 
-        parts = [f"rule_id={fixture.rule_id}: predicate conformance failed."]
-        if false_positives:
-            parts.append(
-                f"  False positives (order on predicate-false bar): bars {false_positives[:10]}"
-            )
-        if false_negatives:
-            parts.append(
-                f"  False negatives (no order on predicate-true bar): bars {false_negatives[:10]}"
-            )
-        detail = "\n".join(parts)
+        detail = _build_conformance_detail(fixture, spec, false_positives, false_negatives)
 
         if demote:
             return self._warning(detail, rule_id=fixture.rule_id)
         return self._critical(detail, rule_id=fixture.rule_id)
+
+
+# ---------------------------------------------------------------------------
+# Failure-detail rendering (targeted-repair trace)
+# ---------------------------------------------------------------------------
+
+_RULE_ID_ENTRY = re.compile(r"^entry\[(\d+)\]$")
+_RULE_ID_SIGNAL_EXIT = re.compile(r"^exit\[(\d+)\]:signal_exit$")
+
+# Cap on the number of enriched per-bar trace rows appended to a failure
+# detail. The bare index lists (truncated to 10) already convey breadth; the
+# enriched rows exist to give the refinement agent concrete values for a few
+# representative bars without making the detail string unbounded.
+_MAX_TRACE_ROWS = 5
+
+
+def _predicate_for_rule_id(spec: Any, fixture: ConformanceFixture) -> Optional[_Predicate]:
+    """Recover the ``Predicate`` behind ``fixture.rule_id`` from ``spec``.
+
+    Preconditions:
+      ``fixture.rule_id`` follows the documented format emitted by
+      :mod:`predicate_conformance_fixtures` — ``entry[{idx}]`` for entry
+      rules or ``exit[{idx}]:signal_exit`` for signal-exit rules, where
+      ``idx`` indexes ``spec.entry_rules`` / ``spec.exit_rules`` respectively.
+    Postconditions:
+      Returns the matching rule's ``when`` predicate, or ``None`` when
+      ``spec`` is missing, the id does not match the format, the index is out
+      of range, or the targeted rule is not the expected variant. Never
+      raises on a malformed id.
+    """
+    if spec is None:
+        return None
+    rule_id = fixture.rule_id
+    m = _RULE_ID_ENTRY.match(rule_id)
+    if m is not None:
+        rules = getattr(spec, "entry_rules", []) or []
+        idx = int(m.group(1))
+        if 0 <= idx < len(rules) and isinstance(rules[idx], _EntryRule):
+            return rules[idx].when
+        return None
+    m = _RULE_ID_SIGNAL_EXIT.match(rule_id)
+    if m is not None:
+        rules = getattr(spec, "exit_rules", []) or []
+        idx = int(m.group(1))
+        if 0 <= idx < len(rules) and isinstance(rules[idx], _SignalExitRule):
+            return rules[idx].when
+        return None
+    return None
+
+
+def _format_scalar(v: Optional[float]) -> str:
+    """Render an evaluator scalar for a stable, bounded detail string.
+
+    Postconditions:
+      ``None`` (warmup / unresolved) renders as ``"None"``; finite floats use
+      a fixed ``%.4g`` format so the detail string is deterministic.
+    """
+    if v is None:
+        return "None"
+    return f"{v:.4g}"
+
+
+def _enriched_trace_lines(
+    pred: _Predicate,
+    fixture: ConformanceFixture,
+    false_positives: List[int],
+    false_negatives: List[int],
+) -> List[str]:
+    """Render up to :data:`_MAX_TRACE_ROWS` per-bar diagnostic lines.
+
+    Preconditions:
+      ``pred`` is the predicate behind ``fixture.rule_id``;
+      ``false_positives`` / ``false_negatives`` are valid indices into
+      ``fixture.bars``.
+    Postconditions:
+      Returns at most ``_MAX_TRACE_ROWS`` lines covering the lowest-indexed
+      offending bars, each naming the resolved ``lhs``/``rhs``, the engine
+      verdict, and whether the bar is a false positive or false negative.
+      Returns ``[]`` when there are no offending bars.
+    """
+    from ..executor.predicate_evaluator import PandasHistoryView, evaluate_predicate
+    from .rule_probes.synthesizer import _bars_to_df
+
+    fp = set(false_positives)
+    fn = set(false_negatives)
+    ordered = sorted(fp | fn)[:_MAX_TRACE_ROWS]
+    if not ordered:
+        return []
+
+    view = PandasHistoryView(_bars_to_df(fixture.bars), {})
+    lines: List[str] = []
+    for i in ordered:
+        if i in fp:
+            kind = "false positive (ordered on predicate-false bar)"
+        else:
+            kind = "false negative (no order on predicate-true bar)"
+        res = evaluate_predicate(pred, view, i)
+        lines.append(
+            f"  bar {i}: lhs={_format_scalar(res.lhs)} {pred.op} "
+            f"rhs={_format_scalar(res.rhs)} -> engine={res.status}; {kind}"
+        )
+    return lines
+
+
+def _build_conformance_detail(
+    fixture: ConformanceFixture,
+    spec: Any,
+    false_positives: List[int],
+    false_negatives: List[int],
+) -> str:
+    """Build the failure-detail string for a non-conforming fixture.
+
+    Preconditions:
+      At least one of ``false_positives`` / ``false_negatives`` is non-empty.
+    Postconditions:
+      Returns a multi-line string that always carries the ``rule_id`` header
+      and the (≤10) offending-bar index lists. When the predicate is
+      recoverable from ``spec`` (see :func:`_predicate_for_rule_id`), it also
+      carries the rendered predicate, a bounded per-bar ``lhs``/``rhs``/verdict
+      trace, and a one-line directive for the refinement agent. Falls back to
+      the index-only form when the predicate cannot be recovered.
+    """
+    parts = [f"rule_id={fixture.rule_id}: predicate conformance failed."]
+    pred = _predicate_for_rule_id(spec, fixture)
+    if pred is not None:
+        parts.append(f"  Predicate: {_format_predicate(pred)}")
+    if false_positives:
+        parts.append(
+            f"  False positives (order on predicate-false bar): bars {false_positives[:10]}"
+        )
+    if false_negatives:
+        parts.append(
+            f"  False negatives (no order on predicate-true bar): bars {false_negatives[:10]}"
+        )
+    if pred is not None:
+        parts.extend(_enriched_trace_lines(pred, fixture, false_positives, false_negatives))
+        parts.append(
+            f"  Fix the on_bar branch implementing '{fixture.rule_id}' so it submits on the "
+            "predicate-true bars above and not on predicate-false bars."
+        )
+    return "\n".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -609,7 +758,17 @@ def _build_indicators_stub():
     from ..executor import strategy_indicators as _scalar
 
     mod = types.ModuleType("indicators")
-    for _name in ("sma", "ema", "rsi", "macd", "bollinger_bands", "atr", "adx", "stochastic", "vwap"):
+    for _name in (
+        "sma",
+        "ema",
+        "rsi",
+        "macd",
+        "bollinger_bands",
+        "atr",
+        "adx",
+        "stochastic",
+        "vwap",
+    ):
         setattr(mod, _name, getattr(_scalar, _name))
     return mod
 

--- a/backend/agents/investment_team/tests/test_predicate_conformance_gate.py
+++ b/backend/agents/investment_team/tests/test_predicate_conformance_gate.py
@@ -12,8 +12,15 @@ import textwrap
 from investment_team.models import StrategySpec
 from investment_team.strategy_lab.quality_gates.predicate_conformance import (
     PredicateConformanceGate,
+    _build_conformance_detail,
     _code_conformance_retries,
+    _enriched_trace_lines,
     _exec_strategy,
+    _format_scalar,
+    _predicate_for_rule_id,
+)
+from investment_team.strategy_lab.quality_gates.predicate_conformance_fixtures import (
+    ConformanceFixture,
 )
 from investment_team.strategy_lab.spec_dsl import (
     EntryRule,
@@ -482,3 +489,131 @@ class TestRuleIdOnResults:
         results = gate.check(_FAITHFUL_CLOSE_GT_50, spec)
         for r in results:
             assert r.rule_id is not None
+
+
+def _drift_critical(gate, spec, *, attempt=0):
+    """Return the first non-passing conformance result for the drifted entry."""
+    results = gate.check(_DRIFTED_CLOSE_GT_50, spec, attempt=attempt)
+    failing = [r for r in results if not r.passed]
+    assert failing, "expected at least one conformance failure"
+    return failing[0]
+
+
+class TestTargetedRepairTrace:
+    """Enriched failure detail (predicate + per-bar lhs/rhs/verdict)."""
+
+    def test_details_include_predicate_expression(self):
+        gate = PredicateConformanceGate()
+        spec = _spec(entry_rules=[EntryRule(when=_pred_close_gt_50(), side="long")])
+        result = _drift_critical(gate, spec, attempt=0)
+        assert result.severity == "critical"
+        # Rendered predicate ("bar.close > 50") and at least one enriched bar line.
+        assert "Predicate:" in result.details
+        # _format_predicate renders the bar-field literal without the "bar." prefix.
+        assert "close > 50" in result.details
+        assert "lhs=" in result.details
+        assert "rhs=" in result.details
+        assert "engine=" in result.details
+
+    def test_details_include_lhs_rhs_values(self):
+        gate = PredicateConformanceGate()
+        spec = _spec(entry_rules=[EntryRule(when=_pred_close_gt_50(), side="long")])
+        result = _drift_critical(gate, spec, attempt=0)
+        # The threshold (rhs) is a literal 50 — it must surface verbatim in a trace row.
+        assert "rhs=50" in result.details
+        # A directive line tells the refiner which branch to fix.
+        assert "Fix the on_bar branch implementing 'entry[0]'" in result.details
+
+    def test_repair_before_demote_attempt_sequence(self, monkeypatch):
+        """Two critical (repairable) rounds precede the demotion warning."""
+        monkeypatch.delenv("STRATEGY_LAB_CODE_CONFORMANCE_RETRIES", raising=False)
+        gate = PredicateConformanceGate()
+        spec = _spec(entry_rules=[EntryRule(when=_pred_close_gt_50(), side="long")])
+        assert _drift_critical(gate, spec, attempt=0).severity == "critical"
+        assert _drift_critical(gate, spec, attempt=1).severity == "critical"
+        # attempt == max_retries (default 2) -> demoted to warning.
+        assert _drift_critical(gate, spec, attempt=2).severity == "warning"
+
+    def test_enriched_details_bounded(self):
+        """Enriched per-bar rows are capped and the index list is retained."""
+        gate = PredicateConformanceGate()
+        spec = _spec(entry_rules=[EntryRule(when=_pred_close_gt_50(), side="long")])
+        result = _drift_critical(gate, spec, attempt=0)
+        bar_lines = [ln for ln in result.details.splitlines() if ln.strip().startswith("bar ")]
+        assert 1 <= len(bar_lines) <= 5
+        # The bare (≤10) index list is still present alongside the enriched rows.
+        assert "False positives" in result.details or "False negatives" in result.details
+
+
+class TestUnsynthesizableWarning:
+    def test_unsynthesizable_detail_prefix(self):
+        """The unsynthesizable warning carries a stable prefix the telemetry excludes."""
+        gate = PredicateConformanceGate()
+        fixture = ConformanceFixture(
+            rule_id="entry[0]",
+            rule_kind="entry",
+            side="long",
+            synthesizable=False,
+            unsynthesizable_reason="no forcing sequence",
+        )
+        with gate._using_phase("synthesis"):
+            result = gate._check_fixture(object, fixture, spec=None, demote=False)
+        assert result.severity == "warning"
+        assert result.details.startswith("Fixture unsynthesizable:")
+
+
+class TestPredicateForRuleId:
+    def test_resolves_entry_predicate(self):
+        pred = _pred_close_gt_50()
+        spec = _spec(entry_rules=[EntryRule(when=pred, side="long")])
+        fixture = ConformanceFixture(rule_id="entry[0]", rule_kind="entry", side="long")
+        assert _predicate_for_rule_id(spec, fixture) is pred
+
+    def test_resolves_signal_exit_predicate(self):
+        pred = Predicate(lhs="bar.close", op="<", rhs=90.0)
+        spec = _spec(
+            exit_rules=[StopLossRule(pct=0.05), SignalExitRule(when=pred)],
+        )
+        # exit_rules[1] is the SignalExitRule -> rule_id carries that index.
+        fixture = ConformanceFixture(rule_id="exit[1]:signal_exit", rule_kind="signal_exit")
+        assert _predicate_for_rule_id(spec, fixture) is pred
+
+    def test_malformed_rule_id_returns_none(self):
+        spec = _spec(entry_rules=[EntryRule(when=_pred_close_gt_50(), side="long")])
+        fixture = ConformanceFixture(rule_id="bogus[x]", rule_kind="entry", side="long")
+        assert _predicate_for_rule_id(spec, fixture) is None
+
+    def test_out_of_range_index_returns_none(self):
+        spec = _spec(entry_rules=[EntryRule(when=_pred_close_gt_50(), side="long")])
+        fixture = ConformanceFixture(rule_id="entry[7]", rule_kind="entry", side="long")
+        assert _predicate_for_rule_id(spec, fixture) is None
+
+    def test_none_spec_returns_none(self):
+        fixture = ConformanceFixture(rule_id="entry[0]", rule_kind="entry", side="long")
+        assert _predicate_for_rule_id(None, fixture) is None
+
+    def test_wrong_variant_at_index_returns_none(self):
+        # exit[0] points at a StopLossRule, not a SignalExitRule -> no predicate.
+        spec = _spec(exit_rules=[StopLossRule(pct=0.05)])
+        fixture = ConformanceFixture(rule_id="exit[0]:signal_exit", rule_kind="signal_exit")
+        assert _predicate_for_rule_id(spec, fixture) is None
+
+
+class TestDetailHelpers:
+    def test_format_scalar_none_and_float(self):
+        assert _format_scalar(None) == "None"
+        assert _format_scalar(1.23456) == "1.235"
+
+    def test_enriched_trace_lines_empty_when_no_offending_bars(self):
+        fixture = ConformanceFixture(rule_id="entry[0]", rule_kind="entry", side="long")
+        assert _enriched_trace_lines(_pred_close_gt_50(), fixture, [], []) == []
+
+    def test_build_conformance_detail_falls_back_without_predicate(self):
+        # Unresolvable rule_id -> index-only detail, no "Predicate:" / directive line.
+        spec = _spec(entry_rules=[EntryRule(when=_pred_close_gt_50(), side="long")])
+        fixture = ConformanceFixture(rule_id="bogus[x]", rule_kind="entry", side="long")
+        detail = _build_conformance_detail(fixture, spec, [3], [7])
+        assert "Predicate:" not in detail
+        assert "Fix the on_bar branch" not in detail
+        assert "False positives" in detail
+        assert "False negatives" in detail

--- a/backend/agents/investment_team/tests/test_rule_probes_orchestrator.py
+++ b/backend/agents/investment_team/tests/test_rule_probes_orchestrator.py
@@ -111,9 +111,7 @@ def test_probe_gate_runs_when_conformance_is_clean(monkeypatch):
     captured: List[dict] = []
 
     def fake_refine(*, spec, code, failure_phase, failure_details, **kw):
-        captured.append(
-            {"failure_phase": failure_phase, "failure_details": failure_details}
-        )
+        captured.append({"failure_phase": failure_phase, "failure_details": failure_details})
         return spec, code, True  # exhausted
 
     orch._refine_or_exhaust = fake_refine
@@ -151,9 +149,7 @@ def test_probe_gate_skipped_when_any_prior_validation_gate_emits_critical():
     orch = StrategyLabOrchestrator()
     # spec_readiness emits a critical — code_safety/conformance happen to
     # be clean. Probe must not run.
-    orch.spec_readiness_gate.validate = lambda spec, **kw: [
-        _critical_result("spec_readiness")
-    ]
+    orch.spec_readiness_gate.validate = lambda spec, **kw: [_critical_result("spec_readiness")]
     orch.code_safety_checker.check = lambda code, spec: [_info_result("code_safety")]
     orch.code_conformance_gate.check = lambda code, spec: [_info_result("code_conformance")]
 
@@ -304,3 +300,106 @@ def test_record_gates_captures_probe_results_with_rule_id():
     probe_results = [r for r in all_results if r.gate_name == "rule_probes"]
     assert probe_results, "rule_probes results must be recorded in all_gate_results"
     assert probe_results[0].rule_id == "entry[0]"
+
+
+# ---------------------------------------------------------------------------
+# ran_on_non_conforming_code is captured at trade-collection time, attributed
+# to the round whose backtest is persisted (not any historical demoted round)
+# ---------------------------------------------------------------------------
+
+
+def _demoted_conformance(code, spec, **kw):
+    return [
+        QualityGateResult(
+            gate_name="predicate_conformance",
+            passed=False,
+            severity="warning",
+            phase="synthesis",
+            details="rule_id=entry[0]: predicate conformance failed.",
+        )
+    ]
+
+
+def _stub_execute_path(orch: StrategyLabOrchestrator, *, exec_results) -> None:
+    """Stub fetch → execute → coverage → anomaly so the loop reaches (or passes)
+    trade collection without a sandbox or market-data service."""
+    from investment_team.market_data_service import OHLCVBar
+    from investment_team.strategy_lab import orchestrator as orch_mod
+    from investment_team.strategy_lab._orchestrator_helpers import _MarketDataFetch
+
+    bars = [
+        OHLCVBar(
+            date=f"2023-01-{i + 1:02d}", open=100.0, high=101.0, low=99.0, close=100.0, volume=1
+        )
+        for i in range(20)
+    ]
+    orch._fetch_market_data = lambda spec, config: _MarketDataFetch(
+        data={"PROBE": bars}, requested_symbols=["PROBE"], fetched_symbols=["PROBE"]
+    )
+    orch.target_symbol_coverage_gate.check_fetch = lambda *a, **k: [_info_result("coverage_fetch")]
+    orch.target_symbol_coverage_gate.check_trades = lambda *a, **k: [
+        _info_result("coverage_trades")
+    ]
+    orch.anomaly_detector.check = lambda *a, **k: [_info_result("anomaly")]
+    # Bypass the real coverage-report attachment (needs live market internals).
+    orch_mod._maybe_attach_coverage_report = lambda **kw: None
+
+    results = list(exec_results)
+    orch._cached_run_strategy_code = lambda code, md, config, *, strategy=None: results.pop(0)
+
+
+def test_demoted_conformance_with_execution_flags_outcome(monkeypatch):
+    """A demoted-conformance round that executes and collects trades flags the
+    outcome non-conforming."""
+    from investment_team.trading_service.modes.sandbox_compat import StrategyRunResult
+
+    orch = StrategyLabOrchestrator()
+    _stub_clean_gates(orch)
+    orch.rule_probes_gate.check = lambda code, spec, **kw: [_info_result("rule_probes")]
+    orch.predicate_conformance_gate.check = _demoted_conformance
+    _stub_execute_path(orch, exec_results=[StrategyRunResult(success=True, trades=[])])
+
+    outcome = orch._run_synthesis_loop(
+        spec=_minimal_spec(),
+        code=_minimal_spec().strategy_code,
+        config=_minimal_config(),
+        all_gate_results=[],
+        refinement_attempts=[],
+        zero_trade_attempts=[],
+        emit=lambda *a, **k: None,
+    )
+
+    assert outcome.execution_succeeded is True
+    assert outcome.ran_on_non_conforming_code is True
+
+
+def test_demoted_conformance_without_execution_does_not_flag(monkeypatch):
+    """The fix's core: a demoted-conformance warning alone does NOT flag the
+    record — the flag is captured only when a round actually collects trades.
+    Here execution fails before trade collection, so the persisted (empty)
+    backtest never ran on the demoted code."""
+    from investment_team.trading_service.modes.sandbox_compat import StrategyRunResult
+
+    orch = StrategyLabOrchestrator()
+    _stub_clean_gates(orch)
+    orch.rule_probes_gate.check = lambda code, spec, **kw: [_info_result("rule_probes")]
+    orch.predicate_conformance_gate.check = _demoted_conformance
+    _stub_execute_path(
+        orch,
+        exec_results=[StrategyRunResult(success=False, error_type="runtime", stderr="boom")],
+    )
+    # Execution failure routes to refinement; exhaust immediately to end the loop.
+    orch._refine_or_exhaust = lambda **kw: (kw["spec"], kw["code"], True)
+
+    outcome = orch._run_synthesis_loop(
+        spec=_minimal_spec(),
+        code=_minimal_spec().strategy_code,
+        config=_minimal_config(),
+        all_gate_results=[],
+        refinement_attempts=[],
+        zero_trade_attempts=[],
+        emit=lambda *a, **k: None,
+    )
+
+    assert outcome.execution_succeeded is False
+    assert outcome.ran_on_non_conforming_code is False

--- a/backend/agents/investment_team/tests/test_strategy_lab_alignment.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_alignment.py
@@ -1589,3 +1589,132 @@ def test_alignment_veto_falls_back_to_rationale_when_no_findings() -> None:
     reason = verification.metrics.acceptance_reason or ""
     assert "some fallback reason" in reason
     assert verification.is_winning is False
+
+
+# ---------------------------------------------------------------------------
+# ran_on_non_conforming_code is re-derived when alignment commits new code
+# (the committed proposal replaces the persisted trades but is not otherwise
+# conformance-gated, so the synthesis-loop verdict can go stale either way).
+# ---------------------------------------------------------------------------
+
+
+def _commit_then_align(monkeypatch):
+    """Build an orchestrator whose alignment loop commits one fix (round 0)
+    then reports aligned (round 1). Returns (orch,) ready to drive."""
+    from investment_team.strategy_lab import orchestrator as orchestrator_module
+
+    orch, _align_stub, _checker_stub = _make_orchestrator(
+        check_results=[_misaligned_check_result(), _aligned_check_result()],
+        propose_results=[_proposed_fix("conformance-relevant fix")],
+    )
+    monkeypatch.setattr(
+        orchestrator_module,
+        "run_strategy_code",
+        lambda code, _md, _cfg, *, strategy=None: _code_exec(
+            success=True, raw_trades=_benign_sandbox_trades()
+        ),
+    )
+    return orch
+
+
+def test_alignment_commit_clears_stale_non_conforming_flag(monkeypatch) -> None:
+    """A synthesis round was demoted (flag True), but alignment commits code
+    that passes conformance — the persisted backtest is now the conforming
+    aligned code, so the flag must clear to False."""
+    orch = _commit_then_align(monkeypatch)
+    orch.predicate_conformance_gate.check = lambda code, spec, **kw: [
+        QualityGateResult(
+            gate_name="predicate_conformance",
+            passed=True,
+            severity="info",
+            phase="verification",
+            details="Predicate conformance OK (60 bars checked).",
+        )
+    ]
+
+    _events, emit = _collect_emit()
+    outcome = orch._run_trade_alignment_loop(
+        spec=_spec(),
+        code="code-v0",
+        trades=_trade_records(),
+        metrics=_metrics(),
+        market_data=_market_data(),
+        config=_config(),
+        execution_succeeded=True,
+        all_gate_results=[],
+        emit=emit,
+        ran_on_non_conforming_code=True,  # synthesis said non-conforming
+    )
+
+    assert outcome.code == _FIXED_CODE
+    assert outcome.ran_on_non_conforming_code is False
+
+
+def test_alignment_commit_sets_non_conforming_flag(monkeypatch) -> None:
+    """Synthesis was clean (flag False) but the committed alignment code drifts
+    from the predicate — the persisted backtest now ran on non-conforming code,
+    so the flag must set to True."""
+    orch = _commit_then_align(monkeypatch)
+    orch.predicate_conformance_gate.check = lambda code, spec, **kw: [
+        QualityGateResult(
+            gate_name="predicate_conformance",
+            passed=False,
+            severity="warning",
+            phase="verification",
+            details="rule_id=entry[0]: predicate conformance failed.",
+        )
+    ]
+
+    _events, emit = _collect_emit()
+    outcome = orch._run_trade_alignment_loop(
+        spec=_spec(),
+        code="code-v0",
+        trades=_trade_records(),
+        metrics=_metrics(),
+        market_data=_market_data(),
+        config=_config(),
+        execution_succeeded=True,
+        all_gate_results=[],
+        emit=emit,
+        ran_on_non_conforming_code=False,  # synthesis was clean
+    )
+
+    assert outcome.code == _FIXED_CODE
+    assert outcome.ran_on_non_conforming_code is True
+
+
+def test_alignment_no_commit_preserves_flag(monkeypatch) -> None:
+    """When the audit reports aligned immediately (no code committed), the
+    incoming synthesis flag is carried through unchanged and the conformance
+    gate is not consulted."""
+    from investment_team.strategy_lab import orchestrator as orchestrator_module
+
+    orch, _align_stub, _checker_stub = _make_orchestrator(
+        check_results=[_aligned_check_result()],
+    )
+    monkeypatch.setattr(
+        orchestrator_module,
+        "run_strategy_code",
+        lambda code, _md, _cfg, *, strategy=None: _code_exec(success=True, raw_trades=[]),
+    )
+    conformance_calls: List[int] = []
+    orch.predicate_conformance_gate.check = lambda code, spec, **kw: (
+        conformance_calls.append(1) or []
+    )
+
+    _events, emit = _collect_emit()
+    outcome = orch._run_trade_alignment_loop(
+        spec=_spec(),
+        code="code-v0",
+        trades=_trade_records(),
+        metrics=_metrics(),
+        market_data=_market_data(),
+        config=_config(),
+        execution_succeeded=True,
+        all_gate_results=[],
+        emit=emit,
+        ran_on_non_conforming_code=True,
+    )
+
+    assert outcome.ran_on_non_conforming_code is True
+    assert conformance_calls == [], "no commit ⇒ conformance gate not re-run"

--- a/backend/agents/investment_team/tests/test_strategy_lab_design_loop.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_design_loop.py
@@ -1103,6 +1103,76 @@ def test_loop_telemetry_persisted_on_record(monkeypatch: pytest.MonkeyPatch) -> 
     # Gate histograms are present (readiness gate ran at least once).
     assert isinstance(telemetry["gate_pass_counts"], dict)
     assert isinstance(telemetry["gate_fail_counts"], dict)
+    # The non-conforming flag is present on the telemetry and mirrored on the
+    # record; a clean compiled cycle never ran on demoted code.
+    assert telemetry["ran_on_non_conforming_code"] is False
+    assert record.ran_on_non_conforming_code is False
+
+
+def test_record_ran_on_non_conforming_flag_round_trips() -> None:
+    """The top-level record field carries (and defaults) the non-conforming flag."""
+    from investment_team.models import (
+        BacktestConfig,
+        BacktestRecord,
+        StrategyLabRecord,
+        StrategySpec,
+    )
+    from investment_team.trade_simulator import compute_metrics
+
+    spec = StrategySpec(
+        strategy_id="s1",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="h",
+        signal_definition="sig",
+        timeframe="1d",
+        requires_custom_code=True,
+    )
+    config = BacktestConfig(
+        start_date="2023-01-01",
+        end_date="2023-12-31",
+        initial_capital=100_000.0,
+        benchmark_symbol="SPY",
+        transaction_cost_bps=5.0,
+        slippage_bps=2.0,
+    )
+    backtest = BacktestRecord(
+        backtest_id="bt-1",
+        strategy_id=spec.strategy_id,
+        strategy=spec,
+        config=config,
+        submitted_by="test",
+        submitted_at="2026-06-02T00:00:00+00:00",
+        completed_at="2026-06-02T00:00:00+00:00",
+        status="completed",
+        result=compute_metrics([], config.initial_capital, config.start_date, config.end_date),
+        trades=[],
+    )
+
+    flagged = StrategyLabRecord(
+        lab_record_id="lab-1",
+        strategy=spec,
+        backtest=backtest,
+        is_winning=False,
+        strategy_rationale="r",
+        analysis_narrative="n",
+        created_at="2026-06-02T00:00:00+00:00",
+        loop_telemetry={"ran_on_non_conforming_code": True},
+        ran_on_non_conforming_code=True,
+    )
+    assert flagged.ran_on_non_conforming_code is True
+
+    # Legacy / default construction leaves the flag False.
+    default = StrategyLabRecord(
+        lab_record_id="lab-2",
+        strategy=spec,
+        backtest=backtest,
+        is_winning=False,
+        strategy_rationale="r",
+        analysis_narrative="n",
+        created_at="2026-06-02T00:00:00+00:00",
+    )
+    assert default.ran_on_non_conforming_code is False
 
 
 def test_telemetry_events_emitted_on_phase_callback(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1252,3 +1322,94 @@ def test_finalize_loop_telemetry_marks_unsynthesized_failures() -> None:
     assert _finalize_loop_telemetry(ctx, [], _Spec(), code="   \n")["code_path"] == (
         "not_synthesized"
     )
+
+
+def _non_conforming_ctx():
+    from investment_team.strategy_lab._orchestrator_helpers import _DesignPersistContext
+
+    return _DesignPersistContext(
+        rounds=1,
+        critiques=[],
+        stop_reason="ready",
+        loop_telemetry={"design_review_rounds": 1, "stop_reason": "ready"},
+    )
+
+
+class _CustomSpec:
+    requires_custom_code = True
+
+
+def _demoted_conformance_gate(
+    details: str = "rule_id=entry[0]: predicate conformance failed.\n  ...",
+):
+    return QualityGateResult(
+        gate_name="predicate_conformance",
+        passed=False,
+        severity="warning",
+        phase="synthesis",
+        details=details,
+    )
+
+
+def test_finalize_loop_telemetry_flags_non_conforming() -> None:
+    """A demoted predicate-conformance warning marks the backtest non-conforming."""
+    from investment_team.strategy_lab.orchestrator import _finalize_loop_telemetry
+
+    telemetry = _finalize_loop_telemetry(
+        _non_conforming_ctx(),
+        [_demoted_conformance_gate()],
+        _CustomSpec(),
+        code="def on_bar(): ...",
+    )
+    assert telemetry["ran_on_non_conforming_code"] is True
+
+
+def test_finalize_loop_telemetry_not_flagged_when_critical() -> None:
+    """An un-demoted critical conformance failure never reached a settled backtest."""
+    from investment_team.strategy_lab.orchestrator import _finalize_loop_telemetry
+
+    critical = QualityGateResult(
+        gate_name="predicate_conformance",
+        passed=False,
+        severity="critical",
+        phase="synthesis",
+        details="rule_id=entry[0]: predicate conformance failed.",
+    )
+    telemetry = _finalize_loop_telemetry(
+        _non_conforming_ctx(), [critical], _CustomSpec(), code="def on_bar(): ..."
+    )
+    assert telemetry["ran_on_non_conforming_code"] is False
+
+
+def test_finalize_loop_telemetry_not_flagged_for_unsynthesizable_warning() -> None:
+    """A 'could not check' warning must NOT mark the backtest non-conforming."""
+    from investment_team.strategy_lab.orchestrator import _finalize_loop_telemetry
+
+    unsynth = _demoted_conformance_gate(details="Fixture unsynthesizable: no forcing sequence")
+    telemetry = _finalize_loop_telemetry(
+        _non_conforming_ctx(), [unsynth], _CustomSpec(), code="def on_bar(): ..."
+    )
+    assert telemetry["ran_on_non_conforming_code"] is False
+
+
+def test_finalize_loop_telemetry_not_flagged_compiled() -> None:
+    """The compiled path runs no conformance gate, so the flag stays False."""
+    from investment_team.strategy_lab.orchestrator import _finalize_loop_telemetry
+
+    class _CompiledSpec:
+        requires_custom_code = False
+
+    gates = [
+        QualityGateResult(
+            gate_name="code_conformance",
+            passed=True,
+            severity="info",
+            phase="synthesis",
+            details="ok",
+        )
+    ]
+    telemetry = _finalize_loop_telemetry(
+        _non_conforming_ctx(), gates, _CompiledSpec(), code="def on_bar(): ..."
+    )
+    assert telemetry["ran_on_non_conforming_code"] is False
+    assert telemetry["code_path"] == "compiled"

--- a/backend/agents/investment_team/tests/test_strategy_lab_design_loop.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_design_loop.py
@@ -1339,137 +1339,85 @@ class _CustomSpec:
     requires_custom_code = True
 
 
-def _demoted_conformance_gate(
-    details: str = "rule_id=entry[0]: predicate conformance failed.\n  ...",
-):
+def _pc_result(*, passed: bool, severity: str, details: str) -> QualityGateResult:
     return QualityGateResult(
         gate_name="predicate_conformance",
-        passed=False,
-        severity="warning",
+        passed=passed,
+        severity=severity,
         phase="synthesis",
         details=details,
     )
 
 
-def test_finalize_loop_telemetry_flags_non_conforming() -> None:
-    """A demoted predicate-conformance warning marks the backtest non-conforming."""
-    from investment_team.strategy_lab.orchestrator import _finalize_loop_telemetry
+class TestRoundDemotedConformance:
+    """`_round_demoted_conformance` attributes the verdict to a single round."""
 
-    telemetry = _finalize_loop_telemetry(
-        _non_conforming_ctx(),
-        [_demoted_conformance_gate()],
-        _CustomSpec(),
-        code="def on_bar(): ...",
-    )
-    assert telemetry["ran_on_non_conforming_code"] is True
+    def test_demoted_warning_is_true(self) -> None:
+        from investment_team.strategy_lab.orchestrator import _round_demoted_conformance
 
+        demoted = _pc_result(
+            passed=False,
+            severity="warning",
+            details="rule_id=entry[0]: predicate conformance failed.",
+        )
+        assert _round_demoted_conformance([demoted]) is True
 
-def test_finalize_loop_telemetry_not_flagged_when_critical() -> None:
-    """An un-demoted critical conformance failure never reached a settled backtest."""
-    from investment_team.strategy_lab.orchestrator import _finalize_loop_telemetry
+    def test_critical_is_false(self) -> None:
+        from investment_team.strategy_lab.orchestrator import _round_demoted_conformance
 
-    critical = QualityGateResult(
-        gate_name="predicate_conformance",
-        passed=False,
-        severity="critical",
-        phase="synthesis",
-        details="rule_id=entry[0]: predicate conformance failed.",
-    )
-    telemetry = _finalize_loop_telemetry(
-        _non_conforming_ctx(), [critical], _CustomSpec(), code="def on_bar(): ..."
-    )
-    assert telemetry["ran_on_non_conforming_code"] is False
+        critical = _pc_result(
+            passed=False,
+            severity="critical",
+            details="rule_id=entry[0]: predicate conformance failed.",
+        )
+        assert _round_demoted_conformance([critical]) is False
 
+    def test_unsynthesizable_warning_is_false(self) -> None:
+        from investment_team.strategy_lab.orchestrator import _round_demoted_conformance
 
-def test_finalize_loop_telemetry_not_flagged_for_unsynthesizable_warning() -> None:
-    """A 'could not check' warning must NOT mark the backtest non-conforming."""
-    from investment_team.strategy_lab.orchestrator import _finalize_loop_telemetry
+        unsynth = _pc_result(
+            passed=False,
+            severity="warning",
+            details="Fixture unsynthesizable: no forcing sequence",
+        )
+        assert _round_demoted_conformance([unsynth]) is False
 
-    unsynth = _demoted_conformance_gate(details="Fixture unsynthesizable: no forcing sequence")
-    telemetry = _finalize_loop_telemetry(
-        _non_conforming_ctx(), [unsynth], _CustomSpec(), code="def on_bar(): ..."
-    )
-    assert telemetry["ran_on_non_conforming_code"] is False
+    def test_passing_conformance_is_false(self) -> None:
+        from investment_team.strategy_lab.orchestrator import _round_demoted_conformance
 
+        ok = _pc_result(
+            passed=True, severity="info", details="Predicate conformance OK (60 bars checked)."
+        )
+        assert _round_demoted_conformance([ok]) is False
 
-def test_finalize_loop_telemetry_not_flagged_compiled() -> None:
-    """The compiled path runs no conformance gate, so the flag stays False."""
-    from investment_team.strategy_lab.orchestrator import _finalize_loop_telemetry
+    def test_no_conformance_gate_is_false(self) -> None:
+        from investment_team.strategy_lab.orchestrator import _round_demoted_conformance
 
-    class _CompiledSpec:
-        requires_custom_code = False
-
-    gates = [
-        QualityGateResult(
+        other = QualityGateResult(
             gate_name="code_conformance",
             passed=True,
             severity="info",
             phase="synthesis",
             details="ok",
         )
-    ]
-    telemetry = _finalize_loop_telemetry(
-        _non_conforming_ctx(), gates, _CompiledSpec(), code="def on_bar(): ..."
-    )
-    assert telemetry["ran_on_non_conforming_code"] is False
-    assert telemetry["code_path"] == "compiled"
+        assert _round_demoted_conformance([other]) is False
 
 
-def test_finalize_loop_telemetry_uses_settled_round_not_history() -> None:
-    """An early demoted warning repaired by a later round must NOT flag the
-    record — the persisted backtest came from the conforming settled round."""
+def test_finalize_loop_telemetry_stores_non_conforming_flag() -> None:
+    """`_finalize_loop_telemetry` records the loop-captured flag verbatim."""
     from investment_team.strategy_lab.orchestrator import _finalize_loop_telemetry
 
-    early_demoted = QualityGateResult(
-        gate_name="predicate_conformance",
-        passed=False,
-        severity="warning",
-        phase="synthesis",
-        details="rule_id=entry[0]: predicate conformance failed.",
-        refinement_round=0,
-    )
-    settled_clean = QualityGateResult(
-        gate_name="predicate_conformance",
-        passed=True,
-        severity="info",
-        phase="synthesis",
-        details="Predicate conformance OK (60 bars checked).",
-        refinement_round=2,
-    )
-    telemetry = _finalize_loop_telemetry(
+    flagged = _finalize_loop_telemetry(
         _non_conforming_ctx(),
-        [early_demoted, settled_clean],
+        [],
         _CustomSpec(),
         code="def on_bar(): ...",
+        ran_on_non_conforming_code=True,
     )
-    assert telemetry["ran_on_non_conforming_code"] is False
+    assert flagged["ran_on_non_conforming_code"] is True
 
-
-def test_finalize_loop_telemetry_flags_demoted_settled_round() -> None:
-    """A demotion in the settled (highest) round flags the record even when an
-    earlier round's conformance passed."""
-    from investment_team.strategy_lab.orchestrator import _finalize_loop_telemetry
-
-    early_clean = QualityGateResult(
-        gate_name="predicate_conformance",
-        passed=True,
-        severity="info",
-        phase="synthesis",
-        details="Predicate conformance OK (60 bars checked).",
-        refinement_round=0,
+    # Default (e.g. short-circuit records) is False.
+    default = _finalize_loop_telemetry(
+        _non_conforming_ctx(), [], _CustomSpec(), code="def on_bar(): ..."
     )
-    settled_demoted = QualityGateResult(
-        gate_name="predicate_conformance",
-        passed=False,
-        severity="warning",
-        phase="synthesis",
-        details="rule_id=entry[0]: predicate conformance failed.",
-        refinement_round=2,
-    )
-    telemetry = _finalize_loop_telemetry(
-        _non_conforming_ctx(),
-        [early_clean, settled_demoted],
-        _CustomSpec(),
-        code="def on_bar(): ...",
-    )
-    assert telemetry["ran_on_non_conforming_code"] is True
+    assert default["ran_on_non_conforming_code"] is False

--- a/backend/agents/investment_team/tests/test_strategy_lab_design_loop.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_design_loop.py
@@ -1413,3 +1413,63 @@ def test_finalize_loop_telemetry_not_flagged_compiled() -> None:
     )
     assert telemetry["ran_on_non_conforming_code"] is False
     assert telemetry["code_path"] == "compiled"
+
+
+def test_finalize_loop_telemetry_uses_settled_round_not_history() -> None:
+    """An early demoted warning repaired by a later round must NOT flag the
+    record — the persisted backtest came from the conforming settled round."""
+    from investment_team.strategy_lab.orchestrator import _finalize_loop_telemetry
+
+    early_demoted = QualityGateResult(
+        gate_name="predicate_conformance",
+        passed=False,
+        severity="warning",
+        phase="synthesis",
+        details="rule_id=entry[0]: predicate conformance failed.",
+        refinement_round=0,
+    )
+    settled_clean = QualityGateResult(
+        gate_name="predicate_conformance",
+        passed=True,
+        severity="info",
+        phase="synthesis",
+        details="Predicate conformance OK (60 bars checked).",
+        refinement_round=2,
+    )
+    telemetry = _finalize_loop_telemetry(
+        _non_conforming_ctx(),
+        [early_demoted, settled_clean],
+        _CustomSpec(),
+        code="def on_bar(): ...",
+    )
+    assert telemetry["ran_on_non_conforming_code"] is False
+
+
+def test_finalize_loop_telemetry_flags_demoted_settled_round() -> None:
+    """A demotion in the settled (highest) round flags the record even when an
+    earlier round's conformance passed."""
+    from investment_team.strategy_lab.orchestrator import _finalize_loop_telemetry
+
+    early_clean = QualityGateResult(
+        gate_name="predicate_conformance",
+        passed=True,
+        severity="info",
+        phase="synthesis",
+        details="Predicate conformance OK (60 bars checked).",
+        refinement_round=0,
+    )
+    settled_demoted = QualityGateResult(
+        gate_name="predicate_conformance",
+        passed=False,
+        severity="warning",
+        phase="synthesis",
+        details="rule_id=entry[0]: predicate conformance failed.",
+        refinement_round=2,
+    )
+    telemetry = _finalize_loop_telemetry(
+        _non_conforming_ctx(),
+        [early_clean, settled_demoted],
+        _CustomSpec(),
+        code="def on_bar(): ...",
+    )
+    assert telemetry["ran_on_non_conforming_code"] is True

--- a/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
@@ -1123,3 +1123,138 @@ def test_repair_agent_receives_none_when_no_coverage_attached(
 
     assert len(repair_stub.calls) == 1
     assert repair_stub.calls[0]["coverage_report"] is None
+
+
+# ---------------------------------------------------------------------------
+# _handle_critical_anomalies re-derives ran_on_non_conforming_code when a
+# zero-trade repair commits new code (which replaces the persisted trades but
+# is not otherwise conformance-gated). Generic refinement leaves it None.
+# ---------------------------------------------------------------------------
+
+
+class _StubRepairer:
+    """Returns a scripted ``ZeroTradeRepairOutcome`` from ``try_repair``."""
+
+    def __init__(self, outcome: _ZeroTradeRepairOutcome) -> None:
+        self._outcome = outcome
+
+    def try_repair(self, **_kwargs: Any) -> _ZeroTradeRepairOutcome:
+        return self._outcome
+
+
+def _committed_repair_outcome() -> _ZeroTradeRepairOutcome:
+    repair_exec = _code_exec(success=True, raw_trades=_benign_sandbox_trades())
+    return _ZeroTradeRepairOutcome(
+        committed=True,
+        new_code="# repaired code\n",
+        new_spec=_spec(),
+        new_trades=repair_exec.trades,
+        new_metrics=_metrics_for(),
+        new_exec_result=repair_exec,
+        new_gates=[],
+        changes_made="loosened entry threshold",
+    )
+
+
+def _metrics_for():
+    from investment_team.trade_simulator import compute_metrics
+
+    cfg = _config()
+    return compute_metrics([], cfg.initial_capital, cfg.start_date, cfg.end_date)
+
+
+def _critical_anomaly() -> QualityGateResult:
+    return QualityGateResult(
+        gate_name="backtest_anomaly",
+        passed=False,
+        severity="critical",
+        phase="verification",
+        details="zero trades emitted",
+    )
+
+
+def _drive_anomaly_recovery(orch: StrategyLabOrchestrator):
+    return orch._handle_critical_anomalies(
+        spec=_spec(),
+        code="# original code\n",
+        trades=[],
+        metrics=_metrics_for(),
+        exec_result=_zero_trade_exec_result(),
+        market_data=_market_data(),
+        config=_config(),
+        critical_anomalies=[_critical_anomaly()],
+        all_gate_results=[],
+        refinement_attempts=[],
+        zero_trade_attempts=[],
+        round_num=0,
+        emit=lambda *a, **k: None,
+    )
+
+
+def test_ztr_commit_flags_non_conforming_repair_code() -> None:
+    """A committed zero-trade repair whose code drifts from the predicate sets
+    the non-conforming flag on the recovery outcome."""
+    orch = StrategyLabOrchestrator()
+    orch.zero_trade_repairer = _StubRepairer(_committed_repair_outcome())  # type: ignore[assignment]
+    orch.predicate_conformance_gate.check = lambda code, spec, **kw: [
+        QualityGateResult(
+            gate_name="predicate_conformance",
+            passed=False,
+            severity="warning",
+            phase="verification",
+            details="rule_id=entry[0]: predicate conformance failed.",
+        )
+    ]
+
+    recovery = _drive_anomaly_recovery(orch)
+    assert recovery.exhausted is False
+    assert recovery.ran_on_non_conforming_code is True
+
+
+def test_ztr_commit_clears_flag_for_conforming_repair_code() -> None:
+    """A committed repair whose code conforms reports the flag as False."""
+    orch = StrategyLabOrchestrator()
+    orch.zero_trade_repairer = _StubRepairer(_committed_repair_outcome())  # type: ignore[assignment]
+    orch.predicate_conformance_gate.check = lambda code, spec, **kw: [
+        QualityGateResult(
+            gate_name="predicate_conformance",
+            passed=True,
+            severity="info",
+            phase="verification",
+            details="Predicate conformance OK (60 bars checked).",
+        )
+    ]
+
+    recovery = _drive_anomaly_recovery(orch)
+    assert recovery.ran_on_non_conforming_code is False
+
+
+def test_generic_refine_leaves_flag_unset() -> None:
+    """When no zero-trade repair commits (diagnostics carry no category), the
+    generic-refine path leaves the flag None so the caller keeps the round's
+    existing verdict (trades are unchanged)."""
+    orch = StrategyLabOrchestrator()
+    orch._refine_or_exhaust = lambda **kw: (kw["spec"], kw["code"], False)
+    conformance_calls: List[int] = []
+    orch.predicate_conformance_gate.check = lambda code, spec, **kw: (
+        conformance_calls.append(1) or []
+    )
+
+    recovery = orch._handle_critical_anomalies(
+        spec=_spec(),
+        code="# original code\n",
+        trades=[],
+        metrics=_metrics_for(),
+        # No zero_trade_category -> ZTR branch is skipped.
+        exec_result=StrategyRunResult(success=True, trades=[]),
+        market_data=_market_data(),
+        config=_config(),
+        critical_anomalies=[_critical_anomaly()],
+        all_gate_results=[],
+        refinement_attempts=[],
+        zero_trade_attempts=[],
+        round_num=0,
+        emit=lambda *a, **k: None,
+    )
+    assert recovery.ran_on_non_conforming_code is None
+    assert conformance_calls == [], "generic-refine path must not re-run conformance"


### PR DESCRIPTION
Closes #694.

## Summary

Custom-code strategies (`requires_custom_code=True`) take the LLM synthesis path, where the `PredicateConformanceGate` shadow-runs the generated `on_bar` against the engine's predicate verdicts. After the retry budget (`STRATEGY_LAB_CODE_CONFORMANCE_RETRIES`, default 2) a still-failing critical is **demoted to a warning** and the code proceeds to backtest — previously with no marker on the record and with refinement driven only by bare bar-*index* lists.

This implements **Prong B (full) + light Prong A (prompt-only)** of the issue.

### Prong B — targeted repair before demotion
- The conformance failure detail now renders the **violated predicate** plus a bounded per-bar `lhs`/`rhs`/verdict trace (and a one-line fix directive) for the offending bars, instead of bare indices. The synthesis loop already feeds `g.details` into the refinement agent for the two retry rounds that precede demotion, so the existing repair becomes surgical — **no loop, threshold, or env-knob change**.
- New `_predicate_for_rule_id` recovers the rule's predicate from the spec, falling back to the index-only detail when the rule id is unrecognized.

### Prong B — flag non-conforming backtests
- `StrategyLabRecord` gains `ran_on_non_conforming_code: bool` (default `False`, backward-compatible with persisted rows), mirrored into `loop_telemetry`.
- Derived once in `_finalize_loop_telemetry` from a **demoted** (`severity == "warning"`, not passed) `predicate_conformance` result. The `"Fixture unsynthesizable:"` warning is excluded — it means the gate could not *check* the rule, not that the code drifted. Compiled-path records (which skip the gate) stay `False`. The existing `telemetry` event auto-includes the new key.

### Prong A — prompt-only (compiler expansion deferred)
- Tightened the `requires_custom_code` guidance in `design_system.md`: the deterministic compiler already covers the **entire** indicator catalogue, all 7 operators, and all sources, so any single-predicate spec is always compilable; custom code carries the conformance-gate cost.
- **No compiler-catalogue expansion**, deliberately. The catalogue is already at full parity with the DSL (same 9 indicators, same predicate sides, all operators). The real driver of `requires_custom_code` is **multi-condition AND/OR entry logic**, which the single-predicate DSL genuinely cannot express — supporting it requires a composite-predicate change across `spec_dsl` + `predicate_evaluator` + `rule_probes/synthesizer` + `predicate_conformance` + `compiler` in lockstep. That is the large change the issue scopes out, and it is deferred to a separate issue.

## Files
- `strategy_lab/quality_gates/predicate_conformance.py` — `_predicate_for_rule_id` + enriched detail (`_build_conformance_detail`, `_enriched_trace_lines`, `_format_scalar`).
- `models.py` — new `ran_on_non_conforming_code` field.
- `strategy_lab/orchestrator.py` — detection in `_finalize_loop_telemetry`; field set at both record-construction sites.
- `strategy_lab/prompts/design_system.md` — tightened `requires_custom_code` guidance.
- tests — gate + telemetry + record coverage.

## Invariants unchanged
Demote threshold (`attempt >= _code_conformance_retries()`), env knob + default 2, pre-demotion refine round count, and the compiled-path gate skip.

## Test plan
- [x] `test_predicate_conformance_gate.py` — enriched-detail content, repair-before-demote attempt sequence (`attempt` 0/1 critical → 2 warning), predicate-id recovery (entry / signal-exit / malformed / out-of-range / wrong-variant / None spec), detail-helper branches, unsynthesizable prefix. **39 passed.**
- [x] `test_strategy_lab_design_loop.py` — `_finalize_loop_telemetry` detection (flagged / critical-not-flagged / unsynthesizable-excluded / compiled), persisted-record key + field, record-level flag round-trip. **36 passed.**
- [x] Full `agents/investment_team` suite: **3122 passed, 10 skipped**.
- [x] `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRmyvUEdAHtKdYwWmizwLT)_