### PR TITLE
MarketDataService: tolerate None/pd.NA OHLC values instead of crashing the fetch

### DIFF
--- a/backend/agents/investment_team/market_data_service.py
+++ b/backend/agents/investment_team/market_data_service.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import math
 import os
+import sys
 import time
 from datetime import date, datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence, Tuple
@@ -861,30 +862,56 @@ class MarketDataService:
     _FILL_LOG_MAX_DATES = 10
 
     @staticmethod
+    def _is_missing_sentinel(value: object) -> bool:
+        """True iff ``value`` is an explicit missing-value sentinel.
+
+        Recognises ``None`` and pandas ``NA``. pandas is detected via
+        ``sys.modules`` rather than imported: ``pd.NA`` is a singleton that can
+        only exist once pandas is loaded, so if pandas is not in ``sys.modules``
+        the value cannot be ``pd.NA`` — and this module keeps its hard import
+        surface pandas-free.
+
+        Postconditions:
+            Returns ``True`` only for ``None`` / pandas ``NA``; ``False`` for
+            every other value (including numbers, strings, and malformed
+            non-scalar cells such as dicts/lists).
+        """
+        if value is None:
+            return True
+        pd = sys.modules.get("pandas")
+        return pd is not None and value is pd.NA
+
+    @staticmethod
     def _coerce_finite_or_nan(value: float | str | int | None) -> float:
         """Coerce a raw provider value to float, mapping missing sentinels to NaN.
 
         Preconditions:
             ``value`` is a number, a numeric string, or a missing-value sentinel
-            (``None`` or a pandas ``NA``). A non-numeric string is still a caller
-            bug.
+            (``None`` or a pandas ``NA``). A non-numeric string or a malformed
+            non-scalar cell is still a caller bug.
 
         Postconditions:
             Returns ``float(value)`` for numeric input. Returns ``float("nan")``
             for a missing-value sentinel (``None`` / pandas ``NA``) so the
             caller's finite check treats the row as a gap — identical handling to
-            an upstream ``numpy.nan``. A non-numeric string still raises
-            ``ValueError``.
+            an upstream ``numpy.nan``. A non-numeric string (``ValueError``) and a
+            malformed non-scalar cell — e.g. a dict/list/object from a bad JSON
+            schema or an object-dtype column (``TypeError``) — both propagate, so
+            the provider fails and the chain falls back rather than silently
+            imputing a fabricated price.
         """
         try:
             return float(value)  # type: ignore[arg-type]
         except TypeError:
