### PR TITLE
Agent Cognition Core (Step 9): optional manifest CognitionSpec

### DIFF
--- a/backend/agents/agent_cognition/examples/cognition_manifest.example.yaml
+++ b/backend/agents/agent_cognition/examples/cognition_manifest.example.yaml
@@ -1,0 +1,29 @@
+# Illustrative agent manifest showing the optional `cognition:` block.
+#
+# This file documents the schema ONLY. It is deliberately placed outside any
+# team's `agent_console/manifests/` directory, so the Agent Registry loader does
+# not discover it — that keeps it from emitting an orphan-team warning and avoids
+# implying that any live agent is cognition-enabled before the runtime wiring for
+# the Agent Cognition Core exists.
+#
+# The `cognition:` block is metadata: nothing reads it at registry-load time.
+# Later phases consume it — the tools layer resolves `tools`, the invoke proxy
+# honours `requires_idempotency_key`, the seed-pack installer reads `rule_packs`,
+# and the central scheduler prunes memory per `memory.retention_days_events`. The
+# agent generator stamps an equivalent block onto every newly generated agent.
+schema_version: 1
+id: example.cognition_demo
+team: agentic_team_provisioning
+name: Cognition Demo Agent
+summary: Example agent illustrating the optional cognition manifest block.
+description: |
+  Reference manifest for the optional `cognition:` block. Not a real, runnable agent.
+tags: [example, cognition]
+source:
+  entrypoint: example.module:ExampleAgent
+cognition:
+  memory:
+    retention_days_events: 90       # raw episodic events pruned after N days (>= 1)
+  tools: [git, http_api]            # tool ids resolved against the cognition tool registries
+  rule_packs: [default_guardrails]  # seed rule packs installed on first provision
+  requires_idempotency_key: false   # true => side-effecting; reject invokes lacking a caller key

--- a/backend/agents/agent_registry/README.md
+++ b/backend/agents/agent_registry/README.md
@@ -64,10 +64,19 @@ sandbox:                         # consumed by the per-agent sandbox lifecycle
     FEATURE_FLAG_X: "true"
   extra_pip:                     # optional: extra pip packages baked into the image
     - pandas==2.2.*
