### PR TITLE
Agent Cognition Core: package skeleton, Postgres schema, models

### DIFF
--- a/backend/agents/agent_cognition/__init__.py
+++ b/backend/agents/agent_cognition/__init__.py
@@ -1,0 +1,48 @@
+"""Agent Cognition Core — batteries-included memory + rules engine.
+
+This package provides a per-agent cognition substrate (episodic memory,
+calendar rollups, advisory/enforced rules, a human-in-the-loop proposal
+queue, and an invoke idempotency ledger) that the platform attaches to
+generated agents. See ``DESIGN.md`` / ``IMPLEMENTATION_PLAN.md`` in this
+directory for the full design and the staged delivery plan.
+
+This module re-exports the domain models for convenience; importing it has
+no side effects (the Postgres schema is registered explicitly from the
+unified API lifespan via ``register_team_schemas``).
+"""
+
+from __future__ import annotations
+
+from agent_cognition.models import (
+    CognitionContext,
+    CognitionWriteback,
+    EventKind,
+    MemoryEvent,
+    PeriodSummary,
+    ProposalAction,
+    ProposalStatus,
+    Rule,
+    RuleMode,
+    RuleProposal,
+    RuleSource,
+    RuleStatus,
+    Scale,
+    ToolCall,
+)
+
+__all__ = [
+    "CognitionContext",
+    "CognitionWriteback",
+    "EventKind",
+    "MemoryEvent",
+    "PeriodSummary",
+    "ProposalAction",
+    "ProposalStatus",
+    "Rule",
+    "RuleMode",
+    "RuleProposal",
+    "RuleSource",
+    "RuleStatus",
+    "Scale",
+    "ToolCall",
+]