-            # ``None`` and pandas ``NA`` are missing-value sentinels whose
-            # ``float()`` raises TypeError (a malformed numeric string raises
-            # ValueError instead and is left to propagate). Treat them as a
-            # non-finite gap so the existing forward-fill/drop path handles them
-            # exactly like an upstream numpy.nan.
-            return float("nan")
+            # float() raises TypeError for BOTH missing-value sentinels
+            # (None / pd.NA) and malformed non-scalar cells (dict/list/object).
+            # Only the explicit sentinels are a non-finite gap the forward-fill/
+            # drop path should absorb like an upstream numpy.nan; a malformed
+            # value is a genuine data defect and must propagate so this provider
+            # fails and the chain falls back rather than imputing a fake price.
+            if MarketDataService._is_missing_sentinel(value):
+                return float("nan")
+            raise
 
     @staticmethod
     def _normalize_ohlc_bar(
@@ -911,9 +938,10 @@ class MarketDataService:
             / pandas ``NA``). This helper owns the coercion and rounding to 4 dp;
             callers pass the extracted values through verbatim. A missing-value
             sentinel is treated as a non-finite value (the row is forward-filled
-            or dropped, like an upstream ``numpy.nan``); only a genuinely
-            non-numeric string is a caller (precondition) bug and surfaces as a
-            ``ValueError`` rather than being silently coerced.
+            or dropped, like an upstream ``numpy.nan``); a genuinely non-numeric
+            string (``ValueError``) or a malformed non-scalar cell such as a
+            dict/list/object (``TypeError``) is a caller (precondition) bug and
+            propagates rather than being silently coerced.
 
         Postconditions:
             Returns ``(None, False)`` when any of O/H/L/C is non-finite (the

--- a/backend/agents/investment_team/market_data_service.py
+++ b/backend/agents/investment_team/market_data_service.py
@@ -588,7 +588,14 @@ class MarketDataService:
                 return []
 
             if df is not None and not df.empty:
-                return self._df_to_bars(df)
+                try:
+                    return self._df_to_bars(df)
+                except Exception as exc:
+                    # Defense in depth: a malformed frame must never abort the
+                    # whole fetch. Degrade to an empty result (the caller falls
+                    # back to the next provider) rather than propagating.
+                    logger.warning("failed to convert yfinance frame for %s: %s", yf_symbol, exc)
+                    return []
 
             if attempt < max_retries - 1:
                 wait = 2 ** (attempt + 1)
@@ -854,14 +861,40 @@ class MarketDataService:
     _FILL_LOG_MAX_DATES = 10
 
     @staticmethod
+    def _coerce_finite_or_nan(value: float | str | int | None) -> float:
+        """Coerce a raw provider value to float, mapping missing sentinels to NaN.
+
+        Preconditions:
+            ``value`` is a number, a numeric string, or a missing-value sentinel
+            (``None`` or a pandas ``NA``). A non-numeric string is still a caller
+            bug.
+
+        Postconditions:
+            Returns ``float(value)`` for numeric input. Returns ``float("nan")``
+            for a missing-value sentinel (``None`` / pandas ``NA``) so the
+            caller's finite check treats the row as a gap — identical handling to
+            an upstream ``numpy.nan``. A non-numeric string still raises
+            ``ValueError``.
+        """
+        try:
+            return float(value)  # type: ignore[arg-type]
+        except TypeError:
+            # ``None`` and pandas ``NA`` are missing-value sentinels whose
+            # ``float()`` raises TypeError (a malformed numeric string raises
+            # ValueError instead and is left to propagate). Treat them as a
+            # non-finite gap so the existing forward-fill/drop path handles them
+            # exactly like an upstream numpy.nan.
+            return float("nan")
+
+    @staticmethod
     def _normalize_ohlc_bar(
         *,
         date: str,
-        open: float | str | int,
-        high: float | str | int,
-        low: float | str | int,
-        close: float | str | int,
-        volume: float | str | int,
+        open: float | str | int | None,
+        high: float | str | int | None,
+        low: float | str | int | None,
+        close: float | str | int | None,
+        volume: float | str | int | None,
     ) -> Tuple[Optional[OHLCVBar], bool]:
         """Round, finite-check, and H/L-envelope-repair a single OHLC row.
 
@@ -873,12 +906,14 @@ class MarketDataService:
 
         Preconditions:
             ``open``/``high``/``low``/``close``/``volume`` are raw provider
-            values coercible by ``float(...)`` — numeric, or numeric strings
-            such as the JSON values Twelve Data and Alpha Vantage return. This
-            helper owns the coercion and rounding to 4 dp; callers pass the
-            extracted values through verbatim. A value that is ``None`` or a
+            values — numeric, numeric strings (such as the JSON values Twelve
+            Data and Alpha Vantage return), or a missing-value sentinel (``None``
+            / pandas ``NA``). This helper owns the coercion and rounding to 4 dp;
+            callers pass the extracted values through verbatim. A missing-value
+            sentinel is treated as a non-finite value (the row is forward-filled
+            or dropped, like an upstream ``numpy.nan``); only a genuinely
             non-numeric string is a caller (precondition) bug and surfaces as a
-            ``TypeError``/``ValueError`` rather than being silently coerced.
+            ``ValueError`` rather than being silently coerced.
 
         Postconditions:
             Returns ``(None, False)`` when any of O/H/L/C is non-finite (the
@@ -890,10 +925,10 @@ class MarketDataService:
             zero-volume sentinel ADV/liquidity math already excludes), logged
             at WARNING.
         """
-        o = round(float(open), 4)
-        h = round(float(high), 4)
-        ll = round(float(low), 4)
-        c = round(float(close), 4)
+        o = round(MarketDataService._coerce_finite_or_nan(open), 4)
+        h = round(MarketDataService._coerce_finite_or_nan(high), 4)
+        ll = round(MarketDataService._coerce_finite_or_nan(low), 4)
+        c = round(MarketDataService._coerce_finite_or_nan(close), 4)
         if not (math.isfinite(o) and math.isfinite(h) and math.isfinite(ll) and math.isfinite(c)):
             return (None, False)
         # Volume can be non-finite (NaN on early-listing/low-liquidity sessions)
@@ -901,7 +936,7 @@ class MarketDataService:
         # index OHLC positionally — and neutralise only the volume to 0.0, which
         # ADV/liquidity math already excludes via its ``volume > 0`` filter.
         # Dropping the whole row would discard valid price data.
-        v = float(volume)
+        v = MarketDataService._coerce_finite_or_nan(volume)
         if not math.isfinite(v):
             logger.warning("non-finite volume %r on %s bar; coercing to 0.0", volume, date)
             v = 0.0

--- a/backend/agents/investment_team/tests/test_market_data_service.py
+++ b/backend/agents/investment_team/tests/test_market_data_service.py
@@ -401,6 +401,161 @@ def test_df_to_bars_finite_ohlc_nan_volume_kept() -> None:
     assert all(math.isfinite(b.volume) for b in bars)
 
 
+class _MockRow:
+    """Minimal stand-in for a pandas row: ``row[key]`` + ``row.get(key, default)``."""
+
+    def __init__(self, data: Dict[str, Any]) -> None:
+        self._d = data
+
+    def __getitem__(self, key: str) -> Any:
+        return self._d[key]
+
+    def get(self, key: str, default: Any = 0.0) -> Any:
+        return self._d.get(key, default)
+
+
+class _MockIndex:
+    def __init__(self, label: str) -> None:
+        self._label = label
+
+    def strftime(self, fmt: str) -> str:  # noqa: ARG002 — accept arbitrary fmt
+        return self._label
+
+
+class _MockDF:
+    def __init__(self, rows: List[Tuple[_MockIndex, _MockRow]]) -> None:
+        self._rows = rows
+
+    def iterrows(self):
+        return iter(self._rows)
+
+
+def test_df_to_bars_none_ohlc_forward_filled() -> None:
+    """A ``None`` in an OHLC column is a missing-value gap, not a crash.
+
+    Object/nullable dtypes (a pyarrow-backed yfinance frame, a transient
+    object-dtype column, or a hand-built adapter frame) carry ``None`` rather
+    than ``numpy.nan``. ``float(None)`` raises ``TypeError``; left unguarded it
+    aborts the whole fetch. It must instead forward-fill like an upstream NaN.
+    """
+    rows = [
+        (
+            _MockIndex("2024-01-01"),
+            _MockRow({"Open": 100, "High": 101, "Low": 99, "Close": 100, "Volume": 1000}),
+        ),
+        # None Close — non-finite gap, forward-filled from the prior close.
+        (
+            _MockIndex("2024-01-02"),
+            _MockRow({"Open": 100, "High": 101, "Low": 99, "Close": None, "Volume": 1000}),
+        ),
+        (
+            _MockIndex("2024-01-03"),
+            _MockRow({"Open": 102, "High": 103, "Low": 101, "Close": 102, "Volume": 2000}),
+        ),
+    ]
+    bars = MarketDataService._df_to_bars(_MockDF(rows))
+    assert [b.date for b in bars] == ["2024-01-01", "2024-01-02", "2024-01-03"]
+    assert [b.is_imputed for b in bars] == [False, True, False]
+    # Imputed bar carries the prior valid close (100) as a flat, zero-volume bar.
+    assert bars[1].open == bars[1].high == bars[1].low == bars[1].close == 100
+    assert bars[1].volume == 0.0
+    assert all(
+        math.isfinite(b.open)
+        and math.isfinite(b.high)
+        and math.isfinite(b.low)
+        and math.isfinite(b.close)
+        for b in bars
+    )
+
+
+def test_df_to_bars_pd_na_ohlc_forward_filled() -> None:
+    """A pandas ``NA`` in an OHLC column forward-fills identically to ``None``.
+
+    This is the nullable/pyarrow-dtype migration scenario: ``float(pd.NA)``
+    raises ``TypeError`` exactly like ``float(None)``.
+    """
+    pd = pytest.importorskip("pandas")
+    rows = [
+        (
+            _MockIndex("2024-01-01"),
+            _MockRow({"Open": 100, "High": 101, "Low": 99, "Close": 100, "Volume": 1000}),
+        ),
+        # pd.NA Open — non-finite gap, forward-filled.
+        (
+            _MockIndex("2024-01-02"),
+            _MockRow({"Open": pd.NA, "High": 101, "Low": 99, "Close": 100, "Volume": 1000}),
+        ),
+        (
+            _MockIndex("2024-01-03"),
+            _MockRow({"Open": 102, "High": 103, "Low": 101, "Close": 102, "Volume": 2000}),
+        ),
+    ]
+    bars = MarketDataService._df_to_bars(_MockDF(rows))
+    assert [b.date for b in bars] == ["2024-01-01", "2024-01-02", "2024-01-03"]
+    assert [b.is_imputed for b in bars] == [False, True, False]
+    assert bars[1].open == bars[1].high == bars[1].low == bars[1].close == 100
+    assert bars[1].volume == 0.0
+
+
+def test_df_to_bars_none_volume_kept() -> None:
+    """Finite OHLC with a ``None`` volume keeps the real price bar; volume → 0.0.
+
+    Mirrors the NaN-volume case — a missing volume must not drop the bar, since
+    indicators index OHLC positionally.
+    """
+    rows = [
+        (
+            _MockIndex("2024-01-01"),
+            _MockRow({"Open": 100, "High": 101, "Low": 99, "Close": 100, "Volume": 1000}),
+        ),
+        # Finite OHLC, None volume — kept as a real bar with volume coerced to 0.0.
+        (
+            _MockIndex("2024-01-02"),
+            _MockRow({"Open": 102, "High": 103, "Low": 101, "Close": 102, "Volume": None}),
+        ),
+    ]
+    bars = MarketDataService._df_to_bars(_MockDF(rows))
+    assert [b.date for b in bars] == ["2024-01-01", "2024-01-02"]
+    assert bars[1].is_imputed is False
+    assert (bars[1].open, bars[1].high, bars[1].low, bars[1].close) == (102, 103, 101, 102)
+    assert bars[1].volume == 0.0
+    assert all(math.isfinite(b.volume) for b in bars)
+
+
+def test_fetch_yahoo_conversion_error_returns_empty(
+    monkeypatch: pytest.MonkeyPatch, caplog
+) -> None:
+    """A conversion error on a non-empty frame degrades to ``[]`` — never aborts.
+
+    Defense in depth: the price-data fetch must fall through to the next
+    provider rather than propagating an unexpected error from frame conversion.
+    """
+
+    class _DF:
+        empty = False
+
+        def iterrows(self):
+            raise RuntimeError("boom")
+
+    class _Ticker:
+        def __init__(self, sym):
+            self.sym = sym
+
+        def history(self, **kwargs):
+            return _DF()
+
+    fake_yf = types.ModuleType("yfinance")
+    fake_yf.Ticker = _Ticker  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "yfinance", fake_yf)
+
+    with caplog.at_level("WARNING"):
+        bars = MarketDataService()._fetch_yahoo(
+            "AAA", "stocks", "2024-01-01", "2024-01-31", max_retries=1
+        )
+    assert bars == []
+    assert any("failed to convert yfinance frame" in r.message for r in caplog.records)
+
+
 def test_df_to_bars_falls_back_when_index_has_no_strftime() -> None:
     """Indexes without strftime are stringified and truncated to 10 chars."""
 