+cognition:                       # consumed by the Agent Cognition Core (later phases)
+  memory:
+    retention_days_events: 90    # raw episodic events pruned after N days (>= 1)
+  tools: [git, http_api]         # tool ids resolved against the cognition tool registries
+  rule_packs: [default_guardrails]  # seed rule packs installed on first provision
+  requires_idempotency_key: false   # true => side-effecting; reject invokes lacking a caller key
 source:
   entrypoint: blogging.blog_planning_agent.agent:BlogPlanningAgent
   anatomy_ref: backend/agents/blogging/blog_planning_agent/ANATOMY.md
 ```
+
+A fully-annotated standalone example lives at
+[`agent_cognition/examples/cognition_manifest.example.yaml`](../agent_cognition/examples/cognition_manifest.example.yaml).
 
 ### Field rules
 
@@ -80,6 +89,7 @@ source:
 | `source.entrypoint` | yes | `module.path:Symbol` pointing to the agent's class/factory. **Not imported** at registry load — it's metadata. |
 | `inputs.schema_ref` / `outputs.schema_ref` | no | `module.path:ClassName`. Resolved **lazily** by the `/schema/input` and `/schema/output` endpoints via `TypeAdapter.json_schema()`. If the import fails (e.g. the unified_api container doesn't have team code), the endpoint returns 404 — the UI handles this gracefully. |
 | `invoke`, `sandbox` | no | Metadata for later phases. UI shows indicators when present. |
+| `cognition` | no | Per-agent cognition config (memory retention, tools, rule packs, idempotency requirement). Consumed by the Agent Cognition Core; UI shows an indicator when present. |
 
 ### Path conventions
 

--- a/backend/agents/agent_registry/__init__.py
+++ b/backend/agents/agent_registry/__init__.py
@@ -6,8 +6,8 @@ Loads declarative per-agent manifests from
 structured metadata. Read-only; no Postgres, no Temporal, no LLM.
 
 Used by ``backend/unified_api/routes/agents.py`` to serve ``/api/agents``.
-Later phases will consume the ``invoke`` and ``sandbox`` blocks to run
-agents in isolation via warm provisioned sandboxes.
+Later phases consume the ``invoke``, ``sandbox``, and ``cognition`` blocks to
+run agents in isolation and give them durable memory + rules.
 """
 
 from .loader import AgentRegistry, get_registry
@@ -15,6 +15,8 @@ from .models import (
     AgentDetail,
     AgentManifest,
     AgentSummary,
+    CognitionMemorySpec,
+    CognitionSpec,
     InvokeSpec,
     IOSchema,
     SandboxSpec,
@@ -27,6 +29,8 @@ __all__ = [
     "AgentManifest",
     "AgentRegistry",
     "AgentSummary",
+    "CognitionMemorySpec",
+    "CognitionSpec",
     "InvokeSpec",
     "IOSchema",
     "SandboxSpec",

--- a/backend/agents/agent_registry/loader.py
+++ b/backend/agents/agent_registry/loader.py
@@ -231,6 +231,7 @@ class AgentRegistry:
             has_output_schema=bool(m.outputs and m.outputs.schema_ref),
             has_invoke=m.invoke is not None,
             has_sandbox=m.sandbox is not None,
+            has_cognition=m.cognition is not None,
         )
 
     @staticmethod

--- a/backend/agents/agent_registry/models.py
+++ b/backend/agents/agent_registry/models.py
@@ -42,6 +42,54 @@ class SandboxSpec(BaseModel):
     extra_pip: list[str] = Field(default_factory=list)
 
 
+class CognitionMemorySpec(BaseModel):
+    """Per-agent memory-retention knobs for the Agent Cognition Core.
+
+    Preconditions:
+        - ``retention_days_events`` >= 1. A sub-day retention is meaningless for a
+          daily-rollup pruner; enforced by the ``ge=1`` field constraint, so a manifest
+          declaring ``0`` (or negative) fails validation and is skipped by the loader.
+    """
+
+    retention_days_events: int = Field(
+        default=90,
+        ge=1,
+        description="Raw episodic memory events older than this many days are pruned by the "
+        "central cognition scheduler, but only after they have been folded into a non-stale "
+        "day summary (rollup summaries are retained long-term). Must be >= 1.",
+    )
+
+
+class CognitionSpec(BaseModel):
+    """Declarative per-agent cognition config for the Agent Cognition Core.
+
+    Metadata only — the registry never consumes it. Later phases do: the tools layer
+    resolves ``tools``, the invoke proxy honours ``requires_idempotency_key``, the seed-pack
+    installer reads ``rule_packs``, and the central scheduler prunes memory per
+    ``memory.retention_days_events``.
+
+    Invariants:
+        - A manifest may omit the whole block (``AgentManifest.cognition is None``). When the
+          block is present every sub-field carries a safe default, so partial blocks always
+          validate — mirroring the lazy ``InvokeSpec`` / ``SandboxSpec`` pattern.
+    """
+
+    memory: CognitionMemorySpec = Field(default_factory=CognitionMemorySpec)
+    tools: list[str] = Field(
+        default_factory=list,
+        description="Tool ids resolved against LlmToolsService + IntegrationRegistry + agent_git_tools.",
+    )
+    rule_packs: list[str] = Field(
+        default_factory=list,
+        description="Seed rule-pack names installed on first provision, e.g. 'default_guardrails'.",
+    )
+    requires_idempotency_key: bool = Field(
+        default=False,
+        description="When true the agent is side-effecting; invokes without a caller "
+        "idempotency key are rejected.",
+    )
+
+
 class SourceInfo(BaseModel):
     """Traceability — where the agent lives in the codebase."""
 
@@ -70,6 +118,7 @@ class AgentManifest(BaseModel):
     outputs: IOSchema | None = None
     invoke: InvokeSpec | None = None
     sandbox: SandboxSpec | None = None
+    cognition: CognitionSpec | None = None
     source: SourceInfo
 
 
@@ -85,6 +134,7 @@ class AgentSummary(BaseModel):
     has_output_schema: bool = False
     has_invoke: bool = False
     has_sandbox: bool = False
+    has_cognition: bool = False
 
 
 class AgentDetail(BaseModel):

--- a/backend/agents/agent_registry/tests/test_loader.py
+++ b/backend/agents/agent_registry/tests/test_loader.py
@@ -6,8 +6,11 @@ from pathlib import Path
 from textwrap import dedent
 
 import pytest
+import yaml
+from pydantic import ValidationError
 
 from agent_registry.loader import AgentRegistry
+from agent_registry.models import AgentManifest
 
 
 def _write_manifest(root: Path, team: str, filename: str, body: str) -> Path:
@@ -191,6 +194,8 @@ def test_summary_flags_reflect_manifest_content(tmp_path: Path) -> None:
         sandbox:
           manifest_path: default.yaml
           access_tier: standard
+        cognition:
+          tools: [git]
         source:
           entrypoint: pkg.mod:Agent
         """,
@@ -201,6 +206,7 @@ def test_summary_flags_reflect_manifest_content(tmp_path: Path) -> None:
     assert summary.has_output_schema is True
     assert summary.has_invoke is True
     assert summary.has_sandbox is True
+    assert summary.has_cognition is True
 
 
 def test_detail_returns_manifest_and_anatomy_when_present(tmp_path: Path) -> None:
@@ -325,3 +331,124 @@ def test_orphan_team_is_kept_but_logged(tmp_path: Path, caplog: pytest.LogCaptur
     )
     reg = AgentRegistry.load(tmp_path)
     assert reg.get("unknown.agent") is not None
+
+
+def test_cognition_spec_round_trip_with_block(tmp_path: Path) -> None:
+    """A full `cognition:` block parses and every field round-trips."""
+    _write_manifest(
+        tmp_path,
+        "blogging",
+        "smart.yaml",
+        """
+        schema_version: 1
+        id: blogging.smart
+        team: blogging
+        name: Smart
+        summary: has a cognition block
+        cognition:
+          memory:
+            retention_days_events: 30
+          tools: [git, http_api]
+          rule_packs: [default_guardrails]
+          requires_idempotency_key: true
+        source:
+          entrypoint: x:y
+        """,
+    )
+    reg = AgentRegistry.load(tmp_path)
+    smart = reg.get("blogging.smart")
+    assert smart is not None
+    assert smart.cognition is not None
+    assert smart.cognition.memory.retention_days_events == 30
+    assert smart.cognition.tools == ["git", "http_api"]
+    assert smart.cognition.rule_packs == ["default_guardrails"]
+    assert smart.cognition.requires_idempotency_key is True
+
+
+def test_cognition_spec_absent_defaults_to_none(tmp_path: Path) -> None:
+    """Manifests without a `cognition:` block still load; the field is None."""
+    _write_manifest(
+        tmp_path,
+        "blogging",
+        "plain.yaml",
+        """
+        schema_version: 1
+        id: blogging.plain
+        team: blogging
+        name: Plain
+        summary: no cognition block
+        source:
+          entrypoint: x:y
+        """,
+    )
+    reg = AgentRegistry.load(tmp_path)
+    plain = reg.get("blogging.plain")
+    assert plain is not None
+    assert plain.cognition is None
+    [summary] = reg.search()
+    assert summary.has_cognition is False
+
+
+def test_cognition_spec_partial_block_uses_defaults(tmp_path: Path) -> None:
+    """A `cognition:` block that omits sub-fields fills in safe defaults."""
+    _write_manifest(
+        tmp_path,
+        "blogging",
+        "partial.yaml",
+        """
+        schema_version: 1
+        id: blogging.partial
+        team: blogging
+        name: Partial
+        summary: cognition block with only one field set
+        cognition:
+          tools: [git]
+        source:
+          entrypoint: x:y
+        """,
+    )
+    reg = AgentRegistry.load(tmp_path)
+    partial = reg.get("blogging.partial")
+    assert partial is not None
+    assert partial.cognition is not None
+    assert partial.cognition.tools == ["git"]
+    # Omitted sub-fields fall back to defaults, never missing attributes.
+    assert partial.cognition.memory.retention_days_events == 90
+    assert partial.cognition.rule_packs == []
+    assert partial.cognition.requires_idempotency_key is False
+
+
+def test_cognition_retention_must_be_positive(tmp_path: Path) -> None:
+    """`retention_days_events` < 1 violates the precondition and fails validation."""
+    raw = {
+        "schema_version": 1,
+        "id": "blogging.bad",
+        "team": "blogging",
+        "name": "Bad",
+        "summary": "non-positive retention",
+        "cognition": {"memory": {"retention_days_events": 0}},
+        "source": {"entrypoint": "x:y"},
+    }
+    with pytest.raises(ValidationError):
+        AgentManifest.model_validate(raw)
+
+    # The loader swallows the ValidationError and skips the manifest entirely.
+    _write_manifest(tmp_path, "blogging", "bad.yaml", yaml.safe_dump(raw))
+    reg = AgentRegistry.load(tmp_path)
+    assert reg.get("blogging.bad") is None
+
+
+def test_cognition_example_manifest_is_valid() -> None:
+    """The shipped standalone example manifest parses as a valid AgentManifest."""
+    example = (
+        Path(__file__).resolve().parents[2]
+        / "agent_cognition"
+        / "examples"
+        / "cognition_manifest.example.yaml"
+    )
+    manifest = AgentManifest.model_validate(yaml.safe_load(example.read_text(encoding="utf-8")))
+    assert manifest.cognition is not None
+    assert manifest.cognition.tools == ["git", "http_api"]
+    assert manifest.cognition.rule_packs == ["default_guardrails"]
+    assert manifest.cognition.memory.retention_days_events == 90
+    assert manifest.cognition.requires_idempotency_key is False


### PR DESCRIPTION
Closes #732

## Summary

Adds an optional `cognition` block to the Agent Registry manifest schema so every agent can declaratively carry its cognition config — **memory retention, tool ids, seed rule packs, and an idempotency-key requirement**. This is the Manifest `CognitionSpec` step of the Agent Cognition Core (Milestone C). It mirrors the existing lazy `InvokeSpec` / `SandboxSpec` pattern: manifests that omit the block load unchanged, and a present block with omitted sub-fields falls back to safe defaults.

The block is **metadata only** — nothing in the registry consumes it at load time. Later steps read it: the tools layer resolves `tools`, the invoke proxy honours `requires_idempotency_key`, the seed-pack installer reads `rule_packs`, and the central scheduler prunes memory per `memory.retention_days_events`. The shape matches `agent_cognition/DESIGN.md` §10.

## Schema

```yaml
cognition:
  memory:
    retention_days_events: 90      # raw episodic events pruned after N days (>= 1)
  tools: [git, http_api]            # tool ids resolved against the cognition tool registries
  rule_packs: [default_guardrails]  # seed rule packs installed on first provision
  requires_idempotency_key: false   # true => side-effecting; reject invokes lacking a caller key