--- a/backend/agents/agent_cognition/models.py
+++ b/backend/agents/agent_cognition/models.py
@@ -1,0 +1,219 @@
+"""Pydantic domain models for the Agent Cognition Core.
+
+These are the shared types that the memory store, rollup engine, rules
+engine, tools layer, and invoke proxy (later steps) read and write. They
+mirror the Postgres schema in :mod:`agent_cognition.postgres` one-to-one.
+
+Conventions follow the rest of the codebase: Pydantic v2 ``BaseModel``,
+``str | None`` for optionals, ``Field(default_factory=...)`` for mutable
+defaults, and ``str``-mixed enums so values serialize as plain strings.
+
+Design by Contract:
+
+* Preconditions — callers must supply fields that satisfy the declared
+  types and enums; pydantic validation raises on violation at construction.
+* Postconditions — a constructed model round-trips through
+  ``model_dump()`` / ``model_validate()`` without loss.
+* Invariants — enum members exactly match the values persisted in the
+  corresponding ``TEXT`` columns (e.g. ``ProposalStatus`` carries the
+  system-only terminal state ``superseded``).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# Enums — values match the TEXT columns in agent_cognition.postgres.SCHEMA.
+# ---------------------------------------------------------------------------
+class EventKind(str, Enum):
+    """The category of an episodic memory event."""
+
+    OBSERVATION = "observation"
+    ACTION = "action"
+    TOOL_CALL = "tool_call"
+    OUTCOME = "outcome"
+    ERROR = "error"
+    FEEDBACK = "feedback"
+
+
+class Scale(str, Enum):
+    """The calendar scale of a rollup summary."""
+
+    DAY = "day"
+    WEEK = "week"
+    MONTH = "month"
+    YEAR = "year"
+
+
+class RuleMode(str, Enum):
+    """Whether a rule only steers the prompt or is deterministically enforced."""
+
+    ADVISORY = "advisory"
+    ENFORCED = "enforced"
+
+
+class RuleStatus(str, Enum):
+    """Lifecycle status of a rule (see DESIGN §8.3)."""
+
+    ACTIVE = "active"
+    RETIRED = "retired"
+
+
+class RuleSource(str, Enum):
+    """Provenance of a rule."""
+
+    SEED = "seed"
+    DERIVED = "derived"
+    OPERATOR = "operator"
+
+
+class ProposalAction(str, Enum):
+    """The mutation a rule proposal applies on approval."""
+
+    ADD = "add"
+    RETIRE = "retire"
+    AMEND = "amend"
+
+
+class ProposalStatus(str, Enum):
+    """Lifecycle status of a rule proposal (see DESIGN §8.3).
+
+    ``superseded`` is the *system* auto-withdraw terminal state for a
+    proposal whose evidence went stale on recompute — distinct from
+    ``rejected``, which records an explicit human decision.
+    """
+
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    SUPERSEDED = "superseded"
+
+
+# ---------------------------------------------------------------------------
+# Persistent rows.
+# ---------------------------------------------------------------------------
+class MemoryEvent(BaseModel):
+    """One append-only episodic memory event.
+
+    Invariant: ``(agent_id, source_run_id, source_seq)`` is unique — the
+    idempotency key that lets a duplicated writeback be a no-op.
+    """
+
+    id: str
+    agent_id: str
+    kind: EventKind
+    content: str = ""
+    data: dict[str, Any] = Field(default_factory=dict)
+    salience: float = 0.0
+    occurred_at: datetime
+    source_run_id: str
+    source_seq: int
+
+
+class PeriodSummary(BaseModel):
+    """A calendar-scoped rollup of memory for one closed period.
+
+    Invariant: ``(agent_id, scale, period_start)`` is unique; ``version``
+    increments on every recompute and ``stale`` flags a period for
+    re-summarization after a late event lands inside it.
+    """
+
+    id: str
+    agent_id: str
+    scale: Scale
+    period_start: datetime
+    period_end: datetime
+    summary: str = ""
+    highlights: list[Any] = Field(default_factory=list)
+    source_count: int = 0
+    covers_through: datetime | None = None
+    version: int = 1
+    stale: bool = False
+    created_at: datetime
+
+
+class Rule(BaseModel):
+    """An advisory or enforced guardrail for an agent.
+
+    ``evidence`` holds ``(summary_id, version)`` refs for ``derived`` rules
+    so a later recompute can flag ``needs_review`` when the evidence moves.
+    """
+
+    id: str
+    agent_id: str
+    text: str
+    mode: RuleMode
+    status: RuleStatus
+    predicate: dict[str, Any] = Field(default_factory=dict)
+    rationale: str | None = None
+    source: RuleSource
+    evidence: list[Any] = Field(default_factory=list)
+    needs_review: bool = False
+    priority: int = 0
+    created_at: datetime
+    updated_at: datetime
+
+
+class RuleProposal(BaseModel):
+    """A human-in-the-loop proposal to add/retire/amend a rule.
+
+    The explicit ``action`` + ``target_rule_id`` let the approve path apply
+    retire/amend deterministically instead of mis-activating them as new
+    rules.
+    """
+
+    id: str
+    agent_id: str
+    action: ProposalAction
+    target_rule_id: str | None = None
+    proposed_rule: dict[str, Any] | None = None
+    evidence: list[Any] = Field(default_factory=list)
+    stale_evidence: bool = False
+    status: ProposalStatus = ProposalStatus.PENDING
+    decided_by: str | None = None
+    decided_at: datetime | None = None
+    created_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Invoke-path envelope payloads (not persisted rows; carried on the wire).
+# ---------------------------------------------------------------------------
+class ToolCall(BaseModel):
+    """A single tool invocation recorded in a writeback / shim audit."""
+
+    tool_id: str
+    args: dict[str, Any] = Field(default_factory=dict)
+    ok: bool = True
+    result: Any = None
+    error: str | None = None
+    occurred_at: datetime | None = None
+
+
+class CognitionContext(BaseModel):
+    """The ``cognition`` side-channel block injected on invoke.
+
+    Carries the advisory rules the agent runtime should render into its
+    system prompt and the compact memory digest. Kept out of the agent's
+    user-input contract (see DESIGN §10 envelope).
+    """
+
+    rules: list[Rule] = Field(default_factory=list)
+    memory_digest: str = ""
+
+
+class CognitionWriteback(BaseModel):
+    """The cognition payload an agent returns alongside its output.
+
+    ``truncated`` flags that ``events`` / ``tool_calls`` were trimmed to fit
+    the writeback byte cap rather than failing the whole call.
+    """
+
+    events: list[MemoryEvent] = Field(default_factory=list)
+    tool_calls: list[ToolCall] = Field(default_factory=list)
+    truncated: bool = False

--- a/backend/agents/agent_cognition/postgres/__init__.py
+++ b/backend/agents/agent_cognition/postgres/__init__.py
@@ -1,0 +1,136 @@
+"""Postgres schema for the Agent Cognition Core.
+
+Pure data module — importing it has no side effects. DDL runs when the
+unified API lifespan calls ``shared_postgres.register_team_schemas(SCHEMA)``.
+
+The five tables form the durable substrate for the cognition epic:
+
+* ``agent_cognition_events`` — append-only episodic memory.
+* ``agent_cognition_summaries`` — calendar-scoped rollups (day/week/month/year).
+* ``agent_cognition_rules`` — advisory/enforced rules with lifecycle status.
+* ``agent_cognition_rule_proposals`` — the human-in-the-loop review queue.
+* ``agent_cognition_runs`` — the invoke idempotency/leasing ledger.
+
+Every row is keyed by ``agent_id``. Three constraints are load-bearing for
+later steps' ``ON CONFLICT`` / claim clauses and are asserted by the tests:
+the events idempotency triple, the summary period key, and the runs PK.
+"""
+
+from __future__ import annotations
+
+from shared_postgres import TeamSchema
+
+SCHEMA: TeamSchema = TeamSchema(
+    team="agent_cognition",
+    database=None,
+    statements=[
+        # -----------------------------------------------------------------
+        # Episodic memory — append-only events. Idempotent on the writeback
+        # key ``(agent_id, source_run_id, source_seq)`` so a retried or
+        # duplicated persist is a no-op rather than skewing rollups.
+        # -----------------------------------------------------------------
+        """CREATE TABLE IF NOT EXISTS agent_cognition_events (
+            id              TEXT PRIMARY KEY,
+            agent_id        TEXT NOT NULL,
+            kind            TEXT NOT NULL,
+            content         TEXT NOT NULL DEFAULT '',
+            data            JSONB NOT NULL DEFAULT '{}'::jsonb,
+            salience        DOUBLE PRECISION NOT NULL DEFAULT 0,
+            occurred_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            source_run_id   TEXT NOT NULL,
+            source_seq      INTEGER NOT NULL
+        )""",
+        """CREATE UNIQUE INDEX IF NOT EXISTS uq_agent_cognition_events_writeback
+            ON agent_cognition_events(agent_id, source_run_id, source_seq)""",
+        """CREATE INDEX IF NOT EXISTS idx_agent_cognition_events_agent_occurred
+            ON agent_cognition_events(agent_id, occurred_at DESC)""",
+        """CREATE INDEX IF NOT EXISTS idx_agent_cognition_events_agent_kind
+            ON agent_cognition_events(agent_id, kind)""",
+        # -----------------------------------------------------------------
+        # Rollups — one row per closed calendar period. Idempotent upsert on
+        # ``(agent_id, scale, period_start)``; ``version`` bumps on recompute
+        # and ``stale`` flags a period for re-summarization on late arrival.
+        # -----------------------------------------------------------------
+        """CREATE TABLE IF NOT EXISTS agent_cognition_summaries (
+            id              TEXT PRIMARY KEY,
+            agent_id        TEXT NOT NULL,
+            scale           TEXT NOT NULL,
+            period_start    TIMESTAMPTZ NOT NULL,
+            period_end      TIMESTAMPTZ NOT NULL,
+            summary         TEXT NOT NULL DEFAULT '',
+            highlights      JSONB NOT NULL DEFAULT '[]'::jsonb,
+            source_count    INTEGER NOT NULL DEFAULT 0,
+            covers_through  TIMESTAMPTZ,
+            version         INTEGER NOT NULL DEFAULT 1,
+            stale           BOOLEAN NOT NULL DEFAULT FALSE,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )""",
+        """CREATE UNIQUE INDEX IF NOT EXISTS uq_agent_cognition_summaries_period
+            ON agent_cognition_summaries(agent_id, scale, period_start)""",
+        # -----------------------------------------------------------------
+        # Rules — advisory/enforced guardrails. ``evidence`` carries
+        # ``(summary_id, version)`` refs for derived rules; ``needs_review``
+        # resurfaces a rule whose evidence later changed.
+        # -----------------------------------------------------------------
+        """CREATE TABLE IF NOT EXISTS agent_cognition_rules (
+            id              TEXT PRIMARY KEY,
+            agent_id        TEXT NOT NULL,
+            text            TEXT NOT NULL,
+            mode            TEXT NOT NULL,
+            status          TEXT NOT NULL,
+            predicate       JSONB NOT NULL DEFAULT '{}'::jsonb,
+            rationale       TEXT,
+            source          TEXT NOT NULL,
+            evidence        JSONB NOT NULL DEFAULT '[]'::jsonb,
+            needs_review    BOOLEAN NOT NULL DEFAULT FALSE,
+            priority        INTEGER NOT NULL DEFAULT 0,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )""",
+        """CREATE INDEX IF NOT EXISTS idx_agent_cognition_rules_agent_status
+            ON agent_cognition_rules(agent_id, status)""",
+        # -----------------------------------------------------------------
+        # Rule proposals — HITL review queue. ``action`` + ``target_rule_id``
+        # make the approve path deterministic; ``superseded`` is the system
+        # auto-withdraw terminal state (distinct from a human ``rejected``).
+        # -----------------------------------------------------------------
+        """CREATE TABLE IF NOT EXISTS agent_cognition_rule_proposals (
+            id              TEXT PRIMARY KEY,
+            agent_id        TEXT NOT NULL,
+            action          TEXT NOT NULL,
+            target_rule_id  TEXT,
+            proposed_rule   JSONB,
+            evidence        JSONB NOT NULL DEFAULT '[]'::jsonb,
+            stale_evidence  BOOLEAN NOT NULL DEFAULT FALSE,
+            status          TEXT NOT NULL DEFAULT 'pending',
+            decided_by      TEXT,
+            decided_at      TIMESTAMPTZ,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )""",
+        """CREATE INDEX IF NOT EXISTS idx_agent_cognition_rule_proposals_agent_status
+            ON agent_cognition_rule_proposals(agent_id, status)""",
+        # -----------------------------------------------------------------
+        # Run ledger — invoke idempotency + leasing. PK ``(agent_id,
+        # source_run_id)``; the proxy stores the final envelope on both
+        # terminal outcomes (completed/blocked) so retries replay either.
+        # -----------------------------------------------------------------
+        """CREATE TABLE IF NOT EXISTS agent_cognition_runs (
+            agent_id          TEXT NOT NULL,
+            source_run_id     TEXT NOT NULL,
+            status            TEXT NOT NULL,
+            request_hash      TEXT NOT NULL,
+            response          JSONB,
+            lease_expires_at  TIMESTAMPTZ,
+            created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            completed_at      TIMESTAMPTZ,
+            PRIMARY KEY (agent_id, source_run_id)
+        )""",
+    ],
+    table_names=[
+        "agent_cognition_events",
+        "agent_cognition_summaries",
+        "agent_cognition_rules",
+        "agent_cognition_rule_proposals",
+        "agent_cognition_runs",
+    ],
+)

--- a/backend/agents/agent_cognition/tests/__init__.py
+++ b/backend/agents/agent_cognition/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Agent Cognition Core package."""