@@ -983,6 +1138,55 @@ def test_normalize_ohlc_bar_coerces_nonfinite_volume(bad_volume: float, caplog) 
     assert any(
         "non-finite volume" in r.message and "2024-01-02" in r.message for r in caplog.records
     )
+
+
+def _missing_sentinels() -> List[Any]:
+    """``None`` plus pandas ``NA`` when pandas is importable."""
+    sentinels: List[Any] = [None]
+    try:
+        import pandas as pd
+
+        sentinels.append(pd.NA)
+    except ImportError:  # pragma: no cover - pandas is a transitive dep
+        pass
+    return sentinels
+
+
+@pytest.mark.parametrize("sentinel", _missing_sentinels())
+def test_normalize_ohlc_bar_missing_ohlc_is_dropped(sentinel: Any) -> None:
+    """A missing-value sentinel (``None`` / ``pd.NA``) in OHLC → ``(None, False)``.
+
+    The row is reported as a non-finite gap (the caller forward-fills/drops it)
+    rather than raising ``TypeError`` from ``float(sentinel)``.
+    """
+    bar, repaired = MarketDataService._normalize_ohlc_bar(
+        date="2024-01-02", open=sentinel, high=1.5, low=0.5, close=1.2, volume=10.0
+    )
+    assert bar is None
+    assert repaired is False
+
+
+@pytest.mark.parametrize("sentinel", _missing_sentinels())
+def test_normalize_ohlc_bar_missing_volume_coerced(sentinel: Any) -> None:
+    """A missing-value sentinel volume with finite OHLC keeps the bar; volume → 0.0."""
+    bar, repaired = MarketDataService._normalize_ohlc_bar(
+        date="2024-01-02", open=1.0, high=1.5, low=0.5, close=1.2, volume=sentinel
+    )
+    assert bar is not None
+    assert bar.volume == 0.0
+    assert math.isfinite(bar.volume)
+
+
+def test_normalize_ohlc_bar_malformed_string_still_raises() -> None:
+    """A genuinely non-numeric string is still a caller bug → ``ValueError``.
+
+    Only missing-value sentinels (TypeError on ``float()``) are tolerated; a
+    malformed numeric string raises ``ValueError`` and must propagate.
+    """
+    with pytest.raises(ValueError):
+        MarketDataService._normalize_ohlc_bar(
+            date="2024-01-02", open="abc", high=1.5, low=0.5, close=1.2, volume=10.0
+        )
 
 
 def test_fetch_alphavantage_crypto_branch(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/agents/investment_team/tests/test_market_data_service.py
+++ b/backend/agents/investment_team/tests/test_market_data_service.py
@@ -1189,6 +1189,22 @@ def test_normalize_ohlc_bar_malformed_string_still_raises() -> None:
         )
 
 
