### PR TITLE
[Cognition][Step 2] Memory store (DAL)

### DIFF
--- a/backend/agents/agent_cognition/memory/__init__.py
+++ b/backend/agents/agent_cognition/memory/__init__.py
@@ -1,0 +1,37 @@
+"""Episodic memory subsystem for the Agent Cognition Core.
+
+This package owns the durable read/write path for an agent's episodic
+events and calendar-scoped rollups. :mod:`agent_cognition.memory.store` is
+the data-access layer over the ``agent_cognition_events`` and
+``agent_cognition_summaries`` tables; later steps add the rollup engine and
+the retrieval/digest builder on top of it.
+
+Importing this package has no side effects (the Postgres schema is
+registered explicitly from the unified API lifespan).
+"""
+
+from __future__ import annotations
+
+from agent_cognition.memory.store import (
+    AgentCognitionStorageUnavailable,
+    append_event,
+    fetch_events_for_period,
+    fetch_recent_events,
+    fetch_summaries,
+    get_last_summary,
+    mark_period_stale,
+    prune_events,
+    upsert_summary,
+)
+
+__all__ = [
+    "AgentCognitionStorageUnavailable",
+    "append_event",
+    "fetch_events_for_period",
+    "fetch_recent_events",
+    "fetch_summaries",
+    "get_last_summary",
+    "mark_period_stale",
+    "prune_events",
+    "upsert_summary",
+]

--- a/backend/agents/agent_cognition/memory/store.py
+++ b/backend/agents/agent_cognition/memory/store.py
@@ -45,9 +45,10 @@ logger = logging.getLogger(__name__)
 _STORE = "agent_cognition"
 
 # Full column lists so ``SELECT`` results round-trip straight into the models.
-# ``events_pruned`` is store-managed retention bookkeeping (see prune_events /
-# mark_period_stale) and is intentionally not part of the PeriodSummary model,
-# so it is absent here — upsert_summary never writes it and reads never need it.
+# Store-managed retention bookkeeping columns are intentionally absent from
+# these lists (not part of the domain models): ``events.recorded_at`` (set by
+# its DEFAULT NOW() on append), and ``summaries.events_pruned`` / ``computed_at``
+# (managed by prune_events / upsert_summary). The models never see them.
 _EVENT_COLS = "id, agent_id, kind, content, data, salience, occurred_at, source_run_id, source_seq"
 _SUMMARY_COLS = (
     "id, agent_id, scale, period_start, period_end, summary, highlights, "
@@ -154,8 +155,18 @@ def fetch_recent_events(agent_id: str, top_n: int, by_salience: bool = True) -> 
 # Rollup summaries
 # ---------------------------------------------------------------------------
 @timed_query(store=_STORE, op="upsert_summary")
-def upsert_summary(agent_id: str, summary: PeriodSummary) -> None:
+def upsert_summary(
+    agent_id: str, summary: PeriodSummary, *, computed_at: datetime | None = None
+) -> None:
     """Insert or replace one rollup, idempotent on the period unique key.
+
+    Args:
+        computed_at: When this rollup folded its inputs — i.e. the snapshot
+            time up to which events are incorporated. ``prune_events`` only
+            deletes events with ``recorded_at <= computed_at``, so the rollup
+            should pass the timestamp of the event snapshot it summarized
+            (defaults to "now", which is safe when no events are appended
+            concurrently with the recompute).
 
     Preconditions:
         * ``agent_id`` is non-empty and ``summary.agent_id == agent_id``.
@@ -163,7 +174,7 @@ def upsert_summary(agent_id: str, summary: PeriodSummary) -> None:
         * Exactly one row exists for ``(agent_id, scale, period_start)``; a
           second call with the same key updates the mutable columns in place
           rather than inserting a duplicate. ``id`` and ``created_at`` of the
-          original row are preserved on update.
+          original row are preserved on update; ``computed_at`` is refreshed.
         * ``version`` is monotonic non-decreasing: an update carrying a lower
           ``version`` than the stored row (e.g. a freshly-built summary after
           ``mark_period_stale`` bumped it) keeps the higher stored value, so a
@@ -175,10 +186,11 @@ def upsert_summary(agent_id: str, summary: PeriodSummary) -> None:
     """
     assert agent_id, "upsert_summary: agent_id must be non-empty"
     assert summary.agent_id == agent_id, "upsert_summary: summary.agent_id must match agent_id"
+    stamped = computed_at or _now()
     with _conn() as conn, conn.cursor() as cur:
         cur.execute(
-            f"""INSERT INTO agent_cognition_summaries ({_SUMMARY_COLS})
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            f"""INSERT INTO agent_cognition_summaries ({_SUMMARY_COLS}, computed_at)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (agent_id, scale, period_start) DO UPDATE SET
                     period_end = EXCLUDED.period_end,
                     summary = EXCLUDED.summary,
@@ -188,7 +200,8 @@ def upsert_summary(agent_id: str, summary: PeriodSummary) -> None:
                     version = GREATEST(
                         agent_cognition_summaries.version, EXCLUDED.version
                     ),
-                    stale = EXCLUDED.stale""",
+                    stale = EXCLUDED.stale,
+                    computed_at = EXCLUDED.computed_at""",
             (
                 summary.id,
                 summary.agent_id,
@@ -202,6 +215,7 @@ def upsert_summary(agent_id: str, summary: PeriodSummary) -> None:
                 summary.version,
                 summary.stale,
                 summary.created_at,
+                stamped,
             ),
         )
 
@@ -327,10 +341,14 @@ def mark_period_stale(agent_id: str, occurred_at: datetime) -> bool:
 def prune_events(agent_id: str, retention_days: int) -> int:
     """Delete raw events older than the cutoff, losslessly.
 
-    An event is only deleted when the **day** summary containing it exists and
-    is non-stale — so nothing that hasn't been folded into a current summary is
-    ever lost, and the rollup engine always has a base summary to amend if a
-    still-later event arrives for that day.
+    An event is only deleted when the **day** summary containing it exists, is
+    non-stale, **and the event was already folded into that summary** —
+    detected by ``recorded_at <= computed_at`` (the event arrived at or before
+    the summary's last recompute). This closes the race where a late event is
+    appended into an already-summarized day and the pruner runs before the
+    period is marked stale: such an event has ``recorded_at > computed_at`` and
+    is left in place, so it can be amended into the summary later rather than
+    silently dropped. Nothing unsummarized is ever lost.
 
     Before deleting, the affected day summaries are latched
     ``events_pruned = TRUE``. That flag is the durable recompute-vs-amend
@@ -342,10 +360,12 @@ def prune_events(agent_id: str, retention_days: int) -> int:
         * ``agent_id`` is non-empty and ``retention_days >= 0``.
     Postconditions:
         * Only this agent's events with ``occurred_at < now - retention_days``
-          whose containing day summary exists and is non-stale are removed, and
-          exactly those day summaries are marked ``events_pruned``.
-        * Events with no day summary, or under a ``stale`` day summary, or
-          newer than the cutoff, are retained.
+          whose containing day summary exists, is non-stale, and has
+          ``computed_at >= the event's recorded_at`` are removed, and exactly
+          those day summaries are marked ``events_pruned``.
+        * Events with no day summary, under a ``stale`` day summary, newer than
+          the cutoff, or not yet folded into the summary (``recorded_at >
+          computed_at``, incl. a NULL ``computed_at``) are retained.
     Returns:
         The number of events deleted.
     """
@@ -354,18 +374,20 @@ def prune_events(agent_id: str, retention_days: int) -> int:
     cutoff = _now() - timedelta(days=retention_days)
     with _conn() as conn, conn.cursor() as cur:
         # Latch the durable regime marker on every non-stale day summary that
-        # is about to lose events. Done before the DELETE — afterwards the
-        # raw rows are gone and we could no longer tell which days were hit.
+        # is about to lose (folded) events. Done before the DELETE — afterwards
+        # the raw rows are gone and we could no longer tell which days were hit.
         cur.execute(
             """UPDATE agent_cognition_summaries s
                SET events_pruned = TRUE
                WHERE s.agent_id = %s AND s.scale = %s AND s.stale = FALSE
+                 AND s.computed_at IS NOT NULL
                  AND EXISTS (
                      SELECT 1 FROM agent_cognition_events e
                      WHERE e.agent_id = s.agent_id
                        AND e.occurred_at < %s
                        AND e.occurred_at >= s.period_start
                        AND e.occurred_at < s.period_end
+                       AND e.recorded_at <= s.computed_at
                  )""",
             (agent_id, Scale.DAY.value, cutoff),
         )
@@ -378,8 +400,10 @@ def prune_events(agent_id: str, retention_days: int) -> int:
                      WHERE s.agent_id = e.agent_id
                        AND s.scale = %s
                        AND s.stale = FALSE
+                       AND s.computed_at IS NOT NULL
                        AND e.occurred_at >= s.period_start
                        AND e.occurred_at < s.period_end
+                       AND e.recorded_at <= s.computed_at
                  )""",
             (agent_id, cutoff, Scale.DAY.value),
         )

--- a/backend/agents/agent_cognition/memory/store.py
+++ b/backend/agents/agent_cognition/memory/store.py
@@ -155,18 +155,21 @@ def fetch_recent_events(agent_id: str, top_n: int, by_salience: bool = True) -> 
 # Rollup summaries
 # ---------------------------------------------------------------------------
 @timed_query(store=_STORE, op="upsert_summary")
-def upsert_summary(
-    agent_id: str, summary: PeriodSummary, *, computed_at: datetime | None = None
-) -> None:
+def upsert_summary(agent_id: str, summary: PeriodSummary, *, computed_at: datetime) -> None:
     """Insert or replace one rollup, idempotent on the period unique key.
 
     Args:
-        computed_at: When this rollup folded its inputs — i.e. the snapshot
-            time up to which events are incorporated. ``prune_events`` only
-            deletes events with ``recorded_at <= computed_at``, so the rollup
-            should pass the timestamp of the event snapshot it summarized
-            (defaults to "now", which is safe when no events are appended
-            concurrently with the recompute).
+        computed_at: **Required.** The snapshot time up to which this rollup
+            folded its inputs — i.e. the instant the caller read the event set
+            it summarized, *not* the time of this write. ``prune_events`` only
+            deletes events with ``recorded_at <= computed_at``, so this must be
+            the read time: an event appended after the snapshot (even if before
+            this upsert commits) then has ``recorded_at > computed_at`` and is
+            correctly treated as not-yet-folded, so it survives pruning until a
+            later recompute amends it in. The rollup should therefore capture
+            ``computed_at`` before reading events and bound its read by it.
+            Passing the post-generation/write time instead would let a
+            concurrently-appended late event be pruned before it is folded.
 
     Preconditions:
         * ``agent_id`` is non-empty and ``summary.agent_id == agent_id``.
@@ -186,7 +189,6 @@ def upsert_summary(
     """
     assert agent_id, "upsert_summary: agent_id must be non-empty"
     assert summary.agent_id == agent_id, "upsert_summary: summary.agent_id must match agent_id"
-    stamped = computed_at or _now()
     with _conn() as conn, conn.cursor() as cur:
         cur.execute(
             f"""INSERT INTO agent_cognition_summaries ({_SUMMARY_COLS}, computed_at)
@@ -215,7 +217,7 @@ def upsert_summary(
                 summary.version,
                 summary.stale,
                 summary.created_at,
-                stamped,
+                computed_at,
             ),
         )
 