--- a/backend/agents/agent_cognition/tests/test_models.py
+++ b/backend/agents/agent_cognition/tests/test_models.py
@@ -1,0 +1,260 @@
+"""Validation / round-trip tests for the cognition domain models.
+
+These require no Postgres and always run, so they carry the coverage for
+``agent_cognition.models``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from agent_cognition import (
+    CognitionContext,
+    CognitionWriteback,
+    EventKind,
+    MemoryEvent,
+    PeriodSummary,
+    ProposalAction,
+    ProposalStatus,
+    Rule,
+    RuleMode,
+    RuleProposal,
+    RuleSource,
+    RuleStatus,
+    Scale,
+    ToolCall,
+)
+
+NOW = datetime(2026, 6, 3, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Enums — exact member sets are load-bearing (they map to TEXT columns).
+# ---------------------------------------------------------------------------
+def test_enum_member_values() -> None:
+    assert {e.value for e in EventKind} == {
+        "observation",
+        "action",
+        "tool_call",
+        "outcome",
+        "error",
+        "feedback",
+    }
+    assert {s.value for s in Scale} == {"day", "week", "month", "year"}
+    assert {m.value for m in RuleMode} == {"advisory", "enforced"}
+    assert {s.value for s in RuleStatus} == {"active", "retired"}
+    assert {s.value for s in RuleSource} == {"seed", "derived", "operator"}
+    assert {a.value for a in ProposalAction} == {"add", "retire", "amend"}
+
+
+def test_proposal_status_includes_superseded() -> None:
+    # Acceptance criterion: the system auto-withdraw terminal state exists
+    # and is distinct from the human ``rejected`` decision.
+    assert {s.value for s in ProposalStatus} == {
+        "pending",
+        "approved",
+        "rejected",
+        "superseded",
+    }
+    assert ProposalStatus.SUPERSEDED.value == "superseded"
+
+
+def test_enums_are_str_mixed() -> None:
+    # str-mixed enums serialize as plain strings.
+    assert EventKind.OBSERVATION == "observation"
+    assert (
+        MemoryEvent(
+            id="e1",
+            agent_id="a1",
+            kind=EventKind.ACTION,
+            occurred_at=NOW,
+            source_run_id="r1",
+            source_seq=0,
+        ).model_dump()["kind"]
+        == "action"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Model construction + round-trip.
+# ---------------------------------------------------------------------------
+def test_memory_event_round_trip_and_defaults() -> None:
+    ev = MemoryEvent(
+        id="e1",
+        agent_id="a1",
+        kind=EventKind.OBSERVATION,
+        occurred_at=NOW,
+        source_run_id="run-1",
+        source_seq=3,
+    )
+    # Defaults applied.
+    assert ev.content == ""
+    assert ev.data == {}
+    assert ev.salience == 0.0
+    again = MemoryEvent.model_validate(ev.model_dump())
+    assert again == ev
+
+
+def test_period_summary_round_trip_and_defaults() -> None:
+    s = PeriodSummary(
+        id="s1",
+        agent_id="a1",
+        scale=Scale.MONTH,
+        period_start=NOW,
+        period_end=NOW,
+        created_at=NOW,
+    )
+    assert s.version == 1
+    assert s.stale is False
+    assert s.source_count == 0
+    assert s.covers_through is None
+    assert s.highlights == []
+    assert PeriodSummary.model_validate(s.model_dump()) == s
+
+
+def test_rule_round_trip_and_defaults() -> None:
+    r = Rule(
+        id="r1",
+        agent_id="a1",
+        text="never delete prod",
+        mode=RuleMode.ENFORCED,
+        status=RuleStatus.ACTIVE,
+        source=RuleSource.SEED,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+    assert r.predicate == {}
+    assert r.evidence == []
+    assert r.needs_review is False
+    assert r.priority == 0
+    assert r.rationale is None
+    assert Rule.model_validate(r.model_dump()) == r
+
+
+def test_rule_proposal_round_trip_and_defaults() -> None:
+    p = RuleProposal(
+        id="p1",
+        agent_id="a1",
+        action=ProposalAction.ADD,
+        created_at=NOW,
+    )
+    assert p.status is ProposalStatus.PENDING
+    assert p.target_rule_id is None
+    assert p.proposed_rule is None
+    assert p.stale_evidence is False
+    assert p.decided_by is None
+    assert p.decided_at is None
+    assert RuleProposal.model_validate(p.model_dump()) == p
+
+
+def test_rule_proposal_amend_carries_target_and_replacement() -> None:
+    p = RuleProposal(
+        id="p2",
+        agent_id="a1",
+        action=ProposalAction.AMEND,
+        target_rule_id="r1",
+        proposed_rule={"text": "new", "mode": "advisory"},
+        evidence=[["s1", 2]],
+        status=ProposalStatus.SUPERSEDED,
+        decided_by="operator-x",
+        decided_at=NOW,
+        created_at=NOW,
+    )
+    assert p.target_rule_id == "r1"
+    assert p.proposed_rule == {"text": "new", "mode": "advisory"}
+    assert RuleProposal.model_validate(p.model_dump()) == p
+
+
+def test_tool_call_round_trip_and_defaults() -> None:
+    tc = ToolCall(tool_id="git")
+    assert tc.args == {}
+    assert tc.ok is True
+    assert tc.result is None
+    assert tc.error is None
+    assert tc.occurred_at is None
+    populated = ToolCall(
+        tool_id="http_api",
+        args={"url": "https://example.com"},
+        ok=False,
+        result={"status": 500},
+        error="boom",
+        occurred_at=NOW,
+    )
+    assert ToolCall.model_validate(populated.model_dump()) == populated
+
+
+def test_cognition_context_defaults_and_nesting() -> None:
+    ctx = CognitionContext()
+    assert ctx.rules == []
+    assert ctx.memory_digest == ""
+    rule = Rule(
+        id="r1",
+        agent_id="a1",
+        text="t",
+        mode=RuleMode.ADVISORY,
+        status=RuleStatus.ACTIVE,
+        source=RuleSource.OPERATOR,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+    ctx2 = CognitionContext(rules=[rule], memory_digest="recent: ...")
+    again = CognitionContext.model_validate(ctx2.model_dump())
+    assert again.rules[0].id == "r1"
+    assert again.memory_digest == "recent: ..."
+
+
+def test_cognition_writeback_defaults_and_nesting() -> None:
+    wb = CognitionWriteback()
+    assert wb.events == []
+    assert wb.tool_calls == []
+    assert wb.truncated is False
+    wb2 = CognitionWriteback(
+        events=[
+            MemoryEvent(
+                id="e1",
+                agent_id="a1",
+                kind=EventKind.OUTCOME,
+                occurred_at=NOW,
+                source_run_id="r1",
+                source_seq=0,
+            )
+        ],
+        tool_calls=[ToolCall(tool_id="git")],
+        truncated=True,
+    )
+    again = CognitionWriteback.model_validate(wb2.model_dump())
+    assert again.events[0].id == "e1"
+    assert again.tool_calls[0].tool_id == "git"
+    assert again.truncated is True
+
+
+# ---------------------------------------------------------------------------
+# Validation failures (preconditions enforced at construction).
+# ---------------------------------------------------------------------------
+def test_invalid_enum_value_rejected() -> None:
+    with pytest.raises(ValidationError):
+        MemoryEvent(
+            id="e1",
+            agent_id="a1",
+            kind="not_a_kind",  # type: ignore[arg-type]
+            occurred_at=NOW,
+            source_run_id="r1",
+            source_seq=0,
+        )
+
+
+def test_missing_required_field_rejected() -> None:
+    with pytest.raises(ValidationError):
+        Rule(  # type: ignore[call-arg]
+            id="r1",
+            agent_id="a1",
+            text="t",
+            mode=RuleMode.ADVISORY,
+            status=RuleStatus.ACTIVE,
+            # source missing
+            created_at=NOW,
+            updated_at=NOW,
+        )

--- a/backend/agents/agent_cognition/tests/test_postgres_schema.py
+++ b/backend/agents/agent_cognition/tests/test_postgres_schema.py
@@ -1,0 +1,109 @@
+"""Schema tests for the Agent Cognition Core.
+
+Two layers:
+
+* **Shape tests** run without a database and assert the load-bearing
+  constraints exist in the DDL text (the acceptance criteria for Step 1).
+* **Idempotency tests** are skipped unless ``POSTGRES_HOST`` is set; they
+  prove the schema applies and re-applies cleanly against live Postgres,
+  mirroring ``agent_console`` / ``product_delivery`` store tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_cognition.postgres import SCHEMA
+from shared_postgres import TeamSchema
+
+EXPECTED_TABLES = [
+    "agent_cognition_events",
+    "agent_cognition_summaries",
+    "agent_cognition_rules",
+    "agent_cognition_rule_proposals",
+    "agent_cognition_runs",
+]
+
+
+# ---------------------------------------------------------------------------
+# Shape tests (no Postgres required).
+# ---------------------------------------------------------------------------
+def test_schema_identity() -> None:
+    assert isinstance(SCHEMA, TeamSchema)
+    assert SCHEMA.team == "agent_cognition"
+    assert SCHEMA.database is None
+
+
+def test_schema_declares_all_five_tables() -> None:
+    assert SCHEMA.table_names == EXPECTED_TABLES
+    # Every declared table has a matching CREATE TABLE statement.
+    joined = "\n".join(SCHEMA.statements)
+    for table in EXPECTED_TABLES:
+        assert f"CREATE TABLE IF NOT EXISTS {table}" in joined
+
+
+def test_all_ddl_is_idempotent() -> None:
+    # Pattern B requires startup DDL to be safe to re-run.
+    for stmt in SCHEMA.statements:
+        assert "IF NOT EXISTS" in stmt, stmt
+
+
+def test_events_idempotency_key_present() -> None:
+    joined = "".join(SCHEMA.statements)
+    assert (
+        "uq_agent_cognition_events_writeback" in joined
+        and "agent_cognition_events(agent_id, source_run_id, source_seq)" in joined
+    )
+
+
+def test_summary_period_key_present() -> None:
+    joined = "".join(SCHEMA.statements)
+    assert (
+        "uq_agent_cognition_summaries_period" in joined
+        and "agent_cognition_summaries(agent_id, scale, period_start)" in joined
+    )
+
+
+def test_runs_composite_primary_key_present() -> None:
+    runs_ddl = next(s for s in SCHEMA.statements if "agent_cognition_runs" in s)
+    assert "PRIMARY KEY (agent_id, source_run_id)" in runs_ddl
+
+
+def test_summaries_have_version_and_stale_columns() -> None:
+    summaries_ddl = next(
+        s for s in SCHEMA.statements if "CREATE TABLE IF NOT EXISTS agent_cognition_summaries" in s
+    )
+    assert "version" in summaries_ddl
+    assert "stale" in summaries_ddl
+    assert "covers_through" in summaries_ddl
+
+
+def test_evidence_columns_present_on_rules_and_proposals() -> None:
+    rules_ddl = next(
+        s for s in SCHEMA.statements if "CREATE TABLE IF NOT EXISTS agent_cognition_rules" in s
+    )
+    proposals_ddl = next(
+        s
+        for s in SCHEMA.statements
+        if "CREATE TABLE IF NOT EXISTS agent_cognition_rule_proposals" in s
+    )
+    assert "evidence" in rules_ddl and "needs_review" in rules_ddl
+    assert "evidence" in proposals_ddl and "action" in proposals_ddl
+
+
+# ---------------------------------------------------------------------------
+# Idempotency tests (live Postgres only).
+# ---------------------------------------------------------------------------
+def test_schema_applies_idempotently() -> None:
+    from shared_postgres import is_postgres_enabled, register_team_schemas
+
+    if not is_postgres_enabled():
+        pytest.skip("POSTGRES_HOST not set; skipping live-Postgres schema test")
+
+    from shared_postgres.testing import truncate_team_tables
+
+    # Apply twice — the second call must be a no-op (idempotent DDL).
+    assert register_team_schemas(SCHEMA) is True
+    assert register_team_schemas(SCHEMA) is True
+    # Tables exist and are truncatable.
+    assert truncate_team_tables(SCHEMA) == len(EXPECTED_TABLES)