+@pytest.mark.parametrize("malformed", [{"a": 1}, [1, 2], object()])
+def test_normalize_ohlc_bar_malformed_non_scalar_still_raises(malformed: Any) -> None:
+    """A malformed non-scalar cell is a data defect, not a missing value.
+
+    ``float()`` raises ``TypeError`` for a dict/list/object just like it does
+    for ``None``/``pd.NA``, but only the explicit missing sentinels may be
+    mapped to NaN. A malformed value must propagate so the provider fails and
+    the fetch chain falls back, rather than being silently forward-filled as a
+    fabricated price.
+    """
+    with pytest.raises(TypeError):
+        MarketDataService._normalize_ohlc_bar(
+            date="2024-01-02", open=malformed, high=1.5, low=0.5, close=1.2, volume=10.0
+        )
+
+
 def test_fetch_alphavantage_crypto_branch(monkeypatch: pytest.MonkeyPatch) -> None:
     import investment_team.market_data_service as mds
 


### PR DESCRIPTION
## Problem

`MarketDataService._normalize_ohlc_bar` coerced each OHLC value with `round(float(open), 4)` **before** the `math.isfinite()` guard ran. `float(numpy.nan)` returns `nan` (handled fine by the finite check → forward-fill), but `float(None)` and `float(pd.NA)` both raise `TypeError`.

