### PR TITLE
Load all open GitHub issues in the coding-team panel

### DIFF
--- a/backend/unified_api/routes/integrations.py
+++ b/backend/unified_api/routes/integrations.py
@@ -882,6 +882,12 @@ async def medium_clear_session() -> MediumConfigResponse:
 
 _GITHUB_SERVICE = "github"
 _GITHUB_API_BASE = "https://api.github.com"
+# GitHub's issues endpoint returns at most 100 items per page; we request the max
+# and follow the Link header so the panel shows every open issue, not just page one.
+_GITHUB_ISSUES_PER_PAGE = 100
+# Safety bound against a pathological repo or a redirect loop in the Link header.
+# 100 issues/page * 50 pages = 5000 open issues, far beyond any realistic repo.
+_GITHUB_MAX_ISSUE_PAGES = 50
 
 
 class GitHubConfigResponse(BaseModel):
@@ -961,7 +967,20 @@ async def delete_github() -> GitHubConfigResponse:
 
 @router.get("/github/issues", response_model=list[GitHubIssueItem])
 async def list_github_issues(label: str | None = Query(default=None)) -> list[GitHubIssueItem]:
-    """List open issues from the configured GitHub repository."""
+    """List every open issue from the configured GitHub repository.
+
+    Follows GitHub's ``Link``-header pagination so the panel shows the complete set
+    of open issues rather than only the first page.
+
+    Preconditions:
+        - The GitHub integration is enabled and a PAT, owner and repo are configured;
+          each missing prerequisite raises ``HTTPException(400)``.
+    Postconditions:
+        - Returns every open issue (pull requests excluded) across all result pages,
+          in GitHub's response order, bounded by ``_GITHUB_MAX_ISSUE_PAGES`` pages of
+          ``_GITHUB_ISSUES_PER_PAGE`` items. Hitting that bound logs a warning and
+          returns the issues gathered so far rather than failing.
+    """
     cfg = get_github_config()
     if not cfg["enabled"]:
         raise HTTPException(status_code=400, detail="GitHub integration is not enabled.")