--- a/backend/agents/shared_postgres/registry.py
+++ b/backend/agents/shared_postgres/registry.py
@@ -35,6 +35,8 @@ TEAM_POSTGRES_MODULES: dict[str, str] = {
     "blogging": "blogging.postgres",
     "nutrition_meal_planning": "nutrition_meal_planning_team.postgres",
     "product_delivery": "product_delivery.postgres",
+    # Agent Cognition Core — memory, rules, and the invoke idempotency ledger.
+    "agent_cognition": "agent_cognition.postgres",
     # Issue #376 — investment team's first Postgres table: snapshot index
     # for the durable, content-hashed market-data cache.
     "investment_market_data": "investment_team.market_data_cache.postgres",

--- a/backend/unified_api/main.py
+++ b/backend/unified_api/main.py
@@ -309,6 +309,14 @@ async def lifespan(app: FastAPI):
     except Exception:
         logger.exception("agent_console postgres schema registration failed")
 
+    try:
+        from agent_cognition.postgres import SCHEMA as AGENT_COGNITION_SCHEMA
+        from shared_postgres import register_team_schemas
+
+        register_team_schemas(AGENT_COGNITION_SCHEMA)
+    except Exception:
+        logger.exception("agent_cognition postgres schema registration failed")
+
     # Gate the entire product_delivery startup block on the team's
     # `enabled` flag. Disabling the team must also disable its startup
     # side effects (schema DDL, failure logs, health markers) — not


### PR DESCRIPTION
Closes #729

## What

Step 1 (the root step) of the Agent Cognition Core epic: stands up the `agent_cognition` package and its durable storage so every downstream step has shared models and tables to build on. No business logic, routes, or LLM calls in this step.

### Models — `agent_cognition/models.py`
Pydantic v2 domain models mirroring the schema one-to-one:
- `MemoryEvent`, `PeriodSummary`, `Rule`, `RuleProposal`, `ToolCall`, `CognitionContext`, `CognitionWriteback`
- Enums: `EventKind`, `Scale`, `RuleMode`, `RuleStatus`, `RuleSource`, `ProposalAction`, `ProposalStatus` — values map exactly to the `TEXT` columns. `ProposalStatus` includes the system auto-withdraw terminal state **`superseded`** (distinct from the human `rejected`).

### Schema — `agent_cognition/postgres/__init__.py`
Pure-data `TeamSchema` (`team="agent_cognition"`) with five idempotent tables: `events`, `summaries`, `rules`, `rule_proposals`, `runs`. The load-bearing constraints later steps' `ON CONFLICT` / claim clauses depend on are all present:
- events **unique `(agent_id, source_run_id, source_seq)`** (writeback idempotency)
- summaries **unique `(agent_id, scale, period_start)`** (idempotent rollups)
- runs **PK `(agent_id, source_run_id)`** (invoke idempotency ledger)
- summaries `version` / `stale` / `covers_through`; rules & proposals `evidence`

### Wiring
- Registered in `shared_postgres/registry.py` (gets the DDL validated by the CI `register_all_team_schemas` live-Postgres job).
- Explicit `register_team_schemas(SCHEMA)` in the unified API lifespan so tables are created idempotently on startup.

## Tests
- **Always-on (no DB):** model round-trips/defaults/validation + schema-shape assertions on the three critical constraints.
- **Postgres-gated:** applies the schema twice (idempotent) and truncates — skipped when `POSTGRES_HOST` is unset.

```
21 passed, 1 skipped — coverage 98% (agent_cognition)
```
- `ruff check` + `ruff format --check`: clean
- 11/11 DDL statements parse under the Postgres dialect (sqlglot)
- `shared_postgres` suite: 36 passed, 2 skipped (registry change is non-breaking)

## Notes
Following the precedent of the other Postgres-backed in-process packages (`agent_console`, `product_delivery`), this does not add a dedicated `test-backend` CI matrix entry — those siblings aren't in it either; DDL validity is enforced by the live-Postgres registry job and unit coverage runs via `make test`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xxr9xksbd1KPagdjuBdy6r)_