As a result the NaN/forward-fill machinery only worked for the `float64` dtype yfinance happens to emit today. The moment a column carried a nullable/object dtype — yfinance's pyarrow backend, a transient object-dtype hiccup, or a hand-built test/adapter DataFrame — the `TypeError` escaped. Worse, the Yahoo provider's `return self._df_to_bars(df)` sits **outside** the `try/except` wrapping `ticker.history()`, so the error propagated uncaught and aborted the **entire** market-data fetch — silently killing any Strategy Lab backtest depending on that data.

## Fix

- **Add `_coerce_finite_or_nan`** — maps missing-value sentinels (`None` / `pd.NA`, whose `float()` raises `TypeError`) to `nan` so the existing forward-fill/drop path handles them exactly like an upstream `numpy.nan`. A genuinely malformed numeric string raises `ValueError` and still propagates, preserving the documented caller-bug contract.
- **Route all five OHLC + volume values** through the helper in `_normalize_ohlc_bar`. This single change covers **all** providers (Yahoo, Twelve Data, CoinGecko, Alpha Vantage), since each calls `_normalize_ohlc_bar` directly.
- **Update the `_normalize_ohlc_bar` precondition docstring** to reflect that missing-value sentinels are now tolerated (treated as a non-finite gap); only non-numeric strings remain a caller bug.
- **Defense in depth** — wrap the Yahoo `_df_to_bars` conversion so any unexpected frame error degrades to an empty result (the caller falls through to the next provider) instead of propagating. Kept outside the network-retry loop so a conversion error does not trigger a retry.

## Tests

Added to `test_market_data_service.py`, mirroring the existing object-based DataFrame mock style:

- `_df_to_bars` with `None` and with `pd.NA` in an OHLC column → forward-filled (not a crash).
- `None` volume with finite OHLC → bar kept, volume coerced to `0.0`.
- `_normalize_ohlc_bar` parametrized over `None`/`pd.NA`: OHLC sentinel → `(None, False)`; volume sentinel → `volume == 0.0`.
- Malformed string (`open="abc"`) still raises `ValueError`.
- `_fetch_yahoo` conversion-error guard returns `[]` and logs a warning rather than propagating.

## Verification

```
python -m pytest agents/investment_team/tests/test_market_data_service.py -q   # 82 passed
ruff check / ruff format --check                                               # clean
```

Closes #681


---
_Generated by [Claude Code](https://claude.ai/code/session_013SRecRGR337e4RQ9fDAfuF)_