@@ -973,7 +992,7 @@ async def list_github_issues(label: str | None = Query(default=None)) -> list[Gi
     if not owner or not repo:
         raise HTTPException(status_code=400, detail="GitHub owner/repo not configured.")
 
-    params: dict[str, Any] = {"state": "open", "per_page": 30}
+    params: dict[str, Any] = {"state": "open", "per_page": _GITHUB_ISSUES_PER_PAGE}
     use_label = label or cfg["default_label"]
     if use_label:
         params["labels"] = use_label
@@ -985,34 +1004,50 @@ async def list_github_issues(label: str | None = Query(default=None)) -> list[Gi
         "User-Agent": "khala-integrations",
     }
 
-    async with httpx.AsyncClient(timeout=15.0) as client:
-        resp = await client.get(
-            f"{_GITHUB_API_BASE}/repos/{owner}/{repo}/issues",
-            headers=headers,
-            params=params,
-        )
-
-    if resp.status_code == 401:
-        raise HTTPException(status_code=401, detail="GitHub token is invalid or expired.")
-    if resp.status_code == 404:
-        raise HTTPException(status_code=404, detail=f"Repository {owner}/{repo} not found.")
-    if resp.status_code != 200:
-        raise HTTPException(status_code=502, detail=f"GitHub API returned {resp.status_code}.")
-
     items: list[GitHubIssueItem] = []
-    for raw in resp.json():
-        if "pull_request" in raw:
-            continue
-        body = (raw.get("body") or "")[:200]
-        labels = [lbl["name"] for lbl in (raw.get("labels") or []) if isinstance(lbl, dict) and lbl.get("name")]
-        items.append(
-            GitHubIssueItem(
-                number=raw["number"],
-                title=raw.get("title") or "",
-                body_preview=body,
-                labels=labels,
-                html_url=raw.get("html_url") or "",
-            )
+    next_url: str | None = f"{_GITHUB_API_BASE}/repos/{owner}/{repo}/issues"
+    # Query params ride only on the first request; GitHub's "next" Link URL already
+    # carries state/per_page/labels forward, so we must not re-append them.
+    request_params: dict[str, Any] | None = params
+    pages = 0
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        while next_url and pages < _GITHUB_MAX_ISSUE_PAGES:
+            resp = await client.get(next_url, headers=headers, params=request_params)
+
+            if resp.status_code == 401:
+                raise HTTPException(status_code=401, detail="GitHub token is invalid or expired.")
+            if resp.status_code == 404:
+                raise HTTPException(status_code=404, detail=f"Repository {owner}/{repo} not found.")
+            if resp.status_code != 200:
+                raise HTTPException(status_code=502, detail=f"GitHub API returned {resp.status_code}.")
+
+            for raw in resp.json():
+                if "pull_request" in raw:
+                    continue
+                body = (raw.get("body") or "")[:200]
+                labels = [lbl["name"] for lbl in (raw.get("labels") or []) if isinstance(lbl, dict) and lbl.get("name")]
+                items.append(
+                    GitHubIssueItem(
+                        number=raw["number"],
+                        title=raw.get("title") or "",
+                        body_preview=body,
+                        labels=labels,
+                        html_url=raw.get("html_url") or "",
+                    )
+                )
+
+            pages += 1
+            next_url = resp.links.get("next", {}).get("url")
+            request_params = None  # subsequent pages use the Link URL verbatim
+
+    if next_url:
+        logger.warning(
+            "list_github_issues hit the %d-page cap for %s/%s; returning the first %d open issues only",
+            _GITHUB_MAX_ISSUE_PAGES,
+            owner,
+            repo,
+            len(items),
         )
     return items
 

--- a/backend/unified_api/tests/test_integrations_github_issues_route.py
+++ b/backend/unified_api/tests/test_integrations_github_issues_route.py
@@ -1,0 +1,271 @@
+"""Tests for the GitHub issue-listing route: GET /api/integrations/github/issues.
+
+The coding-team page loads the repository's open issues into a picker panel. The
+route previously requested a single page of ``per_page=30`` and never followed
+GitHub's ``Link``-header pagination, so a repo with more than 30 open issues had
+its list silently truncated. These tests pin the corrected behaviour: every open
+issue is returned across all result pages, pull requests are excluded, and a
+safety page-cap is enforced.
+"""
+
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+_backend = Path(__file__).resolve().parent.parent.parent
+if str(_backend) not in sys.path:
+    sys.path.insert(0, str(_backend))
+_agents = _backend / "agents"
+if str(_agents) not in sys.path:
+    sys.path.insert(0, str(_agents))
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from unified_api.main import app  # noqa: E402
+from unified_api.routes import integrations  # noqa: E402
+
+client = TestClient(app, follow_redirects=False)
+
+_M = "unified_api.routes.integrations"
+_ISSUES = "/api/integrations/github/issues"
+
+_GH_CFG = {"enabled": True, "owner": "acme", "repo": "widget", "default_label": ""}
+
+
+# ---------------------------------------------------------------------------
+# Test doubles for the async httpx client used to reach the GitHub REST API
+# ---------------------------------------------------------------------------
+
+
+class _FakeIssuesResp:
+    """Minimal stand-in for an httpx.Response from GET /repos/.../issues."""
+
+    def __init__(self, status_code=200, json_data=None, next_url=None):
+        self.status_code = status_code
+        self._json = json_data if json_data is not None else []
+        # Mirror httpx.Response.links: {"next": {"url": ..., "rel": "next"}}.
+        self.links = {"next": {"url": next_url, "rel": "next"}} if next_url else {}
+
+    def json(self):
+        return self._json
+
+
+class _FakeIssuesClient:
+    """Async-context-manager client returning queued responses, recording calls."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []  # list of (url, params)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    async def get(self, url, headers=None, params=None):
+        self.calls.append((url, params))
+        return self._responses.pop(0)
+
+
+def _issue(number, *, title=None, body="body text", labels=None, html_url=None):
+    return {
+        "number": number,
+        "title": title if title is not None else f"Issue {number}",
+        "body": body,
+        "labels": [{"name": name} for name in (labels or [])],
+        "html_url": html_url or f"https://github.com/acme/widget/issues/{number}",
+    }
+
+
+def _pr(number):
+    """An item as GitHub returns it for a pull request on the issues endpoint."""
+    item = _issue(number, title=f"PR {number}")
+    item["pull_request"] = {"url": f"https://api.github.com/repos/acme/widget/pulls/{number}"}
+    return item
+
+
+# ---------------------------------------------------------------------------
+# Configuration / precondition failures
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{_M}.get_github_config")
+def test_issues_returns_400_when_integration_disabled(mock_cfg):
+    mock_cfg.return_value = {**_GH_CFG, "enabled": False}
+    resp = client.get(_ISSUES)
+    assert resp.status_code == 400
+    assert "not enabled" in resp.json()["detail"]
+
+
+@patch(f"{_M}.get_credential", return_value="")
+@patch(f"{_M}.get_github_config", return_value=dict(_GH_CFG))
+def test_issues_returns_400_when_pat_missing(mock_cfg, mock_cred):
+    resp = client.get(_ISSUES)
+    assert resp.status_code == 400
+    assert "PAT" in resp.json()["detail"]
+
+
+@patch(f"{_M}.get_credential", return_value="ghp_token")
+@patch(f"{_M}.get_github_config", return_value={**_GH_CFG, "owner": "", "repo": ""})
+def test_issues_returns_400_when_owner_repo_missing(mock_cfg, mock_cred):
+    resp = client.get(_ISSUES)
+    assert resp.status_code == 400
+    assert "owner/repo" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# GitHub HTTP error mapping
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{_M}.get_credential", return_value="ghp_token")
+@patch(f"{_M}.get_github_config", return_value=dict(_GH_CFG))
+def test_issues_returns_401_on_bad_token(mock_cfg, mock_cred):
+    fake = _FakeIssuesClient([_FakeIssuesResp(401)])
+    with patch(f"{_M}.httpx.AsyncClient", return_value=fake):
+        resp = client.get(_ISSUES)
+    assert resp.status_code == 401
+    assert "invalid or expired" in resp.json()["detail"]
+
+
+@patch(f"{_M}.get_credential", return_value="ghp_token")
+@patch(f"{_M}.get_github_config", return_value=dict(_GH_CFG))
+def test_issues_returns_404_on_missing_repo(mock_cfg, mock_cred):
+    fake = _FakeIssuesClient([_FakeIssuesResp(404)])
+    with patch(f"{_M}.httpx.AsyncClient", return_value=fake):
+        resp = client.get(_ISSUES)
+    assert resp.status_code == 404
+    assert "not found" in resp.json()["detail"]
+
+
+@patch(f"{_M}.get_credential", return_value="ghp_token")
+@patch(f"{_M}.get_github_config", return_value=dict(_GH_CFG))
+def test_issues_returns_502_on_other_github_error(mock_cfg, mock_cred):
+    fake = _FakeIssuesClient([_FakeIssuesResp(500)])
+    with patch(f"{_M}.httpx.AsyncClient", return_value=fake):
+        resp = client.get(_ISSUES)
+    assert resp.status_code == 502
+    assert "GitHub API returned 500" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Success paths: single page, pull-request filtering, label passthrough
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{_M}.get_credential", return_value="ghp_token")
+@patch(f"{_M}.get_github_config", return_value=dict(_GH_CFG))
+def test_issues_single_page_returns_all_and_excludes_prs(mock_cfg, mock_cred):
+    page = [_issue(1, labels=["bug", "ready"]), _pr(2), _issue(3)]
+    fake = _FakeIssuesClient([_FakeIssuesResp(200, page)])
+    with patch(f"{_M}.httpx.AsyncClient", return_value=fake):
+        resp = client.get(_ISSUES)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [item["number"] for item in body] == [1, 3]  # PR #2 excluded
+    assert body[0]["labels"] == ["bug", "ready"]
+    # Only one page was needed (no Link header), so only one request was made.
+    assert len(fake.calls) == 1
+    # The first request asks GitHub for the max page size and open state.
+    first_params = fake.calls[0][1]
+    assert first_params["state"] == "open"
+    assert first_params["per_page"] == integrations._GITHUB_ISSUES_PER_PAGE
+
+
+@patch(f"{_M}.get_credential", return_value="ghp_token")
+@patch(f"{_M}.get_github_config", return_value=dict(_GH_CFG))
+def test_issues_body_preview_truncated_to_200_chars(mock_cfg, mock_cred):
+    long_body = "x" * 500
+    fake = _FakeIssuesClient([_FakeIssuesResp(200, [_issue(1, body=long_body)])])
+    with patch(f"{_M}.httpx.AsyncClient", return_value=fake):
+        resp = client.get(_ISSUES)
+    assert resp.status_code == 200
+    assert len(resp.json()[0]["body_preview"]) == 200
+
+
+@patch(f"{_M}.get_credential", return_value="ghp_token")
+@patch(f"{_M}.get_github_config", return_value=dict(_GH_CFG))
+def test_issues_handles_null_body_and_label_objects(mock_cfg, mock_cred):
+    raw = {"number": 9, "title": None, "body": None, "labels": [{"no_name": "x"}, {"name": "ok"}], "html_url": None}
+    fake = _FakeIssuesClient([_FakeIssuesResp(200, [raw])])
+    with patch(f"{_M}.httpx.AsyncClient", return_value=fake):
+        resp = client.get(_ISSUES)
+    assert resp.status_code == 200
+    item = resp.json()[0]
+    assert item["title"] == ""
+    assert item["body_preview"] == ""
+    assert item["html_url"] == ""
+    assert item["labels"] == ["ok"]  # malformed label without a name is dropped
+
+
+@patch(f"{_M}.get_credential", return_value="ghp_token")
+@patch(f"{_M}.get_github_config", return_value={**_GH_CFG, "default_label": "ready"})
+def test_issues_uses_default_label_when_no_query(mock_cfg, mock_cred):
+    fake = _FakeIssuesClient([_FakeIssuesResp(200, [_issue(1)])])
+    with patch(f"{_M}.httpx.AsyncClient", return_value=fake):
+        resp = client.get(_ISSUES)
+    assert resp.status_code == 200
+    assert fake.calls[0][1]["labels"] == "ready"
+
+
+@patch(f"{_M}.get_credential", return_value="ghp_token")
+@patch(f"{_M}.get_github_config", return_value={**_GH_CFG, "default_label": "ready"})
+def test_issues_query_label_overrides_default(mock_cfg, mock_cred):
+    fake = _FakeIssuesClient([_FakeIssuesResp(200, [_issue(1)])])
+    with patch(f"{_M}.httpx.AsyncClient", return_value=fake):
+        resp = client.get(_ISSUES, params={"label": "blocked"})
+    assert resp.status_code == 200
+    assert fake.calls[0][1]["labels"] == "blocked"
+
+
+# ---------------------------------------------------------------------------
+# Pagination: the core fix — every page is fetched, not just the first
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{_M}.get_credential", return_value="ghp_token")
+@patch(f"{_M}.get_github_config", return_value=dict(_GH_CFG))
+def test_issues_follows_link_header_across_pages(mock_cfg, mock_cred):
+    page2_url = "https://api.github.com/repositories/1/issues?page=2&per_page=100&state=open"
+    responses = [
+        _FakeIssuesResp(200, [_issue(1), _issue(2)], next_url=page2_url),
+        _FakeIssuesResp(200, [_issue(3), _pr(4), _issue(5)], next_url=None),
+    ]
+    fake = _FakeIssuesClient(responses)
+    with patch(f"{_M}.httpx.AsyncClient", return_value=fake):
+        resp = client.get(_ISSUES)
+    assert resp.status_code == 200
+    # All four issues from both pages are present; the PR (#4) is excluded.
+    assert [item["number"] for item in resp.json()] == [1, 2, 3, 5]
+    # Two requests were made: the base URL, then the verbatim "next" URL.
+    assert len(fake.calls) == 2
+    assert fake.calls[1][0] == page2_url
+    # The first page carries query params; the next-page URL must not re-append them.
+    assert fake.calls[0][1] is not None
+    assert fake.calls[1][1] is None
+
+
+@patch(f"{_M}.get_credential", return_value="ghp_token")
+@patch(f"{_M}.get_github_config", return_value=dict(_GH_CFG))
+def test_issues_stops_at_page_cap_and_warns(mock_cfg, mock_cred, monkeypatch, caplog):
+    # Force a tiny cap and hand back pages that always advertise a "next" link, so
+    # only the cap can stop the loop.
+    monkeypatch.setattr(integrations, "_GITHUB_MAX_ISSUE_PAGES", 2)
+    responses = [
+        _FakeIssuesResp(200, [_issue(1)], next_url="https://api.github.com/x?page=2"),
+        _FakeIssuesResp(200, [_issue(2)], next_url="https://api.github.com/x?page=3"),
+    ]
+    fake = _FakeIssuesClient(responses)
+    with (
+        caplog.at_level(logging.WARNING, logger="unified_api.routes.integrations"),
+        patch(f"{_M}.httpx.AsyncClient", return_value=fake),
+    ):
+        resp = client.get(_ISSUES)
+    assert resp.status_code == 200
+    assert [item["number"] for item in resp.json()] == [1, 2]
+    # Exactly two pages were fetched — the loop honoured the cap rather than chasing
+    # the still-present "next" link into page 3.
+    assert len(fake.calls) == 2
+    assert any("page cap" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary

The coding team page's GitHub issues picker only showed the first 30 open issues. `GET /api/integrations/github/issues` requested a single page of `per_page=30` and never followed GitHub's `Link`-header pagination, so any repository with more than 30 open issues had its list silently truncated server-side. The Angular panel renders the returned list verbatim (no client-side limit), so no frontend change is needed — fixing the endpoint is sufficient.

## Changes

- **Page through every result** in `list_github_issues`: request the 100-item maximum per page (`per_page=100`) and follow the `next` `Link` header until exhausted.
- **Safety cap** (`_GITHUB_MAX_ISSUE_PAGES = 50` → 5000 open issues) that logs a warning and returns what it has gathered rather than failing.
- **Behavior preserved**: pull-request exclusion, default-label/query-label filtering, 200-char body preview, and the existing 401/404/502 error mapping.
- **Tests**: new `test_integrations_github_issues_route.py` covering multi-page pagination, PR filtering, single-page, label resolution, the page cap (asserting the warning fires), null-field handling, body truncation, and error mapping — 13 tests; the modified handler is at 100% line coverage.

## Scope note

This keeps the existing `state=open` filter. The panel feeds the "run the coding team on a ready issue" workflow and the empty-state copy reads "No open issues found", so "all GitHub issues" here means *all open issues* rather than the truncated first 30. If closed issues should also appear in the panel, that's a one-line follow-up (`state="all"`).

## Testing

- `pytest unified_api/tests/test_integrations_github_issues_route.py unified_api/tests/test_integrations_github_route.py` → **32 passed**
- `ruff check` + `ruff format --check` on the changed files → **clean**

Closes #747

https://claude.ai/code/session_015UNrqF7kpTNqvUQ9dasi5o

---
_Generated by [Claude Code](https://claude.ai/code/session_015UNrqF7kpTNqvUQ9dasi5o)_