### PR TITLE
Auto-load and paginate Coding Team GitHub issues panel

### DIFF
--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.html
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.html
@@ -178,7 +178,7 @@
         </div>
       } @else {
         <div class="github-issues-list">
-          @for (issue of issues; track issue.number) {
+          @for (issue of pagedIssues; track issue.number) {
             <button
               class="github-issue-row"
               type="button"
@@ -195,6 +195,16 @@
             </button>
           }
         </div>
+        @if (issues.length > PAGE_SIZE_OPTIONS[0]) {
+          <mat-paginator
+            class="github-issues-paginator"
+            [length]="issues.length"
+            [pageSize]="pageSize"
+            [pageIndex]="pageIndex"
+            [pageSizeOptions]="PAGE_SIZE_OPTIONS"
+            (page)="onPageChange($event)"
+          ></mat-paginator>
+        }
       }
     }
   </section>

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.scss
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.scss
@@ -90,6 +90,11 @@
   gap: 2px;
 }
 
+.github-issues-paginator {
+  margin-top: 0.5rem;
+  background: transparent;
+}
+
 .github-issue-row {
   display: flex;
   align-items: center;

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.spec.ts
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.spec.ts
@@ -1,0 +1,172 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { vi } from 'vitest';
+import { CodingTeamApiService } from '../../services/coding-team-api.service';
+import { IntegrationsApiService } from '../../services/integrations-api.service';
+import { CodingTeamPageComponent } from './coding-team-page.component';
+import type { GitHubConfigResponse, GitHubIssueItem } from '../../models/integrations.model';
+
+function makeIssues(count: number): GitHubIssueItem[] {
+  return Array.from({ length: count }, (_, i) => ({
+    number: i + 1,
+    title: `Issue ${i + 1}`,
+    body_preview: `body ${i + 1}`,
+    labels: i % 2 === 0 ? ['bug'] : [],
+    html_url: `https://example.com/${i + 1}`,
+  }));
+}
+
+const CONFIGURED: GitHubConfigResponse = {
+  enabled: true,
+  token_configured: true,
+  owner: 'acme',
+  repo: 'widgets',
+  default_label: 'ai',
+};
+
+describe('CodingTeamPageComponent', () => {
+  let component: CodingTeamPageComponent;
+  let fixture: ComponentFixture<CodingTeamPageComponent>;
+  let apiSpy: {
+    health: ReturnType<typeof vi.fn>;
+    getJobStatus: ReturnType<typeof vi.fn>;
+  };
+  let integrationsSpy: {
+    getGitHubConfig: ReturnType<typeof vi.fn>;
+    getGitHubIssues: ReturnType<typeof vi.fn>;
+    runGitHubIssue: ReturnType<typeof vi.fn>;
+  };
+
+  async function setup(): Promise<void> {
+    await TestBed.configureTestingModule({
+      imports: [CodingTeamPageComponent, NoopAnimationsModule],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        { provide: CodingTeamApiService, useValue: apiSpy },
+        { provide: IntegrationsApiService, useValue: integrationsSpy },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CodingTeamPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    apiSpy = {
+      health: vi.fn().mockReturnValue(of({ status: 'ok' })),
+      getJobStatus: vi.fn().mockReturnValue(of({ job_id: 'j1', status: 'running' })),
+    };
+    integrationsSpy = {
+      getGitHubConfig: vi.fn().mockReturnValue(of(CONFIGURED)),
+      getGitHubIssues: vi.fn().mockReturnValue(of(makeIssues(3))),
+      runGitHubIssue: vi.fn(),
+    };
+  });
+
+  it('should create', async () => {
+    await setup();
+    expect(component).toBeTruthy();
+  });
+
+  it('auto-loads issues on init when GitHub is configured', async () => {
+    await setup();
+    expect(integrationsSpy.getGitHubConfig).toHaveBeenCalled();
+    expect(integrationsSpy.getGitHubIssues).toHaveBeenCalled();
+    expect(component.githubConfigured).toBe(true);
+    expect(component.issuesLoaded).toBe(true);
+    expect(component.issues.length).toBe(3);
+  });
+
+  it('does NOT auto-load issues when GitHub is not configured', async () => {
+    integrationsSpy.getGitHubConfig.mockReturnValue(
+      of({ ...CONFIGURED, token_configured: false }),
+    );
+    await setup();
+    expect(component.githubConfigured).toBe(false);
+    expect(integrationsSpy.getGitHubIssues).not.toHaveBeenCalled();
+  });
+
+  it('handles a failed config check without loading issues', async () => {
+    integrationsSpy.getGitHubConfig.mockReturnValue(throwError(() => new Error('boom')));
+    await setup();
+    expect(component.githubConfigured).toBe(false);
+    expect(component.loadingConfig).toBe(false);
+    expect(integrationsSpy.getGitHubIssues).not.toHaveBeenCalled();
+  });
+
+  it('paginates client-side and resets to the first page on (re)load', async () => {
+    integrationsSpy.getGitHubIssues.mockReturnValue(of(makeIssues(25)));
+    await setup();
+
+    // Defaults to first page of PAGE_SIZE_OPTIONS[0] (10) items.
+    expect(component.pageIndex).toBe(0);
+    expect(component.pageSize).toBe(10);
+    expect(component.pagedIssues.map((i) => i.number)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+    // Move to the second page.
+    component.onPageChange({ pageIndex: 1, pageSize: 10, length: 25 });
+    expect(component.pagedIssues.map((i) => i.number)).toEqual([11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
+
+    // Changing page size is honoured.
+    component.onPageChange({ pageIndex: 0, pageSize: 25, length: 25 });
+    expect(component.pageSize).toBe(25);
+    expect(component.pagedIssues.length).toBe(25);
+
+    // Reloading resets back to the first page.
+    component.loadIssues();
+    expect(component.pageIndex).toBe(0);
+  });
+
+  it('surfaces an error when loading issues fails', async () => {
+    integrationsSpy.getGitHubIssues.mockReturnValue(
+      throwError(() => ({ error: { detail: 'rate limited' } })),
+    );
+    await setup();
+    expect(component.issueError).toBe('rate limited');
+    expect(component.loadingIssues).toBe(false);
+  });
+
+  it('selects, cancels, and runs an issue', async () => {
+    await setup();
+    const issue = component.issues[0];
+
+    component.selectIssue(issue);
+    expect(component.selectedIssue).toBe(issue);
+
+    component.cancelSelection();
+    expect(component.selectedIssue).toBeNull();
+
+    integrationsSpy.runGitHubIssue.mockReturnValue(
+      of({ job_id: 'j1', issue_number: issue.number, issue_url: 'u', status: 'queued', message: '' }),
+    );
+    component.selectIssue(issue);
+    component.confirmAndRun();
+    expect(integrationsSpy.runGitHubIssue).toHaveBeenCalledWith({ issue_number: issue.number });
+    expect(component.activeJob?.job_id).toBe('j1');
+    expect(component.selectedIssue).toBeNull();
+
+    component.dismissJob();
+    expect(component.activeJob).toBeNull();
+    expect(component.jobStatus).toBeNull();
+  });
+
+  it('confirmAndRun is a no-op without a selected issue', async () => {
+    await setup();
+    component.selectedIssue = null;
+    component.confirmAndRun();
+    expect(integrationsSpy.runGitHubIssue).not.toHaveBeenCalled();
+  });
+
+  it('records the latest job id when a workflow is launched', async () => {
+    await setup();
+    component.onWorkflowLaunched({ job_id: 'wf-1', conversation_id: 'c1' });
+    expect(component.latestJobId).toBe('wf-1');
+  });
+});

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
@@ -5,6 +5,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatChipsModule } from '@angular/material/chips';
+import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import { RouterLink } from '@angular/router';
 import { EMPTY, Subscription, interval } from 'rxjs';
 import { catchError, switchMap, takeWhile } from 'rxjs/operators';
@@ -25,6 +26,7 @@ import type { CodingTeamJobStatus } from '../../models/coding-team.model';
     MatButtonModule,
     MatProgressSpinnerModule,
     MatChipsModule,
+    MatPaginatorModule,
     RouterLink,
     HealthIndicatorComponent,
     TeamAssistantChatComponent,
@@ -52,6 +54,11 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
   issuesLoaded = false;
   issueError: string | null = null;
 
+  // Issue list pagination (client-side over the fully-fetched issue array)
+  readonly PAGE_SIZE_OPTIONS = [10, 25, 50];
+  pageSize = 10;
+  pageIndex = 0;
+
   // Issue selection & confirmation
   selectedIssue: GitHubIssueItem | null = null;
   runningIssue = false;
@@ -77,6 +84,9 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
         this.githubOwner = cfg.owner;
         this.githubRepo = cfg.repo;
         this.loadingConfig = false;
+        if (this.githubConfigured) {
+          this.loadIssues();
+        }
       },
       error: () => {
         this.githubConfigured = false;
@@ -92,6 +102,7 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
     this.integrationsApi.getGitHubIssues().subscribe({
       next: (issues) => {
         this.issues = issues;
+        this.pageIndex = 0;
         this.issuesLoaded = true;
         this.loadingIssues = false;
       },
@@ -100,6 +111,17 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
         this.loadingIssues = false;
       },
     });
+  }
+
+  /** The slice of issues visible on the current page. */
+  get pagedIssues(): GitHubIssueItem[] {
+    const start = this.pageIndex * this.pageSize;
+    return this.issues.slice(start, start + this.pageSize);
+  }
+
+  onPageChange(event: PageEvent): void {
+    this.pageIndex = event.pageIndex;
+    this.pageSize = event.pageSize;
   }
 
   selectIssue(issue: GitHubIssueItem): void {


### PR DESCRIPTION
## Summary

Improves the GitHub Issues panel on the Coding Team page (`/coding-team`):

1. **Auto-load** — issues now load automatically once the integration config check confirms GitHub is configured, instead of requiring a manual click. The existing button is retained as a **Refresh** control.
2. **Pagination** — the issues list is now paginated client-side using a Material `mat-paginator` (default page size 10, options 10/25/50), so the user can comfortably page through all issues. Reloading/refreshing resets to the first page.

No backend change is needed: `GET /api/integrations/github/issues` already follows GitHub's `Link`-header pagination server-side and returns the complete set of open issues in one response, so pagination is done client-side over the fetched array (mirroring the existing Strategy Lab paginator pattern).

## Changes

- `coding-team-page.component.ts` — auto-load issues from the config-check success path when configured; add `pageSize`/`pageIndex` state, a `pagedIssues` getter, and an `onPageChange` handler; reset to page 0 on (re)load.
- `coding-team-page.component.html` — render `pagedIssues` and add the `mat-paginator` below the list (shown only when there is more than one page).
- `coding-team-page.component.scss` — minor paginator spacing.
- `coding-team-page.component.spec.ts` — **new** spec (none existed) covering auto-load, the unconfigured/error paths, pagination, selection/run, and dismiss.

## Testing

- `npx vitest run` for the component — 9/9 pass; line coverage for the changed component is 90.79% (≥90% floor).
- `npx eslint` on the component dir — clean.
- `npm run build` — succeeds (the pre-existing bundle-budget warning is unrelated to this change).

Closes #749

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fg9fhkUspYTY8ocJyYhPBd)_