--- a/backend/agents/agent_cognition/memory/store.py
+++ b/backend/agents/agent_cognition/memory/store.py
@@ -1,0 +1,340 @@
+"""Postgres data-access layer for episodic memory events and rollups.
+
+Follows the ``agent_console`` store idiom:
+  * stateless module-level functions (the pool lives in ``shared_postgres``)
+  * one public function per operation, decorated with ``@timed_query``
+  * synchronous psycopg v3; ``with get_conn()`` commits on clean exit and
+    rolls back on exception, so there are no explicit ``commit()`` calls
+  * ``%s`` positional params; ``Json(...)`` for JSONB columns; rows are
+    rebuilt into pydantic models via ``model_validate``
+
+The cognition plan specifies free functions taking ``agent_id`` first (not a
+class), because the rollup engine, retrieval builder, and invoke facade call
+these directly.
+
+Design by Contract:
+
+* **Preconditions** — every mutating call asserts that the supplied
+  ``agent_id`` matches the row's own ``agent_id`` (no cross-agent writes),
+  and that count/retention arguments are non-negative.
+* **Postconditions** — ``append_event`` and ``upsert_summary`` are
+  idempotent on their schema unique keys
+  (``(agent_id, source_run_id, source_seq)`` and
+  ``(agent_id, scale, period_start)`` respectively); every reader returns
+  only rows owned by ``agent_id``.
+* **Invariant** — *every* statement in this module is filtered by
+  ``agent_id``; no query reads or writes another agent's rows.
+
+When ``POSTGRES_HOST`` is unset, ``shared_postgres.get_conn`` is unavailable,
+so :func:`_conn` raises :class:`AgentCognitionStorageUnavailable` for the API
+layer to translate into a clean 503.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from psycopg.rows import dict_row
+from psycopg.types.json import Json
+
+from agent_cognition.models import MemoryEvent, PeriodSummary, Scale
+from shared_postgres import get_conn, is_postgres_enabled
+from shared_postgres.metrics import timed_query
+
+logger = logging.getLogger(__name__)
+_STORE = "agent_cognition"
+
+# Full column lists so ``SELECT`` results round-trip straight into the models.
+_EVENT_COLS = "id, agent_id, kind, content, data, salience, occurred_at, source_run_id, source_seq"
+_SUMMARY_COLS = (
+    "id, agent_id, scale, period_start, period_end, summary, highlights, "
+    "source_count, covers_through, version, stale, created_at"
+)
+
+
+class AgentCognitionStorageUnavailable(RuntimeError):
+    """Postgres isn't configured, unreachable, or the pool is shut down."""
+
+
+# ---------------------------------------------------------------------------
+# Episodic events
+# ---------------------------------------------------------------------------
+@timed_query(store=_STORE, op="append_event")
+def append_event(agent_id: str, event: MemoryEvent) -> None:
+    """Append one episodic event, idempotent on the writeback key.
+
+    Preconditions:
+        * ``event.agent_id == agent_id`` — the caller owns the row.
+        * ``event.id`` and ``event.source_run_id`` are caller-supplied (the
+          store never mints them).
+    Postconditions:
+        * The event is inserted, or — when ``(agent_id, source_run_id,
+          source_seq)`` already exists — the call is a no-op (a duplicated or
+          retried writeback never skews rollups).
+    """
+    assert event.agent_id == agent_id, "append_event: event.agent_id must match agent_id"
+    with _conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            f"""INSERT INTO agent_cognition_events ({_EVENT_COLS})
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (agent_id, source_run_id, source_seq) DO NOTHING""",
+            (
+                event.id,
+                event.agent_id,
+                event.kind.value,
+                event.content,
+                Json(event.data),
+                event.salience,
+                event.occurred_at,
+                event.source_run_id,
+                event.source_seq,
+            ),
+        )
+
+
+@timed_query(store=_STORE, op="fetch_events_for_period")
+def fetch_events_for_period(
+    agent_id: str, period_start: datetime, period_end: datetime
+) -> list[MemoryEvent]:
+    """Return this agent's events in the half-open window ``[start, end)``.
+
+    Postconditions:
+        * Ordered by ``occurred_at`` ascending; only rows owned by
+          ``agent_id`` and with ``period_start <= occurred_at < period_end``.
+    """
+    with _conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            f"""SELECT {_EVENT_COLS}
+                FROM agent_cognition_events
+                WHERE agent_id = %s AND occurred_at >= %s AND occurred_at < %s
+                ORDER BY occurred_at ASC""",
+            (agent_id, period_start, period_end),
+        )
+        return [MemoryEvent.model_validate(row) for row in cur.fetchall()]
+
+
+@timed_query(store=_STORE, op="fetch_recent_events")
+def fetch_recent_events(agent_id: str, top_n: int, by_salience: bool = True) -> list[MemoryEvent]:
+    """Return the ``top_n`` most relevant recent events for this agent.
+
+    Preconditions:
+        * ``top_n >= 0``.
+    Postconditions:
+        * Ordered by ``(salience DESC, occurred_at DESC)`` when
+          ``by_salience`` else ``occurred_at DESC``; at most ``top_n`` rows,
+          all owned by ``agent_id``.
+    """
+    assert top_n >= 0, "fetch_recent_events: top_n must be non-negative"
+    order_by = "salience DESC, occurred_at DESC" if by_salience else "occurred_at DESC"
+    with _conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            f"""SELECT {_EVENT_COLS}
+                FROM agent_cognition_events
+                WHERE agent_id = %s
+                ORDER BY {order_by}
+                LIMIT %s""",
+            (agent_id, top_n),
+        )
+        return [MemoryEvent.model_validate(row) for row in cur.fetchall()]
+
+
+# ---------------------------------------------------------------------------
+# Rollup summaries
+# ---------------------------------------------------------------------------
+@timed_query(store=_STORE, op="upsert_summary")
+def upsert_summary(agent_id: str, summary: PeriodSummary) -> None:
+    """Insert or replace one rollup, idempotent on the period unique key.
+
+    Preconditions:
+        * ``summary.agent_id == agent_id``.
+    Postconditions:
+        * Exactly one row exists for ``(agent_id, scale, period_start)``; a
+          second call with the same key updates the mutable columns
+          (including ``version`` / ``stale``) in place rather than inserting
+          a duplicate. ``id`` and ``created_at`` of the original row are
+          preserved on update.
+    """
+    assert summary.agent_id == agent_id, "upsert_summary: summary.agent_id must match agent_id"
+    with _conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            f"""INSERT INTO agent_cognition_summaries ({_SUMMARY_COLS})
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (agent_id, scale, period_start) DO UPDATE SET
+                    period_end = EXCLUDED.period_end,
+                    summary = EXCLUDED.summary,
+                    highlights = EXCLUDED.highlights,
+                    source_count = EXCLUDED.source_count,
+                    covers_through = EXCLUDED.covers_through,
+                    version = EXCLUDED.version,
+                    stale = EXCLUDED.stale""",
+            (
+                summary.id,
+                summary.agent_id,
+                summary.scale.value,
+                summary.period_start,
+                summary.period_end,
+                summary.summary,
+                Json(summary.highlights),
+                summary.source_count,
+                summary.covers_through,
+                summary.version,
+                summary.stale,
+                summary.created_at,
+            ),
+        )
+
+
+@timed_query(store=_STORE, op="fetch_summaries")
+def fetch_summaries(
+    agent_id: str, scale: Scale, limit: int | None = None, offset: int = 0
+) -> list[PeriodSummary]:
+    """Return this agent's summaries at ``scale``, newest period first.
+
+    Preconditions:
+        * ``offset >= 0`` and, when supplied, ``limit >= 0``.
+    Postconditions:
+        * Ordered by ``period_start`` descending; only rows owned by
+          ``agent_id`` at the requested ``scale``.
+    """
+    assert offset >= 0, "fetch_summaries: offset must be non-negative"
+    assert limit is None or limit >= 0, "fetch_summaries: limit must be non-negative"
+    sql = f"""SELECT {_SUMMARY_COLS}
+              FROM agent_cognition_summaries
+              WHERE agent_id = %s AND scale = %s
+              ORDER BY period_start DESC"""
+    params: list[object] = [agent_id, scale.value]
+    if limit is not None:
+        sql += " LIMIT %s OFFSET %s"
+        params.extend([limit, offset])
+    with _conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(sql, params)
+        return [PeriodSummary.model_validate(row) for row in cur.fetchall()]
+
+
+@timed_query(store=_STORE, op="get_last_summary")
+def get_last_summary(agent_id: str, scale: Scale) -> PeriodSummary | None:
+    """Return the most recent (latest ``period_start``) summary, or ``None``.
+
+    Postconditions:
+        * The returned summary, if any, is owned by ``agent_id`` at ``scale``
+          and has the maximal ``period_start`` of that set.
+    """
+    with _conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            f"""SELECT {_SUMMARY_COLS}
+                FROM agent_cognition_summaries
+                WHERE agent_id = %s AND scale = %s
+                ORDER BY period_start DESC
+                LIMIT 1""",
+            (agent_id, scale.value),
+        )
+        row = cur.fetchone()
+        return PeriodSummary.model_validate(row) if row else None
+
+
+@timed_query(store=_STORE, op="mark_period_stale")
+def mark_period_stale(agent_id: str, occurred_at: datetime) -> bool:
+    """Flag every summary that contains ``occurred_at`` for recompute.
+
+    A late event landing inside an already-summarized period must trigger a
+    re-summarization. This sets ``stale = true`` and bumps ``version`` on
+    *every* existing summary whose half-open window ``[period_start,
+    period_end)`` contains ``occurred_at`` — i.e. the day, week, and month
+    (and year) rows at once, so the staleness cascade up the scales is
+    implicit.
+
+    Postconditions:
+        * All containing summaries (any scale) are now ``stale`` with
+          ``version`` incremented by one.
+    Returns:
+        Whether the period's **raw events are still retained** — the regime
+        signal the rollup engine uses to choose recompute-from-events
+        (regime a) vs. incremental amend (regime b). ``True`` unless a
+        containing **day** summary exists whose ``source_count`` exceeds the
+        number of events currently stored in its window (meaning some were
+        pruned). With no day summary, the period was never summarized, so
+        events are trivially retained and ``True`` is returned.
+    """
+    with _conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """UPDATE agent_cognition_summaries
+               SET stale = TRUE, version = version + 1
+               WHERE agent_id = %s AND period_start <= %s AND %s < period_end""",
+            (agent_id, occurred_at, occurred_at),
+        )
+        cur.execute(
+            """SELECT period_start, period_end, source_count
+               FROM agent_cognition_summaries
+               WHERE agent_id = %s AND scale = %s
+                 AND period_start <= %s AND %s < period_end""",
+            (agent_id, Scale.DAY.value, occurred_at, occurred_at),
+        )
+        day = cur.fetchone()
+        if day is None:
+            return True
+        period_start, period_end, source_count = day
+        cur.execute(
+            """SELECT count(*) FROM agent_cognition_events
+               WHERE agent_id = %s AND occurred_at >= %s AND occurred_at < %s""",
+            (agent_id, period_start, period_end),
+        )
+        current_count = cur.fetchone()[0]
+        return current_count >= source_count
+
+
+@timed_query(store=_STORE, op="prune_events")
+def prune_events(agent_id: str, retention_days: int) -> int:
+    """Delete raw events older than the cutoff, losslessly.
+
+    An event is only deleted when the **day** summary containing it exists
+    and is non-stale — so nothing that hasn't been folded into a current
+    summary is ever lost, and the rollup engine always has a base summary to
+    amend if a still-later event arrives for that day.
+
+    Preconditions:
+        * ``retention_days >= 0``.
+    Postconditions:
+        * Only this agent's events with ``occurred_at < now - retention_days``
+          whose containing day summary exists and is non-stale are removed.
+        * Events with no day summary, or under a ``stale`` day summary, or
+          newer than the cutoff, are retained.
+    Returns:
+        The number of events deleted.
+    """
+    assert retention_days >= 0, "prune_events: retention_days must be non-negative"
+    cutoff = _now() - timedelta(days=retention_days)
+    with _conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """DELETE FROM agent_cognition_events AS e
+               WHERE e.agent_id = %s
+                 AND e.occurred_at < %s
+                 AND EXISTS (
+                     SELECT 1 FROM agent_cognition_summaries s
+                     WHERE s.agent_id = e.agent_id
+                       AND s.scale = 'day'
+                       AND s.stale = FALSE
+                       AND e.occurred_at >= s.period_start
+                       AND e.occurred_at < s.period_end
+                 )""",
+            (agent_id, cutoff),
+        )
+        return cur.rowcount
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+def _conn():
+    if not is_postgres_enabled():
+        raise AgentCognitionStorageUnavailable(
+            "POSTGRES_HOST is not configured; Agent Cognition storage is unavailable."
+        )
+    try:
+        return get_conn()
+    except Exception as exc:  # pragma: no cover — infra paths
+        raise AgentCognitionStorageUnavailable(str(exc)) from exc
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)

--- a/backend/agents/agent_cognition/memory/store.py
+++ b/backend/agents/agent_cognition/memory/store.py
@@ -45,15 +45,20 @@ logger = logging.getLogger(__name__)
 _STORE = "agent_cognition"
 
 # Full column lists so ``SELECT`` results round-trip straight into the models.
-# Store-managed retention bookkeeping columns are intentionally absent from
-# these lists (not part of the domain models): ``events.recorded_at`` (set by
-# its DEFAULT NOW() on append), and ``summaries.events_pruned`` / ``computed_at``
-# (managed by prune_events / upsert_summary). The models never see them.
+# ``events.recorded_at`` and ``summaries.computed_at`` are store-managed write
+# bookkeeping (set by append's DEFAULT NOW() and by upsert_summary) and stay out
+# of these lists. ``summaries.events_pruned`` *is* surfaced to readers (it is the
+# durable recompute-vs-amend regime, see _SUMMARY_READ_COLS) but is never written
+# by upsert_summary — only prune_events latches it.
 _EVENT_COLS = "id, agent_id, kind, content, data, salience, occurred_at, source_run_id, source_seq"
 _SUMMARY_COLS = (
     "id, agent_id, scale, period_start, period_end, summary, highlights, "
     "source_count, covers_through, version, stale, created_at"
 )
+# Read projection: the write columns plus the store-managed regime flag, so a
+# rollup that rediscovers a stale summary can tell pruned (amend) from retained
+# (recompute) without re-calling mark_period_stale.
+_SUMMARY_READ_COLS = f"{_SUMMARY_COLS}, events_pruned"
 
 
 class AgentCognitionStorageUnavailable(RuntimeError):
@@ -100,25 +105,41 @@ def append_event(agent_id: str, event: MemoryEvent) -> None:
 
 @timed_query(store=_STORE, op="fetch_events_for_period")
 def fetch_events_for_period(
-    agent_id: str, period_start: datetime, period_end: datetime
+    agent_id: str,
+    period_start: datetime,
+    period_end: datetime,
+    *,
+    snapshot: datetime | None = None,
 ) -> list[MemoryEvent]:
     """Return this agent's events in the half-open window ``[start, end)``.
+
+    Args:
+        snapshot: Optional arrival-time bound. When set, only events with
+            ``recorded_at <= snapshot`` are returned. A rollup folding this
+            period **must** pass the same value it gives ``upsert_summary``'s
+            ``computed_at``, so it never folds an event the prune guard would
+            then consider not-yet-folded (``recorded_at > computed_at``) — i.e.
+            the read and the recorded/computed prune comparison stay consistent.
+            Omit it for plain time-window reads.
 
     Preconditions:
         * ``agent_id`` is non-empty.
     Postconditions:
         * Ordered by ``(occurred_at, id)`` ascending (stable); only rows owned
-          by ``agent_id`` with ``period_start <= occurred_at < period_end``.
+          by ``agent_id`` with ``period_start <= occurred_at < period_end`` and,
+          when ``snapshot`` is given, ``recorded_at <= snapshot``.
     """
     assert agent_id, "fetch_events_for_period: agent_id must be non-empty"
+    sql = f"""SELECT {_EVENT_COLS}
+              FROM agent_cognition_events
+              WHERE agent_id = %s AND occurred_at >= %s AND occurred_at < %s"""
+    params: list[object] = [agent_id, period_start, period_end]
+    if snapshot is not None:
+        sql += " AND recorded_at <= %s"
+        params.append(snapshot)
+    sql += " ORDER BY occurred_at ASC, id ASC"
     with _conn() as conn, conn.cursor(row_factory=dict_row) as cur:
-        cur.execute(
-            f"""SELECT {_EVENT_COLS}
-                FROM agent_cognition_events
-                WHERE agent_id = %s AND occurred_at >= %s AND occurred_at < %s
-                ORDER BY occurred_at ASC, id ASC""",
-            (agent_id, period_start, period_end),
-        )
+        cur.execute(sql, params)
         return [MemoryEvent.model_validate(row) for row in cur.fetchall()]
 
 
@@ -239,7 +260,7 @@ def fetch_summaries(
     assert agent_id, "fetch_summaries: agent_id must be non-empty"
     assert offset >= 0, "fetch_summaries: offset must be non-negative"
     assert limit is None or limit >= 0, "fetch_summaries: limit must be non-negative"
-    sql = f"""SELECT {_SUMMARY_COLS}
+    sql = f"""SELECT {_SUMMARY_READ_COLS}
               FROM agent_cognition_summaries
               WHERE agent_id = %s AND scale = %s
               ORDER BY period_start DESC"""
@@ -270,7 +291,7 @@ def get_last_summary(agent_id: str, scale: Scale) -> PeriodSummary | None:
     assert agent_id, "get_last_summary: agent_id must be non-empty"
     with _conn() as conn, conn.cursor(row_factory=dict_row) as cur:
         cur.execute(
-            f"""SELECT {_SUMMARY_COLS}
+            f"""SELECT {_SUMMARY_READ_COLS}
                 FROM agent_cognition_summaries
                 WHERE agent_id = %s AND scale = %s
                 ORDER BY period_start DESC

--- a/backend/agents/agent_cognition/memory/store.py
+++ b/backend/agents/agent_cognition/memory/store.py
@@ -244,6 +244,15 @@ def mark_period_stale(agent_id: str, occurred_at: datetime) -> bool:
     (and year) rows at once, so the staleness cascade up the scales is
     implicit.
 
+    Preconditions:
+        * **Call this before persisting the triggering late event.** The
+          retained-count below counts the events currently stored in the
+          period; it must reflect only the events the day summary folded
+          (plus any earlier, not-yet-rolled-up arrivals) and *not* the
+          in-flight late event. Counting the late event would let a
+          partially-pruned day read back up to ``source_count`` and wrongly
+          report the period as retained, so the rollup engine would recompute
+          from an incomplete raw set and silently drop the pruned history.
     Postconditions:
         * All containing summaries (any scale) are now ``stale`` with
           ``version`` incremented by one.

--- a/backend/agents/agent_cognition/memory/store.py
+++ b/backend/agents/agent_cognition/memory/store.py
@@ -213,6 +213,12 @@ def upsert_summary(agent_id: str, summary: PeriodSummary, *, computed_at: dateti
           stale flag raised after its read, so the late event is still folded
           on the next recompute. ``stale_since`` is preserved while stale stays
           set and reset to NULL when it is cleared.
+        * ``computed_at`` is monotonic: an update whose ``computed_at`` is older
+          than the stored row's is **skipped entirely** (no field changes), so
+          two rollups finishing out of order can't let the staler one overwrite
+          the fresher summary, regress ``computed_at``, or reset ``stale`` /
+          ``version``. A first recompute of a back-filled row (stored
+          ``computed_at IS NULL``) is always allowed.
     """
     assert agent_id, "upsert_summary: agent_id must be non-empty"
     assert summary.agent_id == agent_id, "upsert_summary: summary.agent_id must match agent_id"
@@ -249,7 +255,9 @@ def upsert_summary(agent_id: str, summary: PeriodSummary, *, computed_at: dateti
                         THEN agent_cognition_summaries.stale_since
                         ELSE NULL
                     END,
-                    computed_at = EXCLUDED.computed_at""",
+                    computed_at = EXCLUDED.computed_at
+                WHERE agent_cognition_summaries.computed_at IS NULL
+                    OR EXCLUDED.computed_at >= agent_cognition_summaries.computed_at""",
             (
                 summary.id,
                 summary.agent_id,

--- a/backend/agents/agent_cognition/memory/store.py
+++ b/backend/agents/agent_cognition/memory/store.py
@@ -207,6 +207,12 @@ def upsert_summary(agent_id: str, summary: PeriodSummary, *, computed_at: dateti
         * The store-managed ``events_pruned`` flag is not touched here (it is
           owned solely by ``prune_events``), so a recompute can never silently
           clear it.
+        * ``stale`` is **not** cleared if the period was flagged stale after
+          this rollup's ``computed_at`` snapshot (``stale_since > computed_at``)
+          — a slow rollup that read before a late arrival cannot clobber the
+          stale flag raised after its read, so the late event is still folded
+          on the next recompute. ``stale_since`` is preserved while stale stays
+          set and reset to NULL when it is cleared.
     """
     assert agent_id, "upsert_summary: agent_id must be non-empty"
     assert summary.agent_id == agent_id, "upsert_summary: summary.agent_id must match agent_id"
@@ -223,7 +229,26 @@ def upsert_summary(agent_id: str, summary: PeriodSummary, *, computed_at: dateti
                     version = GREATEST(
                         agent_cognition_summaries.version, EXCLUDED.version
                     ),
-                    stale = EXCLUDED.stale,
+                    -- Don't clear a stale flag raised *after* this rollup read
+                    -- its inputs: if the stored period went stale at a time the
+                    -- caller's computed_at snapshot doesn't cover, keep it stale
+                    -- (and keep stale_since) so the late event is folded next.
+                    stale = (
+                        EXCLUDED.stale
+                        OR (
+                            agent_cognition_summaries.stale_since IS NOT NULL
+                            AND agent_cognition_summaries.stale_since > EXCLUDED.computed_at
+                        )
+                    ),
+                    stale_since = CASE
+                        WHEN EXCLUDED.stale
+                            OR (
+                                agent_cognition_summaries.stale_since IS NOT NULL
+                                AND agent_cognition_summaries.stale_since > EXCLUDED.computed_at
+                            )
+                        THEN agent_cognition_summaries.stale_since
+                        ELSE NULL
+                    END,
                     computed_at = EXCLUDED.computed_at""",
             (
                 summary.id,
@@ -313,19 +338,22 @@ def mark_period_stale(agent_id: str, occurred_at: datetime) -> bool:
     rows at once, so the staleness cascade up the scales is implicit.
 
     Idempotency: only the non-stale → stale transition bumps ``version`` (the
-    ``stale = FALSE`` guard). A retried writeback, or a second distinct late
-    event into a period already pending recompute, re-affirms ``stale`` as a
-    no-op and never advances ``version`` a second time — so the
+    ``CASE`` guard). A retried writeback, or a second distinct late event into a
+    period already pending recompute, re-affirms ``stale`` as a no-op for
+    ``version`` and never advances it a second time — so the
     ``(summary_id, version)`` evidence refs that proposals/rules depend on are
-    not spuriously invalidated. The regime result is order-independent: it does
-    not matter whether the triggering late event has already been appended.
+    not spuriously invalidated. ``stale_since`` *is* refreshed on every late
+    arrival (it tracks the latest unfolded staleness, which ``upsert_summary``
+    compares against a rollup's ``computed_at``). The regime result is
+    order-independent: it does not matter whether the triggering late event has
+    already been appended.
 
     Preconditions:
         * ``agent_id`` is non-empty.
     Postconditions:
-        * Each containing summary that was not already ``stale`` is now
-          ``stale`` with ``version`` incremented by one; already-stale
-          summaries are untouched.
+        * Each containing summary is now ``stale`` with ``stale_since`` set to
+          now; ``version`` is incremented by one only for summaries that were
+          not already stale (already-stale summaries keep their ``version``).
     Returns:
         Whether the period's **raw events are still retained** — the durable
         regime signal the rollup engine uses to choose recompute-from-events
@@ -342,9 +370,10 @@ def mark_period_stale(agent_id: str, occurred_at: datetime) -> bool:
     with _conn() as conn, conn.cursor() as cur:
         cur.execute(
             """UPDATE agent_cognition_summaries
-               SET stale = TRUE, version = version + 1
-               WHERE agent_id = %s AND stale = FALSE
-                 AND period_start <= %s AND %s < period_end""",
+               SET stale = TRUE,
+                   stale_since = NOW(),
+                   version = version + (CASE WHEN stale THEN 0 ELSE 1 END)
+               WHERE agent_id = %s AND period_start <= %s AND %s < period_end""",
             (agent_id, occurred_at, occurred_at),
         )
         cur.execute(

--- a/backend/agents/agent_cognition/memory/store.py
+++ b/backend/agents/agent_cognition/memory/store.py
@@ -229,8 +229,13 @@ def fetch_summaries(
               ORDER BY period_start DESC"""
     params: list[object] = [agent_id, scale.value]
     if limit is not None:
-        sql += " LIMIT %s OFFSET %s"
-        params.extend([limit, offset])
+        sql += " LIMIT %s"
+        params.append(limit)
+    # OFFSET is independent of LIMIT — apply it whenever the caller skips rows,
+    # so offset-only pagination doesn't silently return the first page again.
+    if offset:
+        sql += " OFFSET %s"
+        params.append(offset)
     with _conn() as conn, conn.cursor(row_factory=dict_row) as cur:
         cur.execute(sql, params)
         return [PeriodSummary.model_validate(row) for row in cur.fetchall()]

--- a/backend/agents/agent_cognition/memory/store.py
+++ b/backend/agents/agent_cognition/memory/store.py
@@ -14,14 +14,12 @@ these directly.
 
 Design by Contract:
 
-* **Preconditions** — every mutating call asserts that the supplied
-  ``agent_id`` matches the row's own ``agent_id`` (no cross-agent writes),
-  and that count/retention arguments are non-negative.
-* **Postconditions** — ``append_event`` and ``upsert_summary`` are
-  idempotent on their schema unique keys
-  (``(agent_id, source_run_id, source_seq)`` and
-  ``(agent_id, scale, period_start)`` respectively); every reader returns
-  only rows owned by ``agent_id``.
+* **Preconditions** — every call asserts a non-empty ``agent_id``; mutating
+  calls additionally assert that the row's own ``agent_id`` matches, and that
+  count/retention arguments are non-negative.
+* **Postconditions** — ``append_event``, ``upsert_summary``, and
+  ``mark_period_stale`` are idempotent: re-running them with the same inputs
+  does not duplicate rows or advance ``version`` a second time.
 * **Invariant** — *every* statement in this module is filtered by
   ``agent_id``; no query reads or writes another agent's rows.
 
@@ -33,6 +31,7 @@ layer to translate into a clean 503.
 from __future__ import annotations
 
 import logging
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 
 from psycopg.rows import dict_row
@@ -46,6 +45,9 @@ logger = logging.getLogger(__name__)
 _STORE = "agent_cognition"
 
 # Full column lists so ``SELECT`` results round-trip straight into the models.
+# ``events_pruned`` is store-managed retention bookkeeping (see prune_events /
+# mark_period_stale) and is intentionally not part of the PeriodSummary model,
+# so it is absent here — upsert_summary never writes it and reads never need it.
 _EVENT_COLS = "id, agent_id, kind, content, data, salience, occurred_at, source_run_id, source_seq"
 _SUMMARY_COLS = (
     "id, agent_id, scale, period_start, period_end, summary, highlights, "
@@ -65,7 +67,8 @@ def append_event(agent_id: str, event: MemoryEvent) -> None:
     """Append one episodic event, idempotent on the writeback key.
 
     Preconditions:
-        * ``event.agent_id == agent_id`` — the caller owns the row.
+        * ``agent_id`` is non-empty and ``event.agent_id == agent_id`` — the
+          caller owns the row.
         * ``event.id`` and ``event.source_run_id`` are caller-supplied (the
           store never mints them).
     Postconditions:
@@ -73,6 +76,7 @@ def append_event(agent_id: str, event: MemoryEvent) -> None:
           source_seq)`` already exists — the call is a no-op (a duplicated or
           retried writeback never skews rollups).
     """
+    assert agent_id, "append_event: agent_id must be non-empty"
     assert event.agent_id == agent_id, "append_event: event.agent_id must match agent_id"
     with _conn() as conn, conn.cursor() as cur:
         cur.execute(
@@ -99,16 +103,19 @@ def fetch_events_for_period(
 ) -> list[MemoryEvent]:
     """Return this agent's events in the half-open window ``[start, end)``.
 
+    Preconditions:
+        * ``agent_id`` is non-empty.
     Postconditions:
-        * Ordered by ``occurred_at`` ascending; only rows owned by
-          ``agent_id`` and with ``period_start <= occurred_at < period_end``.
+        * Ordered by ``(occurred_at, id)`` ascending (stable); only rows owned
+          by ``agent_id`` with ``period_start <= occurred_at < period_end``.
     """
+    assert agent_id, "fetch_events_for_period: agent_id must be non-empty"
     with _conn() as conn, conn.cursor(row_factory=dict_row) as cur:
         cur.execute(
             f"""SELECT {_EVENT_COLS}
                 FROM agent_cognition_events
                 WHERE agent_id = %s AND occurred_at >= %s AND occurred_at < %s
-                ORDER BY occurred_at ASC""",
+                ORDER BY occurred_at ASC, id ASC""",
             (agent_id, period_start, period_end),
         )
         return [MemoryEvent.model_validate(row) for row in cur.fetchall()]
@@ -119,14 +126,18 @@ def fetch_recent_events(agent_id: str, top_n: int, by_salience: bool = True) -> 
     """Return the ``top_n`` most relevant recent events for this agent.
 
     Preconditions:
-        * ``top_n >= 0``.
+        * ``agent_id`` is non-empty and ``top_n >= 0``.
     Postconditions:
-        * Ordered by ``(salience DESC, occurred_at DESC)`` when
-          ``by_salience`` else ``occurred_at DESC``; at most ``top_n`` rows,
+        * Ordered by ``(salience DESC, occurred_at DESC, id)`` when
+          ``by_salience`` else ``(occurred_at DESC, id)``; the trailing ``id``
+          breaks ties so the order is deterministic. At most ``top_n`` rows,
           all owned by ``agent_id``.
     """
+    assert agent_id, "fetch_recent_events: agent_id must be non-empty"
     assert top_n >= 0, "fetch_recent_events: top_n must be non-negative"
-    order_by = "salience DESC, occurred_at DESC" if by_salience else "occurred_at DESC"
+    order_by = (
+        "salience DESC, occurred_at DESC, id ASC" if by_salience else "occurred_at DESC, id ASC"
+    )
     with _conn() as conn, conn.cursor(row_factory=dict_row) as cur:
         cur.execute(
             f"""SELECT {_EVENT_COLS}
@@ -147,14 +158,22 @@ def upsert_summary(agent_id: str, summary: PeriodSummary) -> None:
     """Insert or replace one rollup, idempotent on the period unique key.
 
     Preconditions:
-        * ``summary.agent_id == agent_id``.
+        * ``agent_id`` is non-empty and ``summary.agent_id == agent_id``.
     Postconditions:
         * Exactly one row exists for ``(agent_id, scale, period_start)``; a
-          second call with the same key updates the mutable columns
-          (including ``version`` / ``stale``) in place rather than inserting
-          a duplicate. ``id`` and ``created_at`` of the original row are
-          preserved on update.
+          second call with the same key updates the mutable columns in place
+          rather than inserting a duplicate. ``id`` and ``created_at`` of the
+          original row are preserved on update.
+        * ``version`` is monotonic non-decreasing: an update carrying a lower
+          ``version`` than the stored row (e.g. a freshly-built summary after
+          ``mark_period_stale`` bumped it) keeps the higher stored value, so a
+          recompute never regresses the ``(summary_id, version)`` evidence
+          refs that proposals/rules key on.
+        * The store-managed ``events_pruned`` flag is not touched here (it is
+          owned solely by ``prune_events``), so a recompute can never silently
+          clear it.
     """
+    assert agent_id, "upsert_summary: agent_id must be non-empty"
     assert summary.agent_id == agent_id, "upsert_summary: summary.agent_id must match agent_id"
     with _conn() as conn, conn.cursor() as cur:
         cur.execute(
@@ -166,7 +185,9 @@ def upsert_summary(agent_id: str, summary: PeriodSummary) -> None:
                     highlights = EXCLUDED.highlights,
                     source_count = EXCLUDED.source_count,
                     covers_through = EXCLUDED.covers_through,
-                    version = EXCLUDED.version,
+                    version = GREATEST(
+                        agent_cognition_summaries.version, EXCLUDED.version
+                    ),
                     stale = EXCLUDED.stale""",
             (
                 summary.id,
@@ -192,11 +213,14 @@ def fetch_summaries(
     """Return this agent's summaries at ``scale``, newest period first.
 
     Preconditions:
-        * ``offset >= 0`` and, when supplied, ``limit >= 0``.
+        * ``agent_id`` is non-empty, ``offset >= 0``, and, when supplied,
+          ``limit >= 0``.
     Postconditions:
-        * Ordered by ``period_start`` descending; only rows owned by
-          ``agent_id`` at the requested ``scale``.
+        * Ordered by ``period_start`` descending (deterministic — the period
+          key is unique per scale); only rows owned by ``agent_id`` at the
+          requested ``scale``.
     """
+    assert agent_id, "fetch_summaries: agent_id must be non-empty"
     assert offset >= 0, "fetch_summaries: offset must be non-negative"
     assert limit is None or limit >= 0, "fetch_summaries: limit must be non-negative"
     sql = f"""SELECT {_SUMMARY_COLS}
@@ -216,10 +240,13 @@ def fetch_summaries(
 def get_last_summary(agent_id: str, scale: Scale) -> PeriodSummary | None:
     """Return the most recent (latest ``period_start``) summary, or ``None``.
 
+    Preconditions:
+        * ``agent_id`` is non-empty.
     Postconditions:
         * The returned summary, if any, is owned by ``agent_id`` at ``scale``
           and has the maximal ``period_start`` of that set.
     """
+    assert agent_id, "get_last_summary: agent_id must be non-empty"
     with _conn() as conn, conn.cursor(row_factory=dict_row) as cur:
         cur.execute(
             f"""SELECT {_SUMMARY_COLS}
@@ -239,41 +266,47 @@ def mark_period_stale(agent_id: str, occurred_at: datetime) -> bool:
 
     A late event landing inside an already-summarized period must trigger a
     re-summarization. This sets ``stale = true`` and bumps ``version`` on
-    *every* existing summary whose half-open window ``[period_start,
-    period_end)`` contains ``occurred_at`` — i.e. the day, week, and month
-    (and year) rows at once, so the staleness cascade up the scales is
-    implicit.
+    every existing summary whose half-open window ``[period_start,
+    period_end)`` contains ``occurred_at`` — the day, week, month (and year)
+    rows at once, so the staleness cascade up the scales is implicit.
+
+    Idempotency: only the non-stale → stale transition bumps ``version`` (the
+    ``stale = FALSE`` guard). A retried writeback, or a second distinct late
+    event into a period already pending recompute, re-affirms ``stale`` as a
+    no-op and never advances ``version`` a second time — so the
+    ``(summary_id, version)`` evidence refs that proposals/rules depend on are
+    not spuriously invalidated. The regime result is order-independent: it does
+    not matter whether the triggering late event has already been appended.
 
     Preconditions:
-        * **Call this before persisting the triggering late event.** The
-          retained-count below counts the events currently stored in the
-          period; it must reflect only the events the day summary folded
-          (plus any earlier, not-yet-rolled-up arrivals) and *not* the
-          in-flight late event. Counting the late event would let a
-          partially-pruned day read back up to ``source_count`` and wrongly
-          report the period as retained, so the rollup engine would recompute
-          from an incomplete raw set and silently drop the pruned history.
+        * ``agent_id`` is non-empty.
     Postconditions:
-        * All containing summaries (any scale) are now ``stale`` with
-          ``version`` incremented by one.
+        * Each containing summary that was not already ``stale`` is now
+          ``stale`` with ``version`` incremented by one; already-stale
+          summaries are untouched.
     Returns:
-        Whether the period's **raw events are still retained** — the regime
-        signal the rollup engine uses to choose recompute-from-events
-        (regime a) vs. incremental amend (regime b). ``True`` unless a
-        containing **day** summary exists whose ``source_count`` exceeds the
-        number of events currently stored in its window (meaning some were
-        pruned). With no day summary, the period was never summarized, so
-        events are trivially retained and ``True`` is returned.
+        Whether the period's **raw events are still retained** — the durable
+        regime signal the rollup engine uses to choose recompute-from-events
+        (regime a) vs. incremental amend (regime b). Read from the
+        store-managed ``events_pruned`` flag that ``prune_events`` latches on a
+        day summary when it deletes that day's raw events, so the answer
+        survives a restart and never miscounts an in-flight late event.
+        ``True`` (retained) when the containing **day** summary is not pruned,
+        or when no day summary exists at all — in which case ``prune_events``
+        (which only deletes under a non-stale day summary) cannot have removed
+        any events.
     """
+    assert agent_id, "mark_period_stale: agent_id must be non-empty"
     with _conn() as conn, conn.cursor() as cur:
         cur.execute(
             """UPDATE agent_cognition_summaries
                SET stale = TRUE, version = version + 1
-               WHERE agent_id = %s AND period_start <= %s AND %s < period_end""",
+               WHERE agent_id = %s AND stale = FALSE
+                 AND period_start <= %s AND %s < period_end""",
             (agent_id, occurred_at, occurred_at),
         )
         cur.execute(
-            """SELECT period_start, period_end, source_count
+            """SELECT events_pruned
                FROM agent_cognition_summaries
                WHERE agent_id = %s AND scale = %s
                  AND period_start <= %s AND %s < period_end""",
@@ -282,38 +315,55 @@ def mark_period_stale(agent_id: str, occurred_at: datetime) -> bool:
         day = cur.fetchone()
         if day is None:
             return True
-        period_start, period_end, source_count = day
-        cur.execute(
-            """SELECT count(*) FROM agent_cognition_events
-               WHERE agent_id = %s AND occurred_at >= %s AND occurred_at < %s""",
-            (agent_id, period_start, period_end),
-        )
-        current_count = cur.fetchone()[0]
-        return current_count >= source_count
+        return not day[0]
 
 
 @timed_query(store=_STORE, op="prune_events")
 def prune_events(agent_id: str, retention_days: int) -> int:
     """Delete raw events older than the cutoff, losslessly.
 
-    An event is only deleted when the **day** summary containing it exists
-    and is non-stale — so nothing that hasn't been folded into a current
-    summary is ever lost, and the rollup engine always has a base summary to
-    amend if a still-later event arrives for that day.
+    An event is only deleted when the **day** summary containing it exists and
+    is non-stale — so nothing that hasn't been folded into a current summary is
+    ever lost, and the rollup engine always has a base summary to amend if a
+    still-later event arrives for that day.
+
+    Before deleting, the affected day summaries are latched
+    ``events_pruned = TRUE``. That flag is the durable recompute-vs-amend
+    marker read by :func:`mark_period_stale`: once a day's raw events are gone,
+    a later late arrival into that day must be amended onto the existing
+    summary rather than recomputed from the now-incomplete event set.
 
     Preconditions:
-        * ``retention_days >= 0``.
+        * ``agent_id`` is non-empty and ``retention_days >= 0``.
     Postconditions:
         * Only this agent's events with ``occurred_at < now - retention_days``
-          whose containing day summary exists and is non-stale are removed.
+          whose containing day summary exists and is non-stale are removed, and
+          exactly those day summaries are marked ``events_pruned``.
         * Events with no day summary, or under a ``stale`` day summary, or
           newer than the cutoff, are retained.
     Returns:
         The number of events deleted.
     """
+    assert agent_id, "prune_events: agent_id must be non-empty"
     assert retention_days >= 0, "prune_events: retention_days must be non-negative"
     cutoff = _now() - timedelta(days=retention_days)
     with _conn() as conn, conn.cursor() as cur:
+        # Latch the durable regime marker on every non-stale day summary that
+        # is about to lose events. Done before the DELETE — afterwards the
+        # raw rows are gone and we could no longer tell which days were hit.
+        cur.execute(
+            """UPDATE agent_cognition_summaries s
+               SET events_pruned = TRUE
+               WHERE s.agent_id = %s AND s.scale = %s AND s.stale = FALSE
+                 AND EXISTS (
+                     SELECT 1 FROM agent_cognition_events e
+                     WHERE e.agent_id = s.agent_id
+                       AND e.occurred_at < %s
+                       AND e.occurred_at >= s.period_start
+                       AND e.occurred_at < s.period_end
+                 )""",
+            (agent_id, Scale.DAY.value, cutoff),
+        )
         cur.execute(
             """DELETE FROM agent_cognition_events AS e
                WHERE e.agent_id = %s
@@ -321,12 +371,12 @@ def prune_events(agent_id: str, retention_days: int) -> int:
                  AND EXISTS (
                      SELECT 1 FROM agent_cognition_summaries s
                      WHERE s.agent_id = e.agent_id
-                       AND s.scale = 'day'
+                       AND s.scale = %s
                        AND s.stale = FALSE
                        AND e.occurred_at >= s.period_start
                        AND e.occurred_at < s.period_end
                  )""",
-            (agent_id, cutoff),
+            (agent_id, cutoff, Scale.DAY.value),
         )
         return cur.rowcount
 
@@ -334,15 +384,36 @@ def prune_events(agent_id: str, retention_days: int) -> int:
 # ---------------------------------------------------------------------------
 # Internals
 # ---------------------------------------------------------------------------
+@contextmanager
 def _conn():
+    """Yield a pooled connection, translating *acquisition* failures only.
+
+    Preconditions:
+        * Postgres is configured (``POSTGRES_HOST`` set).
+    Postconditions:
+        * Errors raised while *acquiring* the connection surface as
+          :class:`AgentCognitionStorageUnavailable`; errors raised inside the
+          ``with`` body propagate unchanged, so a genuine query bug is never
+          masked as an infrastructure outage. Commit-on-success and
+          rollback-on-error are delegated to the underlying ``shared_postgres``
+          pool context.
+    """
     if not is_postgres_enabled():
         raise AgentCognitionStorageUnavailable(
             "POSTGRES_HOST is not configured; Agent Cognition storage is unavailable."
         )
+    pool_ctx = get_conn()
     try:
-        return get_conn()
-    except Exception as exc:  # pragma: no cover — infra paths
+        conn = pool_ctx.__enter__()
+    except Exception as exc:  # pragma: no cover — pool/connection failure path
         raise AgentCognitionStorageUnavailable(str(exc)) from exc
+    try:
+        yield conn
+    except BaseException as exc:
+        if not pool_ctx.__exit__(type(exc), exc, exc.__traceback__):
+            raise
+    else:
+        pool_ctx.__exit__(None, None, None)
 
 
 def _now() -> datetime:

--- a/backend/agents/agent_cognition/models.py
+++ b/backend/agents/agent_cognition/models.py
@@ -135,6 +135,13 @@ class PeriodSummary(BaseModel):
     covers_through: datetime | None = None
     version: int = 1
     stale: bool = False
+    # Store-managed retention regime marker: set TRUE by the memory store's
+    # prune_events when a day's raw events are deleted, so a reader that
+    # rediscovers a stale summary knows it must be *amended* (regime b) rather
+    # than recomputed from the now-incomplete raw events (regime a). Read-only
+    # for callers — upsert_summary never writes it, so a recompute cannot clear
+    # it. Defaults to FALSE.
+    events_pruned: bool = False
     created_at: datetime
 
 

--- a/backend/agents/agent_cognition/postgres/__init__.py
+++ b/backend/agents/agent_cognition/postgres/__init__.py
@@ -75,6 +75,7 @@ SCHEMA: TeamSchema = TeamSchema(
             stale           BOOLEAN NOT NULL DEFAULT FALSE,
             events_pruned   BOOLEAN NOT NULL DEFAULT FALSE,
             computed_at     TIMESTAMPTZ,
+            stale_since     TIMESTAMPTZ,
             created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
         )""",
         # ``events_pruned`` is the durable recompute-vs-amend marker: the memory
@@ -92,6 +93,14 @@ SCHEMA: TeamSchema = TeamSchema(
         # until the next recompute, which conservatively prunes nothing).
         """ALTER TABLE agent_cognition_summaries
             ADD COLUMN IF NOT EXISTS computed_at TIMESTAMPTZ""",
+        # ``stale_since`` is the time the most recent late arrival flagged this
+        # period stale (refreshed by mark_period_stale). upsert_summary refuses
+        # to clear ``stale`` when ``stale_since > computed_at`` — i.e. a slow
+        # rollup that read before the late event must not overwrite the stale
+        # flag set after its read, which would drop the late event. Idempotent
+        # ALTER back-fills existing clusters.
+        """ALTER TABLE agent_cognition_summaries
+            ADD COLUMN IF NOT EXISTS stale_since TIMESTAMPTZ""",
         """CREATE UNIQUE INDEX IF NOT EXISTS uq_agent_cognition_summaries_period
             ON agent_cognition_summaries(agent_id, scale, period_start)""",
         # -----------------------------------------------------------------

--- a/backend/agents/agent_cognition/postgres/__init__.py
+++ b/backend/agents/agent_cognition/postgres/__init__.py
@@ -63,8 +63,16 @@ SCHEMA: TeamSchema = TeamSchema(
             covers_through  TIMESTAMPTZ,
             version         INTEGER NOT NULL DEFAULT 1,
             stale           BOOLEAN NOT NULL DEFAULT FALSE,
+            events_pruned   BOOLEAN NOT NULL DEFAULT FALSE,
             created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
         )""",
+        # ``events_pruned`` is the durable recompute-vs-amend marker: the memory
+        # store latches it TRUE on a day summary when retention deletes that
+        # day's raw events, so a later late arrival is amended onto the existing
+        # summary (not recomputed from an incomplete set) even across a restart.
+        # ALTER form is idempotent and back-fills clusters provisioned before it.
+        """ALTER TABLE agent_cognition_summaries
+            ADD COLUMN IF NOT EXISTS events_pruned BOOLEAN NOT NULL DEFAULT FALSE""",
         """CREATE UNIQUE INDEX IF NOT EXISTS uq_agent_cognition_summaries_period
             ON agent_cognition_summaries(agent_id, scale, period_start)""",
         # -----------------------------------------------------------------

--- a/backend/agents/agent_cognition/postgres/__init__.py
+++ b/backend/agents/agent_cognition/postgres/__init__.py
@@ -38,8 +38,18 @@ SCHEMA: TeamSchema = TeamSchema(
             salience        DOUBLE PRECISION NOT NULL DEFAULT 0,
             occurred_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
             source_run_id   TEXT NOT NULL,
-            source_seq      INTEGER NOT NULL
+            source_seq      INTEGER NOT NULL,
+            recorded_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
         )""",
+        # ``recorded_at`` is the event's arrival (append) time, distinct from
+        # ``occurred_at`` (when it happened). prune_events deletes only events
+        # already folded into the day summary (``recorded_at <=
+        # summaries.computed_at``), so a late event appended after the summary
+        # was computed is never pruned before it can be amended in — even if the
+        # pruner races ahead of the stale-marking. Idempotent ALTER back-fills
+        # clusters provisioned before this column.
+        """ALTER TABLE agent_cognition_events
+            ADD COLUMN IF NOT EXISTS recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW()""",
         """CREATE UNIQUE INDEX IF NOT EXISTS uq_agent_cognition_events_writeback
             ON agent_cognition_events(agent_id, source_run_id, source_seq)""",
         """CREATE INDEX IF NOT EXISTS idx_agent_cognition_events_agent_occurred
@@ -64,6 +74,7 @@ SCHEMA: TeamSchema = TeamSchema(
             version         INTEGER NOT NULL DEFAULT 1,
             stale           BOOLEAN NOT NULL DEFAULT FALSE,
             events_pruned   BOOLEAN NOT NULL DEFAULT FALSE,
+            computed_at     TIMESTAMPTZ,
             created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
         )""",
         # ``events_pruned`` is the durable recompute-vs-amend marker: the memory
@@ -73,6 +84,14 @@ SCHEMA: TeamSchema = TeamSchema(
         # ALTER form is idempotent and back-fills clusters provisioned before it.
         """ALTER TABLE agent_cognition_summaries
             ADD COLUMN IF NOT EXISTS events_pruned BOOLEAN NOT NULL DEFAULT FALSE""",
+        # ``computed_at`` records when the rollup last (re)computed this summary.
+        # prune_events compares it against an event's ``recorded_at`` to delete
+        # only events that were folded in (``recorded_at <= computed_at``), so a
+        # not-yet-incorporated late arrival is never pruned. Set by
+        # upsert_summary; idempotent ALTER back-fills existing clusters (NULL
+        # until the next recompute, which conservatively prunes nothing).
+        """ALTER TABLE agent_cognition_summaries
+            ADD COLUMN IF NOT EXISTS computed_at TIMESTAMPTZ""",
         """CREATE UNIQUE INDEX IF NOT EXISTS uq_agent_cognition_summaries_period
             ON agent_cognition_summaries(agent_id, scale, period_start)""",
         # -----------------------------------------------------------------

--- a/backend/agents/agent_cognition/tests/test_models.py
+++ b/backend/agents/agent_cognition/tests/test_models.py
@@ -109,6 +109,7 @@ def test_period_summary_round_trip_and_defaults() -> None:
     )
     assert s.version == 1
     assert s.stale is False
+    assert s.events_pruned is False
     assert s.source_count == 0
     assert s.covers_through is None
     assert s.highlights == []

--- a/backend/agents/agent_cognition/tests/test_postgres_schema.py
+++ b/backend/agents/agent_cognition/tests/test_postgres_schema.py
@@ -89,6 +89,16 @@ def test_summaries_have_events_pruned_column() -> None:
     )
 
 
+def test_retention_guard_columns_present() -> None:
+    # Arrival-time guard for prune_events: events.recorded_at +
+    # summaries.computed_at, each in its CREATE and a back-filling ALTER.
+    joined = "".join(SCHEMA.statements)
+    assert "recorded_at" in joined
+    assert "ADD COLUMN IF NOT EXISTS recorded_at" in joined
+    assert "computed_at" in joined
+    assert "ADD COLUMN IF NOT EXISTS computed_at" in joined
+
+
 def test_evidence_columns_present_on_rules_and_proposals() -> None:
     rules_ddl = next(
         s for s in SCHEMA.statements if "CREATE TABLE IF NOT EXISTS agent_cognition_rules" in s

--- a/backend/agents/agent_cognition/tests/test_postgres_schema.py
+++ b/backend/agents/agent_cognition/tests/test_postgres_schema.py
@@ -78,6 +78,17 @@ def test_summaries_have_version_and_stale_columns() -> None:
     assert "covers_through" in summaries_ddl
 
 
+def test_summaries_have_events_pruned_column() -> None:
+    # Durable recompute-vs-amend marker owned by the memory store. Present in
+    # the CREATE for fresh clusters and back-filled via an idempotent ALTER.
+    joined = "".join(SCHEMA.statements)
+    assert "events_pruned" in joined
+    assert (
+        "ALTER TABLE agent_cognition_summaries" in joined
+        and "ADD COLUMN IF NOT EXISTS events_pruned" in joined
+    )
+
+
 def test_evidence_columns_present_on_rules_and_proposals() -> None:
     rules_ddl = next(
         s for s in SCHEMA.statements if "CREATE TABLE IF NOT EXISTS agent_cognition_rules" in s

--- a/backend/agents/agent_cognition/tests/test_store.py
+++ b/backend/agents/agent_cognition/tests/test_store.py
@@ -300,6 +300,25 @@ def test_upsert_summary_preserves_concurrently_set_stale() -> None:
     assert store.get_last_summary("a", Scale.DAY).stale is False
 
 
+def test_upsert_summary_older_snapshot_is_skipped() -> None:
+    # Out-of-order rollups: a fresher snapshot (T2) writes, then a staler one
+    # (T1 < T2) commits last. The older write must be ignored wholesale — it
+    # can't regress content, computed_at, version, or stale.
+    _upsert("a", _summary("a", window=_DAY, version=1, summary="t1"), computed_at=_PRECOMPUTED_AT)
+    _upsert("a", _summary("a", window=_DAY, version=2, summary="t2"), computed_at=_FOLDED_AT)
+    assert store.get_last_summary("a", Scale.DAY).summary == "t2"
+
+    # Staler rollup (snapshot T1) committing last is a no-op on conflict.
+    _upsert(
+        "a",
+        _summary("a", window=_DAY, version=99, summary="t1-late"),
+        computed_at=_PRECOMPUTED_AT,
+    )
+    row = store.get_last_summary("a", Scale.DAY)
+    assert row.summary == "t2"  # not clobbered by the older snapshot
+    assert row.version == 2  # skipped update never reached the GREATEST bump
+
+
 def test_fetch_summaries_filters_scale_and_paginates() -> None:
     months = [
         _summary(

--- a/backend/agents/agent_cognition/tests/test_store.py
+++ b/backend/agents/agent_cognition/tests/test_store.py
@@ -271,6 +271,35 @@ def test_upsert_summary_requires_computed_at() -> None:
         store.upsert_summary("a", _summary("a"))
 
 
+def test_upsert_summary_preserves_concurrently_set_stale() -> None:
+    # Lost-update race: a rollup reads the period (snapshot T0), a late event
+    # then marks it stale (stale_since = now ≫ T0), and the slow rollup's write
+    # (computed_at = T0) must NOT clear that stale flag — else the late event
+    # is never folded.
+    _upsert("a", _summary("a", window=_DAY, version=1), computed_at=_PRECOMPUTED_AT)
+    store.mark_period_stale("a", _MID_DAY)
+    assert store.get_last_summary("a", Scale.DAY).stale is True
+
+    # Slow rollup that read at T0 finishes and writes a non-stale recompute.
+    _upsert(
+        "a",
+        _summary("a", window=_DAY, version=2, stale=False, summary="stale-read"),
+        computed_at=_PRECOMPUTED_AT,
+    )
+    kept = store.get_last_summary("a", Scale.DAY)
+    assert kept.stale is True  # stale_since (now) > computed_at (T0) → preserved
+    assert kept.summary == "stale-read"  # content still updated
+
+    # A rollup that read *after* the staleness (snapshot in the far future)
+    # legitimately clears the flag.
+    _upsert(
+        "a",
+        _summary("a", window=_DAY, version=3, stale=False, summary="fresh"),
+        computed_at=_FOLDED_AT,
+    )
+    assert store.get_last_summary("a", Scale.DAY).stale is False
+
+
 def test_fetch_summaries_filters_scale_and_paginates() -> None:
     months = [
         _summary(

--- a/backend/agents/agent_cognition/tests/test_store.py
+++ b/backend/agents/agent_cognition/tests/test_store.py
@@ -267,6 +267,10 @@ def test_fetch_summaries_filters_scale_and_paginates() -> None:
     page = store.fetch_summaries("a", Scale.MONTH, limit=1, offset=1)
     assert [r.period_start.month for r in page] == [2]
 
+    # offset without limit must still skip rows (not silently return page one).
+    offset_only = store.fetch_summaries("a", Scale.MONTH, offset=1)
+    assert [r.period_start.month for r in offset_only] == [2, 1]
+
 
 def test_fetch_summaries_negative_offset_raises() -> None:
     with pytest.raises(AssertionError):

--- a/backend/agents/agent_cognition/tests/test_store.py
+++ b/backend/agents/agent_cognition/tests/test_store.py
@@ -1,0 +1,388 @@
+"""Live-Postgres tests for the cognition memory store (Step 2 DAL).
+
+Skipped automatically when ``POSTGRES_HOST`` is unset, matching the pattern
+used by ``agent_console`` / ``shared_postgres`` store tests. The autouse
+fixture registers the schema and truncates the cognition tables before each
+test so cases are independent.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from agent_cognition.memory import store
+from agent_cognition.models import EventKind, MemoryEvent, PeriodSummary, Scale
+from agent_cognition.postgres import SCHEMA
+from shared_postgres import is_postgres_enabled, register_team_schemas
+from shared_postgres.testing import truncate_team_tables
+
+pytestmark = pytest.mark.skipif(
+    not is_postgres_enabled(),
+    reason="POSTGRES_HOST not set; skipping live-Postgres store tests",
+)
+
+
+@pytest.fixture(autouse=True)
+def _provision_schema() -> None:
+    register_team_schemas(SCHEMA)
+    truncate_team_tables(SCHEMA)
+
+
+# ---------------------------------------------------------------------------
+# Fixed UTC windows. 2026-06-01 is a Monday, so the calendar day, ISO week,
+# and month windows below all contain ``_MID_DAY``.
+# ---------------------------------------------------------------------------
+_UTC = timezone.utc
+_MID_DAY = datetime(2026, 6, 1, 12, 0, tzinfo=_UTC)
+_DAY = (datetime(2026, 6, 1, tzinfo=_UTC), datetime(2026, 6, 2, tzinfo=_UTC))
+_WEEK = (datetime(2026, 6, 1, tzinfo=_UTC), datetime(2026, 6, 8, tzinfo=_UTC))
+_MONTH = (datetime(2026, 6, 1, tzinfo=_UTC), datetime(2026, 7, 1, tzinfo=_UTC))
+_CREATED = datetime(2026, 6, 2, tzinfo=_UTC)
+
+# Far-past windows for prune tests (always older than any sane cutoff).
+_OLD = datetime(2020, 1, 1, 12, 0, tzinfo=_UTC)
+_OLD_DAY = (datetime(2020, 1, 1, tzinfo=_UTC), datetime(2020, 1, 2, tzinfo=_UTC))
+_OLD2 = datetime(2020, 2, 1, 12, 0, tzinfo=_UTC)
+_OLD2_DAY = (datetime(2020, 2, 1, tzinfo=_UTC), datetime(2020, 2, 2, tzinfo=_UTC))
+_OLD3 = datetime(2020, 3, 1, 12, 0, tzinfo=_UTC)
+_OLD3_DAY = (datetime(2020, 3, 1, tzinfo=_UTC), datetime(2020, 3, 2, tzinfo=_UTC))
+
+
+def _event(
+    agent_id: str,
+    *,
+    seq: int = 1,
+    run_id: str | None = None,
+    salience: float = 0.0,
+    occurred_at: datetime = _MID_DAY,
+    kind: EventKind = EventKind.OBSERVATION,
+    content: str = "",
+    data: dict | None = None,
+) -> MemoryEvent:
+    return MemoryEvent(
+        id=str(uuid4()),
+        agent_id=agent_id,
+        kind=kind,
+        content=content,
+        data=data or {},
+        salience=salience,
+        occurred_at=occurred_at,
+        source_run_id=run_id or str(uuid4()),
+        source_seq=seq,
+    )
+
+
+def _summary(
+    agent_id: str,
+    *,
+    scale: Scale = Scale.DAY,
+    window: tuple[datetime, datetime] = _DAY,
+    source_count: int = 0,
+    version: int = 1,
+    stale: bool = False,
+    summary: str = "",
+    highlights: list | None = None,
+    covers_through: datetime | None = None,
+) -> PeriodSummary:
+    return PeriodSummary(
+        id=str(uuid4()),
+        agent_id=agent_id,
+        scale=scale,
+        period_start=window[0],
+        period_end=window[1],
+        summary=summary,
+        highlights=highlights or [],
+        source_count=source_count,
+        covers_through=covers_through,
+        version=version,
+        stale=stale,
+        created_at=_CREATED,
+    )
+
+
+def _all_events(agent_id: str) -> list[MemoryEvent]:
+    """Every event for an agent (wide window spanning all test fixtures)."""
+    return store.fetch_events_for_period(
+        agent_id,
+        datetime(2000, 1, 1, tzinfo=_UTC),
+        datetime(2100, 1, 1, tzinfo=_UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Events: round-trip + idempotency
+# ---------------------------------------------------------------------------
+def test_append_and_fetch_for_period_round_trip() -> None:
+    ev = _event(
+        "a",
+        kind=EventKind.OUTCOME,
+        content="shipped",
+        data={"pr": 42, "nested": {"ok": True}},
+        salience=0.7,
+    )
+    store.append_event("a", ev)
+
+    got = store.fetch_events_for_period("a", _DAY[0], _DAY[1])
+    assert len(got) == 1
+    row = got[0]
+    assert row.id == ev.id
+    assert row.kind is EventKind.OUTCOME
+    assert row.content == "shipped"
+    assert row.data == {"pr": 42, "nested": {"ok": True}}
+    assert row.salience == 0.7
+    assert row.occurred_at == _MID_DAY
+
+
+def test_fetch_events_for_period_is_half_open() -> None:
+    on_start = _event("a", occurred_at=_DAY[0])
+    on_end = _event("a", occurred_at=_DAY[1])
+    store.append_event("a", on_start)
+    store.append_event("a", on_end)
+
+    got = store.fetch_events_for_period("a", _DAY[0], _DAY[1])
+    # start is inclusive, end is exclusive
+    assert [e.id for e in got] == [on_start.id]
+
+
+def test_append_event_idempotent_on_writeback_key() -> None:
+    run_id = "run-1"
+    store.append_event("a", _event("a", run_id=run_id, seq=3, content="first"))
+    # Same (agent_id, source_run_id, source_seq), different content/id → no-op.
+    store.append_event("a", _event("a", run_id=run_id, seq=3, content="second"))
+
+    events = _all_events("a")
+    assert len(events) == 1
+    assert events[0].content == "first"
+
+
+def test_append_event_agent_id_mismatch_raises() -> None:
+    with pytest.raises(AssertionError):
+        store.append_event("a", _event("b"))
+
+
+# ---------------------------------------------------------------------------
+# fetch_recent_events ordering + limits
+# ---------------------------------------------------------------------------
+def test_fetch_recent_events_by_salience() -> None:
+    low = _event("a", run_id="r1", salience=0.1, occurred_at=_MID_DAY)
+    high = _event(
+        "a",
+        run_id="r2",
+        salience=0.9,
+        occurred_at=datetime(2026, 6, 1, 6, tzinfo=_UTC),
+    )
+    store.append_event("a", low)
+    store.append_event("a", high)
+
+    ordered = store.fetch_recent_events("a", top_n=10, by_salience=True)
+    assert [e.id for e in ordered] == [high.id, low.id]
+
+
+def test_fetch_recent_events_by_recency() -> None:
+    older = _event("a", run_id="r1", salience=0.9, occurred_at=datetime(2026, 6, 1, 6, tzinfo=_UTC))
+    newer = _event("a", run_id="r2", salience=0.1, occurred_at=_MID_DAY)
+    store.append_event("a", older)
+    store.append_event("a", newer)
+
+    ordered = store.fetch_recent_events("a", top_n=10, by_salience=False)
+    assert [e.id for e in ordered] == [newer.id, older.id]
+
+
+def test_fetch_recent_events_respects_top_n() -> None:
+    for i in range(5):
+        store.append_event("a", _event("a", run_id=f"r{i}", seq=i, salience=i / 10))
+    assert len(store.fetch_recent_events("a", top_n=2)) == 2
+
+
+def test_fetch_recent_events_top_n_zero_is_empty() -> None:
+    store.append_event("a", _event("a"))
+    assert store.fetch_recent_events("a", top_n=0) == []
+
+
+def test_fetch_recent_events_negative_top_n_raises() -> None:
+    with pytest.raises(AssertionError):
+        store.fetch_recent_events("a", top_n=-1)
+
+
+# ---------------------------------------------------------------------------
+# Summaries: upsert idempotency + reads
+# ---------------------------------------------------------------------------
+def test_upsert_summary_insert_then_update_idempotent() -> None:
+    s = _summary("a", source_count=3, summary="v1")
+    store.upsert_summary("a", s)
+
+    # Same (agent_id, scale, period_start) → update in place, not a new row.
+    updated = _summary("a", window=_DAY, source_count=9, version=2, stale=True, summary="v2")
+    store.upsert_summary("a", updated)
+
+    rows = store.fetch_summaries("a", Scale.DAY)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.summary == "v2"
+    assert row.source_count == 9
+    assert row.version == 2
+    assert row.stale is True
+    # id / created_at of the original row are preserved on update.
+    assert row.id == s.id
+    assert row.created_at == _CREATED
+
+
+def test_upsert_summary_agent_id_mismatch_raises() -> None:
+    with pytest.raises(AssertionError):
+        store.upsert_summary("a", _summary("b"))
+
+
+def test_fetch_summaries_filters_scale_and_paginates() -> None:
+    months = [
+        _summary(
+            "a",
+            scale=Scale.MONTH,
+            window=(datetime(2026, m, 1, tzinfo=_UTC), datetime(2026, m + 1, 1, tzinfo=_UTC)),
+        )
+        for m in (1, 2, 3)
+    ]
+    for m in months:
+        store.upsert_summary("a", m)
+    store.upsert_summary("a", _summary("a", scale=Scale.DAY))
+
+    month_rows = store.fetch_summaries("a", Scale.MONTH)
+    assert [r.period_start.month for r in month_rows] == [3, 2, 1]  # newest first
+    assert store.fetch_summaries("a", Scale.DAY) and len(month_rows) == 3
+
+    page = store.fetch_summaries("a", Scale.MONTH, limit=1, offset=1)
+    assert [r.period_start.month for r in page] == [2]
+
+
+def test_fetch_summaries_negative_offset_raises() -> None:
+    with pytest.raises(AssertionError):
+        store.fetch_summaries("a", Scale.DAY, offset=-1)
+
+
+def test_fetch_summaries_negative_limit_raises() -> None:
+    with pytest.raises(AssertionError):
+        store.fetch_summaries("a", Scale.DAY, limit=-1)
+
+
+def test_get_last_summary_returns_newest_or_none() -> None:
+    assert store.get_last_summary("a", Scale.DAY) is None
+
+    store.upsert_summary(
+        "a",
+        _summary(
+            "a", window=(datetime(2026, 6, 1, tzinfo=_UTC), datetime(2026, 6, 2, tzinfo=_UTC))
+        ),
+    )
+    store.upsert_summary(
+        "a",
+        _summary(
+            "a",
+            window=(datetime(2026, 6, 3, tzinfo=_UTC), datetime(2026, 6, 4, tzinfo=_UTC)),
+            summary="newest",
+        ),
+    )
+    last = store.get_last_summary("a", Scale.DAY)
+    assert last is not None
+    assert last.summary == "newest"
+
+
+# ---------------------------------------------------------------------------
+# mark_period_stale
+# ---------------------------------------------------------------------------
+def test_mark_period_stale_flags_containing_summaries_retained() -> None:
+    # Day summary reports 2 events; both are still present → retained.
+    store.upsert_summary("a", _summary("a", scale=Scale.DAY, window=_DAY, source_count=2))
+    store.upsert_summary("a", _summary("a", scale=Scale.WEEK, window=_WEEK))
+    store.upsert_summary("a", _summary("a", scale=Scale.MONTH, window=_MONTH))
+    store.append_event("a", _event("a", run_id="r1", seq=1, occurred_at=_MID_DAY))
+    store.append_event("a", _event("a", run_id="r2", seq=2, occurred_at=_MID_DAY))
+
+    retained = store.mark_period_stale("a", _MID_DAY)
+    assert retained is True
+
+    for scale in (Scale.DAY, Scale.WEEK, Scale.MONTH):
+        s = store.get_last_summary("a", scale)
+        assert s is not None and s.stale is True
+        assert s.version == 2  # bumped from 1
+
+
+def test_mark_period_stale_pruned_period_returns_false() -> None:
+    # Day summary claims 5 source events, but only the late one remains.
+    store.upsert_summary("a", _summary("a", scale=Scale.DAY, window=_DAY, source_count=5))
+    store.append_event("a", _event("a", occurred_at=_MID_DAY))
+
+    assert store.mark_period_stale("a", _MID_DAY) is False
+
+
+def test_mark_period_stale_no_summary_returns_true_and_flags_nothing() -> None:
+    store.append_event("a", _event("a", occurred_at=_MID_DAY))
+    assert store.mark_period_stale("a", _MID_DAY) is True
+    assert store.fetch_summaries("a", Scale.DAY) == []
+
+
+# ---------------------------------------------------------------------------
+# prune_events
+# ---------------------------------------------------------------------------
+def test_prune_events_deletes_only_summarized_nonstale_past_cutoff() -> None:
+    # A: old, day summary exists non-stale → deleted.
+    a = _event("a", run_id="a", occurred_at=_OLD)
+    store.upsert_summary("a", _summary("a", scale=Scale.DAY, window=_OLD_DAY, source_count=1))
+    # B: old, no day summary → kept.
+    b = _event("a", run_id="b", occurred_at=_OLD2)
+    # C: old, day summary is stale → kept.
+    c = _event("a", run_id="c", occurred_at=_OLD3)
+    store.upsert_summary(
+        "a", _summary("a", scale=Scale.DAY, window=_OLD3_DAY, source_count=1, stale=True)
+    )
+    # D: recent (newer than cutoff), summary exists → kept.
+    d = _event("a", run_id="d", occurred_at=_MID_DAY)
+    store.upsert_summary("a", _summary("a", scale=Scale.DAY, window=_DAY, source_count=1))
+    for ev in (a, b, c, d):
+        store.append_event("a", ev)
+
+    deleted = store.prune_events("a", retention_days=30)
+    assert deleted == 1
+    remaining = {e.id for e in _all_events("a")}
+    assert remaining == {b.id, c.id, d.id}
+
+
+def test_prune_events_negative_retention_raises() -> None:
+    with pytest.raises(AssertionError):
+        store.prune_events("a", retention_days=-1)
+
+
+# ---------------------------------------------------------------------------
+# Cross-agent isolation
+# ---------------------------------------------------------------------------
+def test_cross_agent_isolation() -> None:
+    a_ev = _event("a", run_id="shared", seq=1, occurred_at=_MID_DAY)
+    b_ev = _event("b", run_id="shared", seq=1, occurred_at=_OLD)
+    store.append_event("a", a_ev)
+    store.append_event("b", b_ev)
+    store.upsert_summary("a", _summary("a", scale=Scale.DAY, window=_DAY))
+    store.upsert_summary("b", _summary("b", scale=Scale.DAY, window=_OLD_DAY, source_count=1))
+
+    # Readers never cross agents.
+    assert [e.id for e in _all_events("a")] == [a_ev.id]
+    assert [e.id for e in store.fetch_recent_events("a", top_n=10)] == [a_ev.id]
+    assert [s.agent_id for s in store.fetch_summaries("a", Scale.DAY)] == ["a"]
+
+    # Marking a's period stale leaves b's summary untouched.
+    store.mark_period_stale("a", _MID_DAY)
+    b_summary = store.get_last_summary("b", Scale.DAY)
+    assert b_summary is not None and b_summary.stale is False and b_summary.version == 1
+
+    # Pruning a does not touch b's (prunable) old event.
+    store.prune_events("a", retention_days=30)
+    assert [e.id for e in _all_events("b")] == [b_ev.id]
+
+
+# ---------------------------------------------------------------------------
+# Storage-unavailable guard
+# ---------------------------------------------------------------------------
+def test_storage_unavailable_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(store, "is_postgres_enabled", lambda: False)
+    with pytest.raises(store.AgentCognitionStorageUnavailable):
+        store.fetch_recent_events("a", top_n=5)

--- a/backend/agents/agent_cognition/tests/test_store.py
+++ b/backend/agents/agent_cognition/tests/test_store.py
@@ -42,6 +42,14 @@ _WEEK = (datetime(2026, 6, 1, tzinfo=_UTC), datetime(2026, 6, 8, tzinfo=_UTC))
 _MONTH = (datetime(2026, 6, 1, tzinfo=_UTC), datetime(2026, 7, 1, tzinfo=_UTC))
 _CREATED = datetime(2026, 6, 2, tzinfo=_UTC)
 
+# Rollup snapshot times for prune tests. Events are appended in real time, so
+# their store-set ``recorded_at`` is ~now (2026). _FOLDED_AT (far future) marks
+# a summary computed *after* those events arrived (they count as folded, so
+# prunable); _PRECOMPUTED_AT (far past) marks a summary computed *before* the
+# events arrived (not yet folded, so prune must leave them).
+_FOLDED_AT = datetime(2099, 1, 1, tzinfo=_UTC)
+_PRECOMPUTED_AT = datetime(2000, 1, 1, tzinfo=_UTC)
+
 # Far-past windows for prune tests (always older than any sane cutoff).
 _OLD = datetime(2020, 1, 1, 12, 0, tzinfo=_UTC)
 _OLD_DAY = (datetime(2020, 1, 1, tzinfo=_UTC), datetime(2020, 1, 2, tzinfo=_UTC))
@@ -340,9 +348,12 @@ def test_mark_period_stale_pruned_period_returns_false() -> None:
     # A real prune latches events_pruned on the day summary; a later late event
     # into that (now event-less) day must amend, not recompute. The regime is
     # read from the durable flag, so it is correct regardless of whether the
-    # late event has been appended.
-    store.upsert_summary("a", _summary("a", scale=Scale.DAY, window=_OLD_DAY, source_count=1))
+    # late event has been appended. computed_at=_FOLDED_AT marks the original
+    # event as folded so prune is allowed to delete it.
     store.append_event("a", _event("a", occurred_at=_OLD))
+    store.upsert_summary(
+        "a", _summary("a", scale=Scale.DAY, window=_OLD_DAY, source_count=1), computed_at=_FOLDED_AT
+    )
     assert store.prune_events("a", retention_days=30) == 1
 
     assert store.mark_period_stale("a", _OLD) is False
@@ -358,26 +369,50 @@ def test_mark_period_stale_no_summary_returns_true_and_flags_nothing() -> None:
 # prune_events
 # ---------------------------------------------------------------------------
 def test_prune_events_deletes_only_summarized_nonstale_past_cutoff() -> None:
-    # A: old, day summary exists non-stale → deleted.
-    a = _event("a", run_id="a", occurred_at=_OLD)
-    store.upsert_summary("a", _summary("a", scale=Scale.DAY, window=_OLD_DAY, source_count=1))
-    # B: old, no day summary → kept.
-    b = _event("a", run_id="b", occurred_at=_OLD2)
-    # C: old, day summary is stale → kept.
-    c = _event("a", run_id="c", occurred_at=_OLD3)
-    store.upsert_summary(
-        "a", _summary("a", scale=Scale.DAY, window=_OLD3_DAY, source_count=1, stale=True)
-    )
-    # D: recent (newer than cutoff), summary exists → kept.
-    d = _event("a", run_id="d", occurred_at=_MID_DAY)
-    store.upsert_summary("a", _summary("a", scale=Scale.DAY, window=_DAY, source_count=1))
+    # Append all events first, then compute their day summaries (computed_at in
+    # the future ⇒ every event is folded), so prune is purely gated on the
+    # summary state below.
+    a = _event("a", run_id="a", occurred_at=_OLD)  # day summary non-stale → deleted
+    b = _event("a", run_id="b", occurred_at=_OLD2)  # no day summary → kept
+    c = _event("a", run_id="c", occurred_at=_OLD3)  # day summary stale → kept
+    d = _event("a", run_id="d", occurred_at=_MID_DAY)  # newer than cutoff → kept
     for ev in (a, b, c, d):
         store.append_event("a", ev)
+    store.upsert_summary(
+        "a", _summary("a", scale=Scale.DAY, window=_OLD_DAY, source_count=1), computed_at=_FOLDED_AT
+    )
+    store.upsert_summary(
+        "a",
+        _summary("a", scale=Scale.DAY, window=_OLD3_DAY, source_count=1, stale=True),
+        computed_at=_FOLDED_AT,
+    )
+    store.upsert_summary(
+        "a", _summary("a", scale=Scale.DAY, window=_DAY, source_count=1), computed_at=_FOLDED_AT
+    )
 
     deleted = store.prune_events("a", retention_days=30)
     assert deleted == 1
     remaining = {e.id for e in _all_events("a")}
     assert remaining == {b.id, c.id, d.id}
+
+
+def test_prune_skips_late_event_not_yet_folded() -> None:
+    # Race guard: the day summary was computed BEFORE the late event arrived
+    # (computed_at < recorded_at), so the event isn't folded yet. Even though it
+    # is old and the day summary is non-stale, prune must leave it — otherwise
+    # it would be lost before the rollup could amend it in.
+    store.upsert_summary(
+        "a",
+        _summary("a", scale=Scale.DAY, window=_OLD_DAY, source_count=1),
+        computed_at=_PRECOMPUTED_AT,
+    )
+    late = _event("a", occurred_at=_OLD)  # recorded_at = now ≫ _PRECOMPUTED_AT
+    store.append_event("a", late)
+
+    assert store.prune_events("a", retention_days=30) == 0
+    assert [e.id for e in _all_events("a")] == [late.id]
+    # …and the regime stays "retained" since nothing was actually pruned.
+    assert store.mark_period_stale("a", _OLD) is True
 
 
 def test_prune_events_negative_retention_raises() -> None:

--- a/backend/agents/agent_cognition/tests/test_store.py
+++ b/backend/agents/agent_cognition/tests/test_store.py
@@ -412,6 +412,39 @@ def test_prune_events_deletes_only_summarized_nonstale_past_cutoff() -> None:
     assert remaining == {b.id, c.id, d.id}
 
 
+def test_pruned_regime_visible_on_summary_reads() -> None:
+    # After a prune latches events_pruned, a reader that rediscovers the stale
+    # summary (e.g. the rollup after a restart) must see the regime on the row
+    # itself — not only via mark_period_stale's return.
+    store.append_event("a", _event("a", occurred_at=_OLD))
+    _upsert("a", _summary("a", scale=Scale.DAY, window=_OLD_DAY, source_count=1))
+    assert store.prune_events("a", retention_days=30) == 1
+
+    last = store.get_last_summary("a", Scale.DAY)
+    assert last is not None and last.events_pruned is True
+    assert store.fetch_summaries("a", Scale.DAY)[0].events_pruned is True
+
+    # A non-pruned summary reads back events_pruned == False.
+    _upsert("b", _summary("b", scale=Scale.DAY, window=_DAY))
+    assert store.get_last_summary("b", Scale.DAY).events_pruned is False
+
+
+def test_fetch_events_for_period_snapshot_bound() -> None:
+    # The snapshot bound excludes events recorded after the rollup's read time,
+    # keeping the fold-input read consistent with the prune recorded/computed
+    # comparison.
+    ev = _event("a", occurred_at=_MID_DAY)
+    store.append_event("a", ev)
+
+    # Snapshot before the append → event excluded.
+    assert store.fetch_events_for_period("a", _DAY[0], _DAY[1], snapshot=_PRECOMPUTED_AT) == []
+    # Snapshot after the append → event included.
+    got = store.fetch_events_for_period("a", _DAY[0], _DAY[1], snapshot=_FOLDED_AT)
+    assert [e.id for e in got] == [ev.id]
+    # No snapshot → plain window read still returns it.
+    assert [e.id for e in store.fetch_events_for_period("a", _DAY[0], _DAY[1])] == [ev.id]
+
+
 def test_prune_skips_late_event_not_yet_folded() -> None:
     # Race guard: the day summary was computed BEFORE the late event arrived
     # (computed_at < recorded_at), so the event isn't folded yet. Even though it

--- a/backend/agents/agent_cognition/tests/test_store.py
+++ b/backend/agents/agent_cognition/tests/test_store.py
@@ -230,6 +230,18 @@ def test_upsert_summary_insert_then_update_idempotent() -> None:
     assert row.created_at == _CREATED
 
 
+def test_upsert_summary_does_not_regress_version() -> None:
+    # mark_period_stale (or a prior recompute) can leave version ahead of a
+    # freshly-built summary; the GREATEST guard keeps the higher stored value.
+    store.upsert_summary("a", _summary("a", window=_DAY, version=5, summary="v1"))
+    store.upsert_summary("a", _summary("a", window=_DAY, version=1, summary="v2"))
+
+    row = store.get_last_summary("a", Scale.DAY)
+    assert row is not None
+    assert row.summary == "v2"
+    assert row.version == 5  # not regressed to 1
+
+
 def test_upsert_summary_agent_id_mismatch_raises() -> None:
     with pytest.raises(AssertionError):
         store.upsert_summary("a", _summary("b"))
@@ -292,17 +304,12 @@ def test_get_last_summary_returns_newest_or_none() -> None:
 # mark_period_stale
 # ---------------------------------------------------------------------------
 def test_mark_period_stale_flags_containing_summaries_retained() -> None:
-    # Day summary folded 2 events and both originals are still present.
-    # mark_period_stale is called *before* the late event is appended, so the
-    # retained-count reflects the surviving originals only.
-    store.upsert_summary("a", _summary("a", scale=Scale.DAY, window=_DAY, source_count=2))
+    # Day/week/month summaries exist and the day was never pruned → retained.
+    store.upsert_summary("a", _summary("a", scale=Scale.DAY, window=_DAY))
     store.upsert_summary("a", _summary("a", scale=Scale.WEEK, window=_WEEK))
     store.upsert_summary("a", _summary("a", scale=Scale.MONTH, window=_MONTH))
-    store.append_event("a", _event("a", run_id="r1", seq=1, occurred_at=_MID_DAY))
-    store.append_event("a", _event("a", run_id="r2", seq=2, occurred_at=_MID_DAY))
 
-    retained = store.mark_period_stale("a", _MID_DAY)
-    assert retained is True
+    assert store.mark_period_stale("a", _MID_DAY) is True
 
     for scale in (Scale.DAY, Scale.WEEK, Scale.MONTH):
         s = store.get_last_summary("a", scale)
@@ -310,16 +317,31 @@ def test_mark_period_stale_flags_containing_summaries_retained() -> None:
         assert s.version == 2  # bumped from 1
 
 
-def test_mark_period_stale_pruned_period_returns_false() -> None:
-    # Regression guard for the late-event-inflation bug: a partially-pruned
-    # day folded 2 events, one was pruned, one original survives. The mark
-    # runs before the late event is appended, so the count is 1 < 2 → pruned.
-    # (Had we counted the in-flight late event, the count would be 2 == 2 and
-    # this would wrongly report the period as retained.)
-    store.upsert_summary("a", _summary("a", scale=Scale.DAY, window=_DAY, source_count=2))
-    store.append_event("a", _event("a", run_id="survivor", occurred_at=_MID_DAY))
+def test_mark_period_stale_is_idempotent_on_version() -> None:
+    # The non-stale → stale latch means a second late event into the same
+    # already-stale period must not re-bump version (which would spuriously
+    # move the (summary_id, version) evidence refs).
+    store.upsert_summary("a", _summary("a", scale=Scale.DAY, window=_DAY))
 
-    assert store.mark_period_stale("a", _MID_DAY) is False
+    assert store.mark_period_stale("a", _MID_DAY) is True
+    first = store.get_last_summary("a", Scale.DAY)
+    assert first is not None and first.stale is True and first.version == 2
+
+    assert store.mark_period_stale("a", _MID_DAY) is True
+    second = store.get_last_summary("a", Scale.DAY)
+    assert second is not None and second.version == 2  # not bumped again
+
+
+def test_mark_period_stale_pruned_period_returns_false() -> None:
+    # A real prune latches events_pruned on the day summary; a later late event
+    # into that (now event-less) day must amend, not recompute. The regime is
+    # read from the durable flag, so it is correct regardless of whether the
+    # late event has been appended.
+    store.upsert_summary("a", _summary("a", scale=Scale.DAY, window=_OLD_DAY, source_count=1))
+    store.append_event("a", _event("a", occurred_at=_OLD))
+    assert store.prune_events("a", retention_days=30) == 1
+
+    assert store.mark_period_stale("a", _OLD) is False
 
 
 def test_mark_period_stale_no_summary_returns_true_and_flags_nothing() -> None:
@@ -386,9 +408,41 @@ def test_cross_agent_isolation() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Preconditions
+# ---------------------------------------------------------------------------
+def test_empty_agent_id_raises() -> None:
+    with pytest.raises(AssertionError):
+        store.append_event("", _event("", run_id="r"))
+    with pytest.raises(AssertionError):
+        store.fetch_events_for_period("", _DAY[0], _DAY[1])
+    with pytest.raises(AssertionError):
+        store.fetch_recent_events("", top_n=5)
+    with pytest.raises(AssertionError):
+        store.upsert_summary("", _summary(""))
+    with pytest.raises(AssertionError):
+        store.fetch_summaries("", Scale.DAY)
+    with pytest.raises(AssertionError):
+        store.get_last_summary("", Scale.DAY)
+    with pytest.raises(AssertionError):
+        store.mark_period_stale("", _MID_DAY)
+    with pytest.raises(AssertionError):
+        store.prune_events("", retention_days=30)
+
+
+# ---------------------------------------------------------------------------
 # Storage-unavailable guard
 # ---------------------------------------------------------------------------
 def test_storage_unavailable_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(store, "is_postgres_enabled", lambda: False)
     with pytest.raises(store.AgentCognitionStorageUnavailable):
         store.fetch_recent_events("a", top_n=5)
+
+
+def test_conn_propagates_body_errors_unwrapped() -> None:
+    # An error raised inside the connection body must propagate unchanged
+    # (and roll back) — it must NOT be masked as a storage-unavailable error,
+    # which would hide genuine query bugs as infra outages.
+    with pytest.raises(ValueError):
+        with store._conn() as conn:
+            assert conn is not None
+            raise ValueError("boom")

--- a/backend/agents/agent_cognition/tests/test_store.py
+++ b/backend/agents/agent_cognition/tests/test_store.py
@@ -292,7 +292,9 @@ def test_get_last_summary_returns_newest_or_none() -> None:
 # mark_period_stale
 # ---------------------------------------------------------------------------
 def test_mark_period_stale_flags_containing_summaries_retained() -> None:
-    # Day summary reports 2 events; both are still present → retained.
+    # Day summary folded 2 events and both originals are still present.
+    # mark_period_stale is called *before* the late event is appended, so the
+    # retained-count reflects the surviving originals only.
     store.upsert_summary("a", _summary("a", scale=Scale.DAY, window=_DAY, source_count=2))
     store.upsert_summary("a", _summary("a", scale=Scale.WEEK, window=_WEEK))
     store.upsert_summary("a", _summary("a", scale=Scale.MONTH, window=_MONTH))
@@ -309,15 +311,19 @@ def test_mark_period_stale_flags_containing_summaries_retained() -> None:
 
 
 def test_mark_period_stale_pruned_period_returns_false() -> None:
-    # Day summary claims 5 source events, but only the late one remains.
-    store.upsert_summary("a", _summary("a", scale=Scale.DAY, window=_DAY, source_count=5))
-    store.append_event("a", _event("a", occurred_at=_MID_DAY))
+    # Regression guard for the late-event-inflation bug: a partially-pruned
+    # day folded 2 events, one was pruned, one original survives. The mark
+    # runs before the late event is appended, so the count is 1 < 2 → pruned.
+    # (Had we counted the in-flight late event, the count would be 2 == 2 and
+    # this would wrongly report the period as retained.)
+    store.upsert_summary("a", _summary("a", scale=Scale.DAY, window=_DAY, source_count=2))
+    store.append_event("a", _event("a", run_id="survivor", occurred_at=_MID_DAY))
 
     assert store.mark_period_stale("a", _MID_DAY) is False
 
 
 def test_mark_period_stale_no_summary_returns_true_and_flags_nothing() -> None:
-    store.append_event("a", _event("a", occurred_at=_MID_DAY))
+    # No summary covers the timestamp → never summarized → trivially retained.
     assert store.mark_period_stale("a", _MID_DAY) is True
     assert store.fetch_summaries("a", Scale.DAY) == []
 

--- a/backend/agents/agent_cognition/tests/test_store.py
+++ b/backend/agents/agent_cognition/tests/test_store.py
@@ -120,6 +120,15 @@ def _all_events(agent_id: str) -> list[MemoryEvent]:
     )
 
 
+def _upsert(agent_id: str, summary: PeriodSummary, *, computed_at: datetime = _FOLDED_AT) -> None:
+    """upsert_summary with a required computed_at, defaulting to "folded".
+
+    Most tests don't prune, so the default _FOLDED_AT (a snapshot after every
+    real append) marks events as folded; prune tests pass an explicit snapshot.
+    """
+    store.upsert_summary(agent_id, summary, computed_at=computed_at)
+
+
 # ---------------------------------------------------------------------------
 # Events: round-trip + idempotency
 # ---------------------------------------------------------------------------
@@ -220,11 +229,11 @@ def test_fetch_recent_events_negative_top_n_raises() -> None:
 # ---------------------------------------------------------------------------
 def test_upsert_summary_insert_then_update_idempotent() -> None:
     s = _summary("a", source_count=3, summary="v1")
-    store.upsert_summary("a", s)
+    _upsert("a", s)
 
     # Same (agent_id, scale, period_start) → update in place, not a new row.
     updated = _summary("a", window=_DAY, source_count=9, version=2, stale=True, summary="v2")
-    store.upsert_summary("a", updated)
+    _upsert("a", updated)
 
     rows = store.fetch_summaries("a", Scale.DAY)
     assert len(rows) == 1
@@ -241,8 +250,8 @@ def test_upsert_summary_insert_then_update_idempotent() -> None:
 def test_upsert_summary_does_not_regress_version() -> None:
     # mark_period_stale (or a prior recompute) can leave version ahead of a
     # freshly-built summary; the GREATEST guard keeps the higher stored value.
-    store.upsert_summary("a", _summary("a", window=_DAY, version=5, summary="v1"))
-    store.upsert_summary("a", _summary("a", window=_DAY, version=1, summary="v2"))
+    _upsert("a", _summary("a", window=_DAY, version=5, summary="v1"))
+    _upsert("a", _summary("a", window=_DAY, version=1, summary="v2"))
 
     row = store.get_last_summary("a", Scale.DAY)
     assert row is not None
@@ -252,7 +261,14 @@ def test_upsert_summary_does_not_regress_version() -> None:
 
 def test_upsert_summary_agent_id_mismatch_raises() -> None:
     with pytest.raises(AssertionError):
-        store.upsert_summary("a", _summary("b"))
+        _upsert("a", _summary("b"))
+
+
+def test_upsert_summary_requires_computed_at() -> None:
+    # computed_at is a required keyword arg (the rollup's input-read snapshot),
+    # so the unsafe "default to write time" footgun can't happen.
+    with pytest.raises(TypeError):
+        store.upsert_summary("a", _summary("a"))
 
 
 def test_fetch_summaries_filters_scale_and_paginates() -> None:
@@ -265,8 +281,8 @@ def test_fetch_summaries_filters_scale_and_paginates() -> None:
         for m in (1, 2, 3)
     ]
     for m in months:
-        store.upsert_summary("a", m)
-    store.upsert_summary("a", _summary("a", scale=Scale.DAY))
+        _upsert("a", m)
+    _upsert("a", _summary("a", scale=Scale.DAY))
 
     month_rows = store.fetch_summaries("a", Scale.MONTH)
     assert [r.period_start.month for r in month_rows] == [3, 2, 1]  # newest first
@@ -293,13 +309,13 @@ def test_fetch_summaries_negative_limit_raises() -> None:
 def test_get_last_summary_returns_newest_or_none() -> None:
     assert store.get_last_summary("a", Scale.DAY) is None
 
-    store.upsert_summary(
+    _upsert(
         "a",
         _summary(
             "a", window=(datetime(2026, 6, 1, tzinfo=_UTC), datetime(2026, 6, 2, tzinfo=_UTC))
         ),
     )
-    store.upsert_summary(
+    _upsert(
         "a",
         _summary(
             "a",
@@ -317,9 +333,9 @@ def test_get_last_summary_returns_newest_or_none() -> None:
 # ---------------------------------------------------------------------------
 def test_mark_period_stale_flags_containing_summaries_retained() -> None:
     # Day/week/month summaries exist and the day was never pruned → retained.
-    store.upsert_summary("a", _summary("a", scale=Scale.DAY, window=_DAY))
-    store.upsert_summary("a", _summary("a", scale=Scale.WEEK, window=_WEEK))
-    store.upsert_summary("a", _summary("a", scale=Scale.MONTH, window=_MONTH))
+    _upsert("a", _summary("a", scale=Scale.DAY, window=_DAY))
+    _upsert("a", _summary("a", scale=Scale.WEEK, window=_WEEK))
+    _upsert("a", _summary("a", scale=Scale.MONTH, window=_MONTH))
 
     assert store.mark_period_stale("a", _MID_DAY) is True
 
@@ -333,7 +349,7 @@ def test_mark_period_stale_is_idempotent_on_version() -> None:
     # The non-stale → stale latch means a second late event into the same
     # already-stale period must not re-bump version (which would spuriously
     # move the (summary_id, version) evidence refs).
-    store.upsert_summary("a", _summary("a", scale=Scale.DAY, window=_DAY))
+    _upsert("a", _summary("a", scale=Scale.DAY, window=_DAY))
 
     assert store.mark_period_stale("a", _MID_DAY) is True
     first = store.get_last_summary("a", Scale.DAY)
@@ -351,7 +367,7 @@ def test_mark_period_stale_pruned_period_returns_false() -> None:
     # late event has been appended. computed_at=_FOLDED_AT marks the original
     # event as folded so prune is allowed to delete it.
     store.append_event("a", _event("a", occurred_at=_OLD))
-    store.upsert_summary(
+    _upsert(
         "a", _summary("a", scale=Scale.DAY, window=_OLD_DAY, source_count=1), computed_at=_FOLDED_AT
     )
     assert store.prune_events("a", retention_days=30) == 1
@@ -378,15 +394,15 @@ def test_prune_events_deletes_only_summarized_nonstale_past_cutoff() -> None:
     d = _event("a", run_id="d", occurred_at=_MID_DAY)  # newer than cutoff → kept
     for ev in (a, b, c, d):
         store.append_event("a", ev)
-    store.upsert_summary(
+    _upsert(
         "a", _summary("a", scale=Scale.DAY, window=_OLD_DAY, source_count=1), computed_at=_FOLDED_AT
     )
-    store.upsert_summary(
+    _upsert(
         "a",
         _summary("a", scale=Scale.DAY, window=_OLD3_DAY, source_count=1, stale=True),
         computed_at=_FOLDED_AT,
     )
-    store.upsert_summary(
+    _upsert(
         "a", _summary("a", scale=Scale.DAY, window=_DAY, source_count=1), computed_at=_FOLDED_AT
     )
 
@@ -401,7 +417,7 @@ def test_prune_skips_late_event_not_yet_folded() -> None:
     # (computed_at < recorded_at), so the event isn't folded yet. Even though it
     # is old and the day summary is non-stale, prune must leave it — otherwise
     # it would be lost before the rollup could amend it in.
-    store.upsert_summary(
+    _upsert(
         "a",
         _summary("a", scale=Scale.DAY, window=_OLD_DAY, source_count=1),
         computed_at=_PRECOMPUTED_AT,
@@ -428,8 +444,8 @@ def test_cross_agent_isolation() -> None:
     b_ev = _event("b", run_id="shared", seq=1, occurred_at=_OLD)
     store.append_event("a", a_ev)
     store.append_event("b", b_ev)
-    store.upsert_summary("a", _summary("a", scale=Scale.DAY, window=_DAY))
-    store.upsert_summary("b", _summary("b", scale=Scale.DAY, window=_OLD_DAY, source_count=1))
+    _upsert("a", _summary("a", scale=Scale.DAY, window=_DAY))
+    _upsert("b", _summary("b", scale=Scale.DAY, window=_OLD_DAY, source_count=1))
 
     # Readers never cross agents.
     assert [e.id for e in _all_events("a")] == [a_ev.id]
@@ -457,7 +473,7 @@ def test_empty_agent_id_raises() -> None:
     with pytest.raises(AssertionError):
         store.fetch_recent_events("", top_n=5)
     with pytest.raises(AssertionError):
-        store.upsert_summary("", _summary(""))
+        _upsert("", _summary(""))
     with pytest.raises(AssertionError):
         store.fetch_summaries("", Scale.DAY)
     with pytest.raises(AssertionError):


### PR DESCRIPTION
## Summary

Step 2 of the Agent Cognition Core epic: the Postgres data-access layer that reads/writes episodic memory events and calendar-scoped rollups, built on the schema landed in Step 1.

New `backend/agents/agent_cognition/memory/` subpackage with `store.py` exposing **module-level functions** (the rollup engine, retrieval builder, and invoke facade call these directly). Every statement is filtered by `agent_id`; no query reads or writes another agent's rows.

### Functions
- **`append_event`** — idempotent insert on `(agent_id, source_run_id, source_seq)`.
- **`fetch_events_for_period`** — half-open `[start, end)`, ordered, with an optional `snapshot` bound (`recorded_at <= snapshot`) for consistent rollup fold-reads.
- **`fetch_recent_events(top_n, by_salience)`** — salience/recency ordering with a deterministic `id` tiebreaker.
- **`upsert_summary`** — idempotent on `(agent_id, scale, period_start)`, with a required `computed_at` read-snapshot; see the concurrency guards below.
- **`fetch_summaries` / `get_last_summary`** — surface the durable `events_pruned` regime so a reader can tell amend from recompute.
- **`mark_period_stale`** — flags containing summaries stale (idempotent `version` bump on the non-stale→stale transition), records `stale_since`, returns the durable retained/pruned regime.
- **`prune_events`** — lossless retention prune: deletes only events folded into a non-stale day summary (`recorded_at <= computed_at`), latching `events_pruned`.

### Concurrency model (store-enforced)
Four store-managed columns keep retention and rollup writes safe under concurrent late arrivals, pruning, and out-of-order rollups:
- `events.recorded_at` — append time; prune deletes only already-folded events.
- `summaries.computed_at` — required rollup read-snapshot; prune guard + monotonic write gate (`ON CONFLICT … WHERE EXCLUDED.computed_at >= stored.computed_at`), so a staler rollup can't overwrite a fresher summary.
- `summaries.events_pruned` — durable recompute-vs-amend regime, surfaced on reads, never cleared by `upsert_summary`.
- `summaries.stale_since` — preserves a `stale` flag raised after a rollup's read snapshot, so a slow rollup can't clobber it.
- `version` is monotonic via `GREATEST`.

### Scope / deferred to Step 3
The store now enforces the full set of single-statement concurrency guards a future rollup engine and scheduler-pruner will rely on. The **end-to-end concurrency contract** — how the rollup engine (Step 3, #733) and the central scheduler/pruner (Step 11) actually orchestrate snapshots, amends, and recompute ordering — is finalized alongside those components, where it can be designed and tested against real concurrent callers rather than simulated interleavings. The guards here are the durable substrate they build on.

## Testing
- `tests/test_store.py` — live-Postgres tests (mirrors the `agent_console` pattern): round-trip, writeback idempotency, ordering, upsert idempotency + version monotonicity, pagination (incl. offset-without-limit), the durable pruned regime on reads, snapshot-bounded reads, the prune→amend regime, the prune-before-mark race, the concurrent-stale-preservation race, the out-of-order-rollup race, cross-`agent_id` isolation, and storage-unavailable / body-error propagation.
- `pytest agent_cognition/tests/ --cov=agent_cognition --cov-fail-under=90` → **56 passed**; `store.py` **100%**, package **99.8%**.
- `ruff check` + `ruff format --check` clean. CI: ruff lint and the live-Postgres integration job pass.

Closes #730