```

## Changes

- **`agent_registry/models.py`** — new `CognitionMemorySpec` (`retention_days_events`, constrained `>= 1`) and `CognitionSpec` (`memory`, `tools`, `rule_packs`, `requires_idempotency_key`); wire `cognition` onto `AgentManifest` and a `has_cognition` flag onto `AgentSummary`.
- **`agent_registry/loader.py`** — reflect presence via `has_cognition` in the summary projection (parallel to `has_invoke` / `has_sandbox`).
- **`agent_registry/__init__.py`** — re-export the new specs alongside `InvokeSpec` / `SandboxSpec`.
- **`agent_registry/README.md`** — document the block in the full-manifest example and field-rules table.
- **`agent_cognition/examples/cognition_manifest.example.yaml`** — standalone, fully-annotated sample (deliberately outside any team's `manifests/` dir so the loader does not discover it — no orphan-team warning, no implication that a live agent is cognition-enabled yet).
- **`agent_registry/tests/test_loader.py`** — new tests: parse with/without the block, partial-block default fill-in, the `>= 1` precondition rejection (and loader-skip), and validation of the shipped example manifest.

## Verification

```bash
cd backend
ruff check agents/agent_registry/ && ruff format --check agents/agent_registry/
PYTHONPATH="agents:." python -m pytest agents/agent_registry/tests/ unified_api/tests/test_agents_route.py
```

Ruff clean; **30 tests pass**. `models.py` is at 100% line coverage and the added `loader.py` line is covered; the additive `has_cognition` field does not break the `/api/agents` route test.

## Notes / scope

- `requires_idempotency_key` is included per the authoritative `IMPLEMENTATION_PLAN.md` Step 9 and `DESIGN.md` §10 (the invoke proxy step consumes it), even though the issue body lists only memory/tools/rule_packs.
- Frontend is intentionally untouched. `has_cognition` is additive and ignored by the existing TS interface at runtime; the Agent Console UI surfaces it in the later HITL-review-UI step.

https://claude.ai/code/session_01CcfXB5FyL9SzfL5e7AzXGA

---
_Generated by [Claude Code](https://claude.ai/code/session_01CcfXB5FyL9SzfL5e7AzXGA)_