### PR TITLE
Fix coding-team re-implementation/re-planning loop

### DIFF
--- a/backend/agents/coding_team/orchestrator.py
+++ b/backend/agents/coding_team/orchestrator.py
@@ -49,6 +49,11 @@ def _read_repo_context(repo_path: Path, max_chars: int = 4000) -> str:
                 ".json",
                 ".yaml",
                 ".yml",
+                # Markdown/plain-text docs (specs, plans, READMEs) must be visible too, or a worker
+                # tasked with documentation reports the repo "empty" and recreates docs every round.
+                ".md",
+                ".txt",
+                ".rst",
             }:
                 continue
             if any(
@@ -108,20 +113,41 @@ def run_coding_team_orchestrator(
     phase = "task_graph"
     status_text = "Building task graph from plan"
 
-    # Tech Lead: plan → tasks + stacks
+    # The Tech Lead object is needed for the swarm coordinator (assignments/reviews) regardless of
+    # whether we plan fresh or resume, so build it unconditionally.
     llm = llm_getter("tech_lead")
     tech_lead = TechLeadAgent(llm)
-    out = tech_lead.run_plan_to_task_graph(plan_input)
-    tasks_raw = out.get("tasks") or []
-    stacks_raw = out.get("stacks") or [{"name": "default", "tools_services": []}]
 
-    for t in tasks_raw:
-        graph.add_task(
-            task_id=t["id"],
-            title=t.get("title", t["id"]),
-            description=t.get("description", ""),
-            dependencies=t.get("dependencies", []),
+    # Resume from a persisted snapshot (e.g. a Temporal retry of the same job_id) instead of
+    # re-running the planning LLM and re-doing finished work. `_persist_graph` writes the task
+    # snapshot every round; the stacks are persisted alongside it on the fresh path below.
+    existing = _get_job(job_id) or {}
+    snapshot_tasks = existing.get("task_graph_snapshot") or []
+    if snapshot_tasks:
+        logger.info("Resuming job %s from snapshot (%d tasks)", job_id, len(snapshot_tasks))
+        graph.restore(
+            {
+                "tasks": snapshot_tasks,
+                "agent_task_map": existing.get("agent_task_map") or {},
+            }
         )
+        # In-flight tasks from the dead attempt may be half-done and their agent mapping is stale,
+        # so demote them to unassigned TO_DO; MERGED/FAILED are preserved (no re-work).
+        graph.reset_in_flight()
+        stacks_raw = existing.get("stack_specs") or [{"name": "default", "tools_services": []}]
+    else:
+        out = tech_lead.run_plan_to_task_graph(plan_input)
+        tasks_raw = out.get("tasks") or []
+        stacks_raw = out.get("stacks") or [{"name": "default", "tools_services": []}]
+        for t in tasks_raw:
+            graph.add_task(
+                task_id=t["id"],
+                title=t.get("title", t["id"]),
+                description=t.get("description", ""),
+                dependencies=t.get("dependencies", []),
+            )
+        # Persist the stacks so a later retry can rebuild the workers without re-planning.
+        _update(stack_specs=stacks_raw)
     _persist_graph()
 
     # Build Senior SWE agents (one per stack)
@@ -223,6 +249,12 @@ class CodingTeamSwarm:
         """Worker implements its assigned task, then runs quality gate tools."""
         task = self.graph.get_task_for_agent(swe.agent_id)
         if not task:
+            return
+        # Only (re)implement a task that is actively assigned for work. An IN_REVIEW task is awaiting
+        # Tech Lead review — re-running the engineer on it would regenerate code already under review
+        # and churn the loop. With un-assignment fixed this is belt-and-suspenders, but it makes the
+        # worker's contract explicit and robust against any upstream assignment slip.
+        if task.status != TaskStatus.IN_PROGRESS:
             return
 
         update_fn(status_text=f"Implementing: {task.title}")
@@ -340,10 +372,13 @@ class CodingTeamSwarm:
         self.graph.update_task(
             task.id,
             status=TaskStatus.TO_DO,
-            assigned_agent_id=None,
             revision_count=revision_count,
             revision_feedback=list(task.revision_feedback or []) + list(feedback),
         )
+        # `update_task` ignores assigned_agent_id=None by design, so clear the assignment explicitly:
+        # the task must be genuinely unassigned (and the agent freed) before the next round, or it
+        # stays mapped to its agent and can be double-assigned.
+        self.graph.unassign_task(task.id)
         return False
 
     def _review_and_merge(self, update_fn: Callable) -> None:
@@ -486,6 +521,11 @@ class CodingTeamSwarm:
             if check_cancel and check_cancel():
                 _update(status="cancelled", status_text="Cancelled by user")
                 return
+
+            # Refresh the repo context each round so the implement prompt reflects files written in
+            # prior rounds (specs, plans, code). A one-time snapshot taken at construction makes a
+            # worker blind to earlier work and recreate it.
+            self.repo_context = _read_repo_context(self.path)
 
             # Coordinator: assign ready tasks to free workers
             ready = self._find_ready_tasks()

--- a/backend/agents/coding_team/orchestrator.py
+++ b/backend/agents/coding_team/orchestrator.py
@@ -9,6 +9,7 @@ Exposes run_coding_team_orchestrator for in-process call from software_engineeri
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -31,6 +32,46 @@ logger = logging.getLogger(__name__)
 
 CANCEL_KEY = "cancel_requested"
 MAX_TASK_REVISIONS = 20  # max times a task can be returned for revision before accepting
+
+# Upper bound on Tech Lead review evidence (summary + diff). A correct-but-large diff must not
+# deterministically overflow the reviewer's context and fail an otherwise-good task (cascading to
+# its dependents). Generous enough to pass realistic diffs uncut; pathological diffs are truncated
+# with a marker so the reviewer sees partial — not absent — evidence. Override via
+# CODING_TEAM_REVIEW_EVIDENCE_MAX_CHARS.
+_DEFAULT_REVIEW_EVIDENCE_MAX_CHARS = 50000
+
+
+def _review_evidence_max_chars() -> int:
+    """Evidence cap for Tech Lead review; env override, garbage/non-positive → default."""
+    raw = os.getenv("CODING_TEAM_REVIEW_EVIDENCE_MAX_CHARS", "")
+    try:
+        val = int(raw)
+        return val if val > 0 else _DEFAULT_REVIEW_EVIDENCE_MAX_CHARS
+    except (TypeError, ValueError):
+        return _DEFAULT_REVIEW_EVIDENCE_MAX_CHARS
+
+
+def _build_review_evidence(summary: str, diff: str, max_chars: int) -> str:
+    """Assemble review evidence (summary + diff) bounded to *max_chars*.
+
+    Keeps the full summary (the most important signal) and appends as much of the diff as fits,
+    marking any truncation so the reviewer knows the evidence is partial rather than absent. A huge
+    diff is thereby truncated instead of overflowing the model context and failing the task.
+
+    Preconditions: max_chars > 0.
+    Postconditions: len(result) <= max_chars (modulo a short truncation marker).
+    """
+    assert max_chars > 0, "max_chars must be positive"
+    if not diff:
+        return summary[:max_chars]
+    header = "\n\n--- DIFF ---\n"
+    marker = "\n... [diff truncated for review context] ..."
+    budget = max_chars - len(summary) - len(header)
+    if budget <= 0:
+        return summary[:max_chars]
+    if len(diff) <= budget:
+        return summary + header + diff
+    return summary + header + diff[: max(0, budget - len(marker))] + marker
 
 # Repo-context file selection. The shared full-stack code extensions / exclude dirs live in
 # software_engineering_team.shared.repo_utils; this summariser additionally surfaces the doc and
@@ -308,28 +349,42 @@ class CodingTeamSwarm:
                 changes_summary=result.get("changes_summary"),
             )
             self.graph.set_task_in_review(task.id)
-        elif result.get("status") == "failed":
-            logger.warning("Worker %s task %s failed: %s", swe.agent_id, task.id, result.get("error"))
-            self._handle_implement_failure(task, result)
+        else:
+            # Any non-review outcome — status="failed" (the LLM call raised) or status="in_progress"
+            # (the model set ready_for_review=false / asked for another pass) or any unexpected
+            # status — must be bounded. Otherwise the task stays IN_PROGRESS and assigned, its
+            # revision_count never advances, and the same full implement call repeats every round to
+            # the round cap, after which the task is neither MERGED nor FAILED and the job is reported
+            # a clean success despite incomplete work.
+            logger.warning(
+                "Worker %s task %s did not reach review (status=%s): %s",
+                swe.agent_id, task.id, result.get("status"), result.get("error"),
+            )
+            self._handle_incomplete_implementation(task, result)
 
-    def _handle_implement_failure(self, task: Task, result: Dict[str, Any]) -> None:
-        """Bound a failing implementation so it cannot spin the loop to max_rounds.
+    def _handle_incomplete_implementation(self, task: Task, result: Dict[str, Any]) -> None:
+        """Bound an implementation that did not reach review so it cannot spin the loop to max_rounds.
 
-        A `run_implement` that returns status="failed" (e.g. the LLM call raised) was previously
-        only logged, leaving the task IN_PROGRESS and assigned — so the same failing call repeated
-        every round until the round cap. Count each failure against the shared revision cap and,
-        on exhaustion, fail the task (and its dependents) terminally with the error recorded.
+        Covers both status="failed" (e.g. the LLM call raised) and status="in_progress" (the model
+        set ready_for_review=false). Previously only "failed" was handled and "in_progress" was
+        dropped entirely, leaving the task IN_PROGRESS and assigned — so the same call repeated every
+        round until the round cap. Count each occurrence against the shared revision cap and, on
+        exhaustion, fail the task (and its dependents) terminally with the reason recorded.
         """
+        if result.get("status") == "in_progress":
+            reason = "Engineer did not mark the work ready for review"
+        else:
+            reason = f"Implementation failed: {result.get('error') or 'unknown error'}"
         entry = {
             "source": "engineer",
-            "reason": f"Implementation failed: {result.get('error') or 'unknown error'}",
+            "reason": reason,
             "requested_changes": [],
         }
         feedback = list(task.revision_feedback or []) + [entry]
         revision_count = task.revision_count + 1
         if revision_count >= MAX_TASK_REVISIONS:
             logger.warning(
-                "Task %s implementation failed and exhausted revisions (%d); marking FAILED",
+                "Task %s did not reach review and exhausted revisions (%d); marking FAILED",
                 task.id, MAX_TASK_REVISIONS,
             )
             self.graph.update_task(
@@ -340,7 +395,7 @@ class CodingTeamSwarm:
             )
             self._cascade_fail_dependents(task.id)
             return
-        # Keep it with the same engineer for another bounded attempt; record the failure.
+        # Keep it with the same engineer for another bounded attempt; record the reason.
         self.graph.update_task(
             task.id,
             status=TaskStatus.IN_PROGRESS,
@@ -432,7 +487,7 @@ class CodingTeamSwarm:
             branch = task.feature_branch or f"feature/{task.id}"
             summary = task.changes_summary or "(no summary recorded)"
             diff = branch_diff(self.path, DEVELOPMENT_BRANCH, branch)
-            evidence = summary + (f"\n\n--- DIFF ---\n{diff}" if diff else "")
+            evidence = _build_review_evidence(summary, diff, _review_evidence_max_chars())
             review = self.tech_lead.run_code_review(
                 task_title=task.title,
                 task_description=task.description,

--- a/backend/agents/coding_team/orchestrator.py
+++ b/backend/agents/coding_team/orchestrator.py
@@ -16,7 +16,6 @@ from coding_team.job_store import (
     DEFAULT_CACHE_DIR,
     get_job,
     update_job,
-    update_job_task_graph,
 )
 from coding_team.models import (
     CodingTeamPlanInput,
@@ -33,32 +32,36 @@ logger = logging.getLogger(__name__)
 CANCEL_KEY = "cancel_requested"
 MAX_TASK_REVISIONS = 20  # max times a task can be returned for revision before accepting
 
+# Repo-context file selection. The shared full-stack code extensions / exclude dirs live in
+# software_engineering_team.shared.repo_utils; this summariser additionally surfaces the doc and
+# config formats below (so a docs/spec task is not blind to specs, plans, and READMEs) and skips a
+# few extra interpreter/venv caches. Built from the shared constants in `_read_repo_context` to
+# avoid re-listing the canonical sets here.
+_CONTEXT_EXTRA_EXTENSIONS: frozenset[str] = frozenset(
+    {".js", ".html", ".json", ".md", ".txt", ".rst"}
+)
+_CONTEXT_EXTRA_EXCLUDE_DIRS: frozenset[str] = frozenset({"__pycache__", "venv", ".venv"})
+
 
 def _read_repo_context(repo_path: Path, max_chars: int = 4000) -> str:
     """Read a short summary of repo structure/code for Senior SWE context."""
+    from software_engineering_team.shared.repo_utils import (
+        FULL_STACK_EXTENSIONS,
+        REPO_EXCLUDE_DIRS,
+    )
+
+    # Reuse the shared full-stack code extensions / exclude dirs, plus this summariser's doc/config
+    # extras — so adding a code file type in one place keeps every repo scanner consistent.
+    extensions = frozenset(FULL_STACK_EXTENSIONS) | _CONTEXT_EXTRA_EXTENSIONS
+    exclude_dirs = REPO_EXCLUDE_DIRS | _CONTEXT_EXTRA_EXCLUDE_DIRS
+
     parts: List[str] = []
     total = 0
     try:
         for f in sorted(repo_path.rglob("*"))[:80]:
-            if not f.is_file() or f.suffix not in {
-                ".py",
-                ".ts",
-                ".js",
-                ".java",
-                ".html",
-                ".json",
-                ".yaml",
-                ".yml",
-                # Markdown/plain-text docs (specs, plans, READMEs) must be visible too, or a worker
-                # tasked with documentation reports the repo "empty" and recreates docs every round.
-                ".md",
-                ".txt",
-                ".rst",
-            }:
+            if not f.is_file() or f.suffix not in extensions:
                 continue
-            if any(
-                skip in f.parts for skip in ("node_modules", ".git", "__pycache__", "venv", ".venv")
-            ):
+            if any(skip in f.parts for skip in exclude_dirs):
                 continue
             try:
                 content = f.read_text(encoding="utf-8", errors="replace")[:500]
@@ -105,9 +108,19 @@ def run_coding_team_orchestrator(
 
     # Create Task Graph with persist
     def _persist_graph() -> None:
+        # Persist the snapshot through the SAME store used for the resume read and cancel checks
+        # (the injected update_job_fn). On the software-engineering path that is the SE job record;
+        # the hardcoded coding_team store targets a record that is never created on that path, so
+        # the central job service's UPDATE-WHERE matches no row and the write — hence resume — is
+        # silently lost. The standalone coding_team path's default callback writes the same keys to
+        # the coding_team record exactly as before.
         snap = graph.snapshot()
-        update_job_task_graph(job_id, snap, cache_dir=cache_dir)
-        _update(phase=phase, status_text=status_text)
+        _update(
+            task_graph_snapshot=snap["tasks"],
+            agent_task_map=snap["agent_task_map"],
+            phase=phase,
+            status_text=status_text,
+        )
 
     graph: TaskGraphService = create_task_graph(job_id, persist_callback=_persist_graph)
     phase = "task_graph"
@@ -217,6 +230,12 @@ class CodingTeamSwarm:
         self.agent_ids = agent_ids
         self.llm_getter = llm_getter
         self.repo_context = _read_repo_context(path)
+        # Repo context only changes when merged work lands new files on the working tree, so cache
+        # the merged-task count the context reflects and re-read only when it advances (see run()).
+        self._context_merged_count = self._merged_count()
+
+    def _merged_count(self) -> int:
+        return sum(1 for t in self.graph.get_tasks() if t.status == TaskStatus.MERGED)
 
     def _find_ready_tasks(self) -> List[Task]:
         return [
@@ -522,10 +541,15 @@ class CodingTeamSwarm:
                 _update(status="cancelled", status_text="Cancelled by user")
                 return
 
-            # Refresh the repo context each round so the implement prompt reflects files written in
-            # prior rounds (specs, plans, code). A one-time snapshot taken at construction makes a
-            # worker blind to earlier work and recreate it.
-            self.repo_context = _read_repo_context(self.path)
+            # Refresh the repo context when merged work has landed since the last read, so the
+            # implement prompt reflects files written in prior rounds (specs, plans, code) without
+            # paying for a full repo walk on every idle round (e.g. while tasks sit in review or
+            # blocked). A one-time snapshot taken at construction would make a worker blind to
+            # earlier work and recreate it.
+            merged_now = self._merged_count()
+            if merged_now != self._context_merged_count:
+                self.repo_context = _read_repo_context(self.path)
+                self._context_merged_count = merged_now
 
             # Coordinator: assign ready tasks to free workers
             ready = self._find_ready_tasks()

--- a/backend/agents/coding_team/orchestrator.py
+++ b/backend/agents/coding_team/orchestrator.py
@@ -42,18 +42,37 @@ _CONTEXT_EXTRA_EXTENSIONS: frozenset[str] = frozenset(
 )
 _CONTEXT_EXTRA_EXCLUDE_DIRS: frozenset[str] = frozenset({"__pycache__", "venv", ".venv"})
 
+# Fallback stack when planning/snapshot provide none (one Senior SWE on a generic stack).
+_DEFAULT_STACK_SPECS: List[Dict[str, Any]] = [{"name": "default", "tools_services": []}]
+
+# Full file-selection sets for repo-context scanning, built once from the shared repo_utils
+# constants + the extras above and cached (the import lives below to keep the SE dependency
+# function-level; the sets are static so there is no need to rebuild them on every call).
+_CONTEXT_EXTENSIONS: Optional[frozenset[str]] = None
+_CONTEXT_EXCLUDE_DIRS: Optional[frozenset[str]] = None
+
+
+def _context_file_filters() -> tuple[frozenset[str], frozenset[str]]:
+    """Return (extensions, exclude_dirs) for repo-context scanning, computed once and cached.
+
+    Reuses the shared full-stack code extensions / exclude dirs (so adding a code file type in one
+    place keeps every repo scanner consistent), unioned with this summariser's doc/config extras.
+    """
+    global _CONTEXT_EXTENSIONS, _CONTEXT_EXCLUDE_DIRS
+    if _CONTEXT_EXTENSIONS is None or _CONTEXT_EXCLUDE_DIRS is None:
+        from software_engineering_team.shared.repo_utils import (
+            FULL_STACK_EXTENSIONS,
+            REPO_EXCLUDE_DIRS,
+        )
+
+        _CONTEXT_EXTENSIONS = frozenset(FULL_STACK_EXTENSIONS) | _CONTEXT_EXTRA_EXTENSIONS
+        _CONTEXT_EXCLUDE_DIRS = REPO_EXCLUDE_DIRS | _CONTEXT_EXTRA_EXCLUDE_DIRS
+    return _CONTEXT_EXTENSIONS, _CONTEXT_EXCLUDE_DIRS
+
 
 def _read_repo_context(repo_path: Path, max_chars: int = 4000) -> str:
     """Read a short summary of repo structure/code for Senior SWE context."""
-    from software_engineering_team.shared.repo_utils import (
-        FULL_STACK_EXTENSIONS,
-        REPO_EXCLUDE_DIRS,
-    )
-
-    # Reuse the shared full-stack code extensions / exclude dirs, plus this summariser's doc/config
-    # extras — so adding a code file type in one place keeps every repo scanner consistent.
-    extensions = frozenset(FULL_STACK_EXTENSIONS) | _CONTEXT_EXTRA_EXTENSIONS
-    exclude_dirs = REPO_EXCLUDE_DIRS | _CONTEXT_EXTRA_EXCLUDE_DIRS
+    extensions, exclude_dirs = _context_file_filters()
 
     parts: List[str] = []
     total = 0
@@ -147,11 +166,11 @@ def run_coding_team_orchestrator(
         # In-flight tasks from the dead attempt may be half-done and their agent mapping is stale,
         # so demote them to unassigned TO_DO; MERGED/FAILED are preserved (no re-work).
         graph.reset_in_flight()
-        stacks_raw = existing.get("stack_specs") or [{"name": "default", "tools_services": []}]
+        stacks_raw = existing.get("stack_specs") or _DEFAULT_STACK_SPECS
     else:
         out = tech_lead.run_plan_to_task_graph(plan_input)
         tasks_raw = out.get("tasks") or []
-        stacks_raw = out.get("stacks") or [{"name": "default", "tools_services": []}]
+        stacks_raw = out.get("stacks") or _DEFAULT_STACK_SPECS
         for t in tasks_raw:
             graph.add_task(
                 task_id=t["id"],
@@ -195,8 +214,8 @@ def run_coding_team_orchestrator(
         update_fn=_update,
     )
 
-    merged_count = sum(1 for t in graph.get_tasks() if t.status == TaskStatus.MERGED)
-    failed_count = sum(1 for t in graph.get_tasks() if t.status == TaskStatus.FAILED)
+    merged_count = graph.count_with_status(TaskStatus.MERGED)
+    failed_count = graph.count_with_status(TaskStatus.FAILED)
     # A job with failed tasks must not be presented as a clean success — surface a distinct
     # terminal status so downstream consumers (and the GitHub publish flow) can flag the gap.
     _update(
@@ -235,7 +254,7 @@ class CodingTeamSwarm:
         self._context_merged_count = self._merged_count()
 
     def _merged_count(self) -> int:
-        return sum(1 for t in self.graph.get_tasks() if t.status == TaskStatus.MERGED)
+        return self.graph.count_with_status(TaskStatus.MERGED)
 
     def _find_ready_tasks(self) -> List[Task]:
         return [
@@ -394,9 +413,8 @@ class CodingTeamSwarm:
             revision_count=revision_count,
             revision_feedback=list(task.revision_feedback or []) + list(feedback),
         )
-        # `update_task` ignores assigned_agent_id=None by design, so clear the assignment explicitly:
-        # the task must be genuinely unassigned (and the agent freed) before the next round, or it
-        # stays mapped to its agent and can be double-assigned.
+        # Release the task before the next round (status went to TO_DO above): it must be genuinely
+        # unassigned and its agent freed, or it stays mapped to its agent and can be double-assigned.
         self.graph.unassign_task(task.id)
         return False
 
@@ -541,11 +559,13 @@ class CodingTeamSwarm:
                 _update(status="cancelled", status_text="Cancelled by user")
                 return
 
-            # Refresh the repo context when merged work has landed since the last read, so the
-            # implement prompt reflects files written in prior rounds (specs, plans, code) without
-            # paying for a full repo walk on every idle round (e.g. while tasks sit in review or
-            # blocked). A one-time snapshot taken at construction would make a worker blind to
-            # earlier work and recreate it.
+            # Refresh the repo context when merged work has landed since the last read. The merged
+            # count is the right signal here: a task's files become part of the shared/integrated
+            # tree only once it merges (work in progress lives on per-worker feature branches), and
+            # a dependent task is not assignable until its dependencies are MERGED — so it always
+            # sees its prerequisites' code. This avoids a full repo walk on every idle round (e.g.
+            # while tasks sit in review or blocked); a one-time snapshot at construction would make a
+            # worker blind to earlier merged work and recreate it.
             merged_now = self._merged_count()
             if merged_now != self._context_merged_count:
                 self.repo_context = _read_repo_context(self.path)

--- a/backend/agents/coding_team/senior_software_engineer_agent/agent.py
+++ b/backend/agents/coding_team/senior_software_engineer_agent/agent.py
@@ -21,6 +21,12 @@ from coding_team.senior_software_engineer_agent import prompts
 
 logger = logging.getLogger(__name__)
 
+# Upper bound on the task description embedded in the implement prompt. A pathologically large
+# description (e.g. a long issue body / accumulated spec) would otherwise deterministically overflow
+# the model context, and _handle_incomplete_implementation would then re-run the same overflowing
+# call up to MAX_TASK_REVISIONS times. Generous so realistic descriptions are passed in full.
+_IMPLEMENT_DESCRIPTION_MAX_CHARS = 16000
+
 
 def _parse_json_response(raw: str) -> Dict[str, Any]:
     """Parse a JSON response from an agent, stripping markdown fences if present."""
@@ -165,7 +171,7 @@ class SeniorSWEAgent:
             stack_name=stack_name,
             tools_services=tools_services,
             task_title=task.title,
-            task_description=task.description,
+            task_description=task.description[:_IMPLEMENT_DESCRIPTION_MAX_CHARS],
             acceptance_criteria=json.dumps(task.acceptance_criteria),
             repo_context=repo_context[:4000] or "No existing code context provided.",
         )

--- a/backend/agents/coding_team/task_graph.py
+++ b/backend/agents/coding_team/task_graph.py
@@ -109,6 +109,47 @@ class TaskGraphService:
         self._maybe_persist()
         return task
 
+    def unassign_task(self, task_id: str) -> None:
+        """Clear a task's agent assignment and release the agent that held it.
+
+        `update_task` deliberately ignores `assigned_agent_id=None` (its `is not None` guard lets
+        callers update other fields without clobbering the assignment), so clearing an assignment
+        needs its own entry point. Used when a quality-gate rejection demotes a task to TO_DO: the
+        task must become genuinely unassigned so a free agent can re-pick it and the old agent is
+        freed — otherwise the task is TO_DO yet still mapped to its agent, and the next round can
+        both re-serve it to that agent and assign it to a second free agent (two workers, one task).
+
+        Preconditions:
+            - `task_id` refers to a task tracked by this graph (no-op if it does not).
+        Postconditions:
+            - `task.assigned_agent_id is None` and no agent in `_agent_to_task` maps to `task_id`.
+        """
+        task = self._tasks.get(task_id)
+        if not task:
+            return
+        self._free_agent(task)  # uses task.assigned_agent_id — must run before we null it
+        task.assigned_agent_id = None
+        self._maybe_persist()
+
+    def reset_in_flight(self) -> None:
+        """Demote every non-terminal in-flight task to TO_DO and drop all agent assignments.
+
+        Used on resume from a persisted snapshot (e.g. a Temporal retry of the same job): a task
+        left IN_PROGRESS or IN_REVIEW when the previous attempt died may hold only partial work, and
+        its agent mapping refers to workers that no longer exist in this run. Demoting these to
+        unassigned TO_DO lets the fresh swarm re-plan and re-pick them deterministically. MERGED and
+        FAILED tasks (terminal) are left untouched.
+
+        Postconditions:
+            - No task is IN_PROGRESS or IN_REVIEW; `_agent_to_task` is empty.
+        """
+        for task in self._tasks.values():
+            if task.status in (TaskStatus.IN_PROGRESS, TaskStatus.IN_REVIEW):
+                task.status = TaskStatus.TO_DO
+                task.assigned_agent_id = None
+        self._agent_to_task.clear()
+        self._maybe_persist()
+
     def get_tasks(self) -> List[Task]:
         """Return all tasks (copy)."""
         return list(self._tasks.values())

--- a/backend/agents/coding_team/task_graph.py
+++ b/backend/agents/coding_team/task_graph.py
@@ -169,6 +169,10 @@ class TaskGraphService:
         """Return task by id."""
         return self._tasks.get(task_id)
 
+    def count_with_status(self, status: TaskStatus) -> int:
+        """Number of tasks currently in *status*. Single source of truth for status tallies."""
+        return sum(1 for t in self._tasks.values() if t.status == status)
+
     def _dependencies_satisfied(self, task_id: str) -> bool:
         """True if all dependency tasks are merged."""
         task = self._tasks.get(task_id)

--- a/backend/agents/coding_team/task_graph.py
+++ b/backend/agents/coding_team/task_graph.py
@@ -13,6 +13,11 @@ from coding_team.models import Task, TaskStatus
 
 logger = logging.getLogger(__name__)
 
+# Sentinel distinguishing "argument not supplied" from an explicit None in update_task, so a caller
+# can clear an assignment with assigned_agent_id=None without it being indistinguishable from the
+# default. None previously meant "leave untouched", which silently dropped clear requests.
+_UNSET: Any = object()
+
 
 class TaskGraphService:
     """
@@ -80,12 +85,18 @@ class TaskGraphService:
         self,
         task_id: str,
         status: Optional[TaskStatus] = None,
-        assigned_agent_id: Optional[str] = None,
+        assigned_agent_id: Any = _UNSET,
         feature_branch: Optional[str] = None,
         merged_at: Optional[datetime] = None,
         **kwargs: Any,
     ) -> Optional[Task]:
-        """Update task fields. Returns the task if found."""
+        """Update task fields. Returns the task if found.
+
+        Passing `assigned_agent_id=None` explicitly clears the assignment AND releases the agent
+        (equivalent to `unassign_task`); omitting it leaves the assignment untouched. Clearing must
+        free the agent->task mapping too — nulling only the back-reference would leave the agent
+        marked busy, which is the silent-no-op bug this sentinel design removes.
+        """
         task = self._tasks.get(task_id)
         if not task:
             return None
@@ -97,8 +108,12 @@ class TaskGraphService:
             # persisted right after the failure would still report the agent as occupied.
             if status == TaskStatus.FAILED:
                 self._free_agent(task)
-        if assigned_agent_id is not None:
-            task.assigned_agent_id = assigned_agent_id
+        if assigned_agent_id is not _UNSET:
+            if assigned_agent_id is None:
+                self._free_agent(task)  # uses task.assigned_agent_id — must run before we null it
+                task.assigned_agent_id = None
+            else:
+                task.assigned_agent_id = assigned_agent_id
         if feature_branch is not None:
             task.feature_branch = feature_branch
         if merged_at is not None:
@@ -112,42 +127,38 @@ class TaskGraphService:
     def unassign_task(self, task_id: str) -> None:
         """Clear a task's agent assignment and release the agent that held it.
 
-        `update_task` deliberately ignores `assigned_agent_id=None` (its `is not None` guard lets
-        callers update other fields without clobbering the assignment), so clearing an assignment
-        needs its own entry point. Used when a quality-gate rejection demotes a task to TO_DO: the
-        task must become genuinely unassigned so a free agent can re-pick it and the old agent is
-        freed — otherwise the task is TO_DO yet still mapped to its agent, and the next round can
-        both re-serve it to that agent and assign it to a second free agent (two workers, one task).
+        Thin wrapper over `update_task(task_id, assigned_agent_id=None)` for callers whose intent is
+        purely to release a task (e.g. a quality-gate rejection demoting it to TO_DO): the task must
+        become genuinely unassigned so a free agent can re-pick it and the old agent is freed —
+        otherwise the task is TO_DO yet still mapped to its agent, and the next round can both
+        re-serve it to that agent and assign it to a second free agent (two workers, one task).
 
         Preconditions:
             - `task_id` refers to a task tracked by this graph (no-op if it does not).
         Postconditions:
             - `task.assigned_agent_id is None` and no agent in `_agent_to_task` maps to `task_id`.
         """
-        task = self._tasks.get(task_id)
-        if not task:
-            return
-        self._free_agent(task)  # uses task.assigned_agent_id — must run before we null it
-        task.assigned_agent_id = None
-        self._maybe_persist()
+        self.update_task(task_id, assigned_agent_id=None)
 
     def reset_in_flight(self) -> None:
-        """Demote every non-terminal in-flight task to TO_DO and drop all agent assignments.
+        """Demote every non-terminal in-flight task to TO_DO and release its agent.
 
         Used on resume from a persisted snapshot (e.g. a Temporal retry of the same job): a task
         left IN_PROGRESS or IN_REVIEW when the previous attempt died may hold only partial work, and
         its agent mapping refers to workers that no longer exist in this run. Demoting these to
         unassigned TO_DO lets the fresh swarm re-plan and re-pick them deterministically. MERGED and
-        FAILED tasks (terminal) are left untouched.
+        FAILED tasks (terminal) are left untouched. Agent release routes through `_free_agent` (the
+        single place that maintains the agent->task mapping invariant) rather than clearing the map
+        directly, so the two stay consistent if that mapping ever gains structure.
 
         Postconditions:
-            - No task is IN_PROGRESS or IN_REVIEW; `_agent_to_task` is empty.
+            - No task is IN_PROGRESS or IN_REVIEW; no in-flight task retains an agent mapping.
         """
         for task in self._tasks.values():
             if task.status in (TaskStatus.IN_PROGRESS, TaskStatus.IN_REVIEW):
                 task.status = TaskStatus.TO_DO
+                self._free_agent(task)  # uses task.assigned_agent_id — must run before we null it
                 task.assigned_agent_id = None
-        self._agent_to_task.clear()
         self._maybe_persist()
 
     def get_tasks(self) -> List[Task]:

--- a/backend/agents/coding_team/tech_lead_agent/agent.py
+++ b/backend/agents/coding_team/tech_lead_agent/agent.py
@@ -8,15 +8,14 @@ from __future__ import annotations
 import json
 import logging
 import os
-import random
 import re
-import time
 from typing import Any, Dict, List
 
 from strands import Agent
 
 from coding_team.models import CodingTeamPlanInput
 from coding_team.tech_lead_agent import prompts
+from llm_service import call_llm_with_retries
 
 logger = logging.getLogger(__name__)
 
@@ -41,11 +40,6 @@ def _review_retry_attempts() -> int:
     if retries < 0:
         retries = 2
     return retries + 1
-
-
-def _review_backoff_seconds(attempt: int, base: float = 1.5, cap: float = 20.0) -> float:
-    """Jittered exponential backoff between review retries: min(base**attempt + U(0,0.5), cap)."""
-    return min(base**attempt + random.uniform(0.0, 0.5), cap)
 
 
 def _plan_text(plan: CodingTeamPlanInput) -> str:
@@ -203,36 +197,35 @@ class TechLeadAgent:
         )
         user += "\n\nRespond with valid JSON only, no markdown fences."
         attempts = _review_retry_attempts()
-        last_err: Exception | None = None
-        for i in range(attempts):
-            try:
-                data = _agent_call_json(self._review_agent, user)
-                # A response that parses as JSON but carries no verdict (missing/null "approved")
-                # is not a substantive rejection — it's an unusable review. Treat it like any other
-                # failed attempt so it retries and ultimately surfaces error=True (fail once),
-                # rather than silently becoming approved=False and burning the revision loop.
-                if data.get("approved") is None:
-                    raise ValueError(f"review response missing 'approved' verdict: {data!r}")
-            except Exception as e:  # noqa: BLE001 — a failed review must never abort the swarm
-                last_err = e
-                logger.warning(
-                    "Tech Lead code_review attempt %d/%d failed: %s", i + 1, attempts, e
-                )
-                if i + 1 < attempts:
-                    time.sleep(_review_backoff_seconds(i))
-                continue
+
+        def _attempt_review() -> Dict[str, Any]:
+            data = _agent_call_json(self._review_agent, user)
+            # A response that parses as JSON but carries no verdict (missing/null "approved") is not
+            # a substantive rejection — it's an unusable review. Raise so the shared retry envelope
+            # retries it and it ultimately surfaces error=True (fail once), rather than silently
+            # becoming approved=False and burning the revision loop.
+            if data.get("approved") is None:
+                raise ValueError(f"review response missing 'approved' verdict: {data!r}")
+            return data
+
+        # Reuse the platform's jittered-exponential-backoff retry envelope rather than a bespoke
+        # loop, so review retry/backoff tuning stays consistent with every other LLM caller.
+        try:
+            data = call_llm_with_retries(_attempt_review, max_attempts=attempts)
+        except Exception as e:  # noqa: BLE001 — a failed review must never abort the swarm
+            # Flag an infrastructure failure (error=True) distinctly from a substantive rejection so
+            # the orchestrator fails the task once with a clear diagnostic rather than re-sending the
+            # same failing prompt through the revision loop every round.
+            logger.warning("Tech Lead code_review failed after %d attempts: %s", attempts, e)
             return {
-                "approved": bool(data.get("approved")),
-                "error": False,
-                "reason": str(data.get("reason") or ""),
-                "requested_changes": list(data.get("requested_changes") or []),
+                "approved": False,
+                "error": True,
+                "reason": f"Review could not be completed after {attempts} attempts: {e}",
+                "requested_changes": [],
             }
-        # Every attempt failed. Flag an infrastructure failure (error=True) distinctly from a
-        # substantive rejection so the orchestrator fails the task once with a clear diagnostic
-        # rather than re-sending the same failing prompt through the revision loop every round.
         return {
-            "approved": False,
-            "error": True,
-            "reason": f"Review could not be completed after {attempts} attempts: {last_err}",
-            "requested_changes": [],
+            "approved": bool(data.get("approved")),
+            "error": False,
+            "reason": str(data.get("reason") or ""),
+            "requested_changes": list(data.get("requested_changes") or []),
         }

--- a/backend/agents/coding_team/tests/test_swarm_review.py
+++ b/backend/agents/coding_team/tests/test_swarm_review.py
@@ -563,7 +563,6 @@ def test_status_text_reports_merged_and_failed_counts(tmp_path, monkeypatch):
     monkeypatch.setattr(orch_mod, "SeniorSWEAgent", StubSWE)
     monkeypatch.setattr(orch_mod, "CodingTeamSwarm", StubSwarm)
     # No job service in unit tests — skip the persistence write.
-    monkeypatch.setattr(orch_mod, "update_job_task_graph", lambda *a, **k: None)
 
     updates: List[Dict[str, Any]] = []
     plan = CodingTeamPlanInput(repo_path=str(tmp_path))
@@ -767,7 +766,6 @@ def test_resume_from_snapshot_skips_planning(tmp_path, monkeypatch):
     monkeypatch.setattr(orch_mod, "TechLeadAgent", ExplodingTL)
     monkeypatch.setattr(orch_mod, "SeniorSWEAgent", StubSWE)
     monkeypatch.setattr(orch_mod, "CodingTeamSwarm", StubSwarm)
-    monkeypatch.setattr(orch_mod, "update_job_task_graph", lambda *a, **k: None)
 
     snapshot = {
         "task_graph_snapshot": [
@@ -832,7 +830,6 @@ def test_fresh_run_persists_stack_specs(tmp_path, monkeypatch):
     monkeypatch.setattr(orch_mod, "TechLeadAgent", StubTL)
     monkeypatch.setattr(orch_mod, "SeniorSWEAgent", StubSWE)
     monkeypatch.setattr(orch_mod, "CodingTeamSwarm", StubSwarm)
-    monkeypatch.setattr(orch_mod, "update_job_task_graph", lambda *a, **k: None)
 
     updates: List[Dict[str, Any]] = []
     plan = CodingTeamPlanInput(repo_path=str(tmp_path))
@@ -913,7 +910,6 @@ def test_status_is_completed_when_no_failures(tmp_path, monkeypatch):
     monkeypatch.setattr(orch_mod, "TechLeadAgent", StubTL)
     monkeypatch.setattr(orch_mod, "SeniorSWEAgent", StubSWE)
     monkeypatch.setattr(orch_mod, "CodingTeamSwarm", StubSwarm)
-    monkeypatch.setattr(orch_mod, "update_job_task_graph", lambda *a, **k: None)
 
     updates: List[Dict[str, Any]] = []
     plan = CodingTeamPlanInput(repo_path=str(tmp_path))

--- a/backend/agents/coding_team/tests/test_swarm_review.py
+++ b/backend/agents/coding_team/tests/test_swarm_review.py
@@ -217,7 +217,7 @@ def test_review_retries_transient_error_then_succeeds(monkeypatch):
     from coding_team.tech_lead_agent import agent as tl_mod
 
     monkeypatch.setattr(tl_mod, "Agent", lambda **kw: object())
-    monkeypatch.setattr(tl_mod.time, "sleep", lambda *_a: None)
+    monkeypatch.setattr("llm_service.util.time.sleep", lambda *_a, **_k: None)
     calls = {"n": 0}
 
     def flaky(agent, prompt):
@@ -242,7 +242,7 @@ def test_review_returns_error_after_exhausting_retries(monkeypatch):
 
     monkeypatch.setenv("CODING_TEAM_REVIEW_RETRIES", "1")  # → 2 attempts
     monkeypatch.setattr(tl_mod, "Agent", lambda **kw: object())
-    monkeypatch.setattr(tl_mod.time, "sleep", lambda *_a: None)
+    monkeypatch.setattr("llm_service.util.time.sleep", lambda *_a, **_k: None)
 
     def boom(agent, prompt):
         raise RuntimeError("context overflow")
@@ -264,7 +264,7 @@ def test_review_missing_approved_is_infra_error_not_rejection(monkeypatch):
 
     monkeypatch.setenv("CODING_TEAM_REVIEW_RETRIES", "1")  # → 2 attempts
     monkeypatch.setattr(tl_mod, "Agent", lambda **kw: object())
-    monkeypatch.setattr(tl_mod.time, "sleep", lambda *_a: None)
+    monkeypatch.setattr("llm_service.util.time.sleep", lambda *_a, **_k: None)
     # Valid JSON, but no verdict — e.g. a weak/over-context model that omits 'approved'.
     monkeypatch.setattr(tl_mod, "_agent_call_json", lambda agent, prompt: {"reason": "hmm"})
     tl = tl_mod.TechLeadAgent(model=object())
@@ -925,3 +925,101 @@ def test_status_is_completed_when_no_failures(tmp_path, monkeypatch):
 
     assert updates[-1]["status"] == "completed"
     assert "1 merged, 0 failed" in updates[-1]["status_text"]
+
+
+# ----------------------------------------------------- in_progress (not-ready) is bounded
+
+
+def test_in_progress_implementation_is_bounded(tmp_path, monkeypatch):
+    """A worker that never marks ready_for_review (status='in_progress') is bounded by the revision
+    cap and ends FAILED — not spinning to max_rounds and then reported as a clean success."""
+    monkeypatch.setattr(orch_mod, "MAX_TASK_REVISIONS", 3)
+    _patch_git(monkeypatch)
+
+    class NeverReadyWorker(StubWorker):
+        def run_implement(self, task, path, repo_context=""):
+            self.implement_calls.append(task)
+            return {
+                "status": "in_progress",  # model set ready_for_review=false
+                "feature_branch": f"feature/{task.id}",
+                "changes_summary": "",
+                "error": None,
+            }
+
+    worker = NeverReadyWorker("a1")
+    swarm, graph = _make_swarm(tmp_path, StubTechLead(approved=True), [worker])
+    graph.add_task("t1", title="T1")
+
+    swarm.run(max_rounds=50)
+
+    task = graph.get_task("t1")
+    assert task.status == TaskStatus.FAILED  # bounded, not stuck IN_PROGRESS forever
+    assert task.revision_feedback[-1]["source"] == "engineer"
+    assert "ready for review" in task.revision_feedback[-1]["reason"].lower()
+    assert len(worker.implement_calls) <= orch_mod.MAX_TASK_REVISIONS + 1  # bounded, not 50
+    assert swarm._is_complete()  # loop terminates
+
+
+# ----------------------------------------------------- bounded review evidence
+
+
+def test_build_review_evidence_passes_small_uncut():
+    ev = orch_mod._build_review_evidence("SUMMARY", "DIFFDATA", max_chars=1000)
+    assert "SUMMARY" in ev and "DIFFDATA" in ev and "--- DIFF ---" in ev
+
+
+def test_build_review_evidence_truncates_large_diff():
+    big = "D" * 100000
+    ev = orch_mod._build_review_evidence("SUM", big, max_chars=5000)
+    assert len(ev) <= 5000  # bounded, does not overflow the reviewer context
+    assert ev.startswith("SUM")
+    assert "diff truncated" in ev
+
+
+def test_build_review_evidence_no_diff():
+    assert orch_mod._build_review_evidence("ONLY SUMMARY", "", max_chars=1000) == "ONLY SUMMARY"
+
+
+def test_review_evidence_max_chars_env(monkeypatch):
+    default = orch_mod._DEFAULT_REVIEW_EVIDENCE_MAX_CHARS
+    monkeypatch.setenv("CODING_TEAM_REVIEW_EVIDENCE_MAX_CHARS", "1234")
+    assert orch_mod._review_evidence_max_chars() == 1234
+    monkeypatch.setenv("CODING_TEAM_REVIEW_EVIDENCE_MAX_CHARS", "0")
+    assert orch_mod._review_evidence_max_chars() == default
+    monkeypatch.setenv("CODING_TEAM_REVIEW_EVIDENCE_MAX_CHARS", "junk")
+    assert orch_mod._review_evidence_max_chars() == default
+    monkeypatch.delenv("CODING_TEAM_REVIEW_EVIDENCE_MAX_CHARS", raising=False)
+    assert orch_mod._review_evidence_max_chars() == default
+
+
+# ----------------------------------------------------- implement description cap
+
+
+def test_implement_caps_large_task_description(tmp_path, monkeypatch):
+    """A pathologically large task description is capped in the implement prompt so it cannot
+    deterministically overflow the model context (and then be retried up to the cap)."""
+    from coding_team.senior_software_engineer_agent import agent as swe_mod
+
+    captured: Dict[str, str] = {}
+
+    class FakeAgent:
+        def __init__(self, **kw):
+            pass
+
+        def __call__(self, prompt):
+            captured["prompt"] = prompt
+            return (
+                '{"summary":"ok","files_to_create_or_edit":[],"commands_run":[],'
+                '"ready_for_review":true,"feature_branch":"feature/t1"}'
+            )
+
+    monkeypatch.setattr(swe_mod, "Agent", FakeAgent)
+    swe = SeniorSWEAgent(agent_id="a1", stack_spec=StackSpec(name="backend"), llm=object())
+    cap = swe_mod._IMPLEMENT_DESCRIPTION_MAX_CHARS
+    huge = "X" * (cap + 20000)
+    task = Task(id="t1", title="T1", description=huge)
+
+    swe.run_implement(task, tmp_path, repo_context="ctx")
+
+    assert huge not in captured["prompt"]  # full description not embedded
+    assert "X" * cap in captured["prompt"]  # capped slice is present

--- a/backend/agents/coding_team/tests/test_swarm_review.py
+++ b/backend/agents/coding_team/tests/test_swarm_review.py
@@ -582,6 +582,312 @@ def test_status_text_reports_merged_and_failed_counts(tmp_path, monkeypatch):
     assert "1 merged, 1 failed" in final["status_text"]
 
 
+# ----------------------------------------------------- real quality-gate path
+
+QG = "software_engineering_team.quality_gate_tools"
+
+
+def _make_real_swarm(tmp_path):
+    """A swarm WITHOUT the _run_quality_gates bypass, with one task already assigned to a1."""
+    graph = TaskGraphService(job_id="j1")
+    swarm = CodingTeamSwarm(
+        tech_lead=StubTechLead(approved=True),
+        workers=[StubWorker("a1")],
+        graph=graph,
+        path=Path(tmp_path),
+        agent_ids=["a1"],
+        llm_getter=lambda k: None,
+    )
+    graph.add_task("t1", title="T1")
+    graph.assign_task_to_agent("t1", "a1")
+    return swarm, graph
+
+
+def _patch_gates(monkeypatch, *, build_ok=True, review_ok=True, build_raises=False):
+    import types
+
+    def build(*a, **k):
+        if build_raises:
+            raise RuntimeError("tool crashed")
+        return types.SimpleNamespace(success=build_ok, error="" if build_ok else "boom build")
+
+    monkeypatch.setattr(f"{QG}.run_build_verification", build)
+    monkeypatch.setattr(f"{QG}.run_linting", lambda *a, **k: None)
+    monkeypatch.setattr(
+        f"{QG}.run_code_review",
+        lambda **k: types.SimpleNamespace(
+            approved=review_ok, issues=[] if review_ok else [{"type": "review", "error": "x"}]
+        ),
+    )
+
+
+def test_quality_gates_pass_sets_in_review(tmp_path, monkeypatch):
+    _patch_gates(monkeypatch, build_ok=True, review_ok=True)
+    swarm, graph = _make_real_swarm(tmp_path)
+
+    swarm._implement_and_verify(swarm.workers[0], lambda **kw: None)
+
+    assert graph.get_task("t1").status == TaskStatus.IN_REVIEW
+
+
+def test_quality_gate_build_failure_returns_for_revision(tmp_path, monkeypatch):
+    _patch_gates(monkeypatch, build_ok=False)
+    swarm, graph = _make_real_swarm(tmp_path)
+
+    swarm._implement_and_verify(swarm.workers[0], lambda **kw: None)
+
+    task = graph.get_task("t1")
+    assert task.status == TaskStatus.TO_DO  # returned for revision
+    assert task.assigned_agent_id is None  # and unassigned
+
+
+def test_quality_gate_review_rejection_returns_for_revision(tmp_path, monkeypatch):
+    _patch_gates(monkeypatch, build_ok=True, review_ok=False)
+    swarm, graph = _make_real_swarm(tmp_path)
+
+    swarm._implement_and_verify(swarm.workers[0], lambda **kw: None)
+
+    assert graph.get_task("t1").status == TaskStatus.TO_DO
+
+
+def test_quality_gate_tool_exception_proceeds_to_review(tmp_path, monkeypatch):
+    """An unexpected quality-gate tool error is logged and the task still proceeds (best-effort)."""
+    _patch_gates(monkeypatch, build_raises=True)
+    swarm, graph = _make_real_swarm(tmp_path)
+
+    swarm._implement_and_verify(swarm.workers[0], lambda **kw: None)
+
+    assert graph.get_task("t1").status == TaskStatus.IN_REVIEW  # proceeded despite the tool error
+
+
+# ----------------------------------------------------- un-assignment / double-assignment guard
+
+
+def test_return_for_revision_unassigns_task(tmp_path, monkeypatch):
+    """A quality-gate rejection must genuinely unassign the task (TO_DO + agent freed), not leave it
+    mapped to its agent — otherwise it can be both re-served to that agent and assigned to a second
+    free agent next round (two workers on one task)."""
+    monkeypatch.setattr(orch_mod, "MAX_TASK_REVISIONS", 5)
+    swarm, graph = _make_swarm(tmp_path, StubTechLead(approved=False), [StubWorker("a1")])
+    graph.add_task("t1", title="T1")
+    graph.assign_task_to_agent("t1", "a1")  # IN_PROGRESS, mapped to a1
+
+    ready = swarm._return_for_revision(graph.get_task("t1"), [{"type": "build", "error": "boom"}])
+
+    assert ready is False
+    task = graph.get_task("t1")
+    assert task.status == TaskStatus.TO_DO
+    assert task.assigned_agent_id is None  # genuinely unassigned (was a silent no-op before)
+    assert graph.get_task_for_agent("a1") is None  # agent freed
+    assert graph._agent_to_task.get("a1") is None  # mapping cleared
+    # It can now be cleanly reassigned (no "already has active task" rejection).
+    assert graph.assign_task_to_agent("t1", "a1") is True
+
+
+# ----------------------------------------------------- IN_REVIEW is not re-implemented
+
+
+def test_in_review_task_is_not_reimplemented(tmp_path):
+    """A worker whose mapped task is IN_REVIEW (awaiting Tech Lead review) must not re-run implement
+    — that would regenerate code under review and churn the loop."""
+    worker = StubWorker("a1")
+    swarm, graph = _make_swarm(tmp_path, StubTechLead(approved=True), [worker])
+    graph.add_task("t1", title="T1")
+    graph.assign_task_to_agent("t1", "a1")
+    graph.set_task_in_review("t1")  # IN_REVIEW, still mapped to a1
+
+    swarm._implement_and_verify(worker, lambda **kw: None)
+
+    assert worker.implement_calls == []  # not re-implemented while under review
+    assert graph.get_task("t1").status == TaskStatus.IN_REVIEW
+
+
+# ----------------------------------------------------- repo context visibility / refresh
+
+
+def test_read_repo_context_includes_markdown(tmp_path):
+    """Markdown docs must be visible in repo context so a docs task does not see an 'empty' repo."""
+    (tmp_path / "spec.md").write_text("# Spec\nThe plan lives here.")
+    ctx = orch_mod._read_repo_context(tmp_path)
+    assert "spec.md" in ctx
+    assert "The plan lives here." in ctx
+
+
+def test_repo_context_refreshed_between_rounds(tmp_path, monkeypatch):
+    """The swarm re-reads repo context each round so files written in earlier rounds become visible
+    to later implementations (instead of being recreated)."""
+    _patch_git(monkeypatch)
+    seen: List[str] = []
+
+    class ContextWorker(StubWorker):
+        def run_implement(self, task, path, repo_context=""):
+            seen.append(repo_context)
+            (Path(path) / "notes.md").write_text("notes round content")
+            return super().run_implement(task, path, repo_context=repo_context)
+
+    worker = ContextWorker("a1")
+    swarm, graph = _make_swarm(tmp_path, StubTechLead(approved=True), [worker])
+    graph.add_task("t1", title="T1")
+    graph.add_task("t2", title="T2", dependencies=["t1"])
+
+    swarm.run(max_rounds=20)
+
+    # notes.md (written while implementing t1) is picked up by a later round's context refresh.
+    assert any("notes.md" in ctx for ctx in seen)
+
+
+# ----------------------------------------------------- resume from snapshot (no re-planning)
+
+
+def test_resume_from_snapshot_skips_planning(tmp_path, monkeypatch):
+    """A retry with a persisted task snapshot restores the graph and does NOT re-run planning;
+    MERGED tasks are preserved and in-flight tasks are reset to unassigned TO_DO."""
+
+    class ExplodingTL:
+        def __init__(self, llm):
+            pass
+
+        def run_plan_to_task_graph(self, plan_input):
+            raise AssertionError("planning must not run on resume")
+
+    class StubSWE:
+        def __init__(self, *a, **k):
+            self.agent_id = k.get("agent_id", "backend")
+
+    captured: Dict[str, Any] = {}
+
+    class StubSwarm:
+        def __init__(self, *a, **k):
+            self.graph = k["graph"]
+            captured["graph"] = self.graph
+
+        def run(self, **kw):
+            pass  # leave the restored state as-is so we can assert on it
+
+    monkeypatch.setattr(orch_mod, "TechLeadAgent", ExplodingTL)
+    monkeypatch.setattr(orch_mod, "SeniorSWEAgent", StubSWE)
+    monkeypatch.setattr(orch_mod, "CodingTeamSwarm", StubSwarm)
+    monkeypatch.setattr(orch_mod, "update_job_task_graph", lambda *a, **k: None)
+
+    snapshot = {
+        "task_graph_snapshot": [
+            {"id": "t1", "title": "T1", "status": "merged", "dependencies": []},
+            {
+                "id": "t2",
+                "title": "T2",
+                "status": "in_progress",
+                "dependencies": [],
+                "assigned_agent_id": "backend",
+            },
+        ],
+        "agent_task_map": {"backend": "t2"},
+        "stack_specs": [{"name": "backend", "tools_services": []}],
+    }
+    updates: List[Dict[str, Any]] = []
+    plan = CodingTeamPlanInput(repo_path=str(tmp_path))
+    run_coding_team_orchestrator(
+        "j1",
+        tmp_path,
+        plan,
+        update_job_fn=lambda **kw: updates.append(kw),
+        get_job_fn=lambda jid: snapshot,
+        cache_dir=tmp_path,
+        get_llm=lambda key: None,
+    )
+
+    graph = captured["graph"]
+    assert graph.get_task("t1").status == TaskStatus.MERGED  # finished work preserved
+    assert graph.get_task("t2").status == TaskStatus.TO_DO  # in-flight reset
+    assert graph.get_task("t2").assigned_agent_id is None  # and unassigned
+    # No stack_specs persisted on the resume path (stacks came from the snapshot, not planning).
+    assert not any("stack_specs" in u for u in updates)
+    assert updates[-1]["status"] == "completed"  # 1 merged, 0 failed
+
+
+def test_fresh_run_persists_stack_specs(tmp_path, monkeypatch):
+    """The fresh (non-resume) path persists the stacks so a later retry can resume without
+    re-planning."""
+
+    class StubTL:
+        def __init__(self, llm):
+            pass
+
+        def run_plan_to_task_graph(self, plan_input):
+            return {
+                "tasks": [{"id": "t1", "title": "T1"}],
+                "stacks": [{"name": "backend", "tools_services": ["pytest"]}],
+            }
+
+    class StubSWE:
+        def __init__(self, *a, **k):
+            self.agent_id = k.get("agent_id", "backend")
+
+    class StubSwarm:
+        def __init__(self, *a, **k):
+            self.graph = k["graph"]
+
+        def run(self, **kw):
+            self.graph.mark_branch_merged("t1")
+
+    monkeypatch.setattr(orch_mod, "TechLeadAgent", StubTL)
+    monkeypatch.setattr(orch_mod, "SeniorSWEAgent", StubSWE)
+    monkeypatch.setattr(orch_mod, "CodingTeamSwarm", StubSwarm)
+    monkeypatch.setattr(orch_mod, "update_job_task_graph", lambda *a, **k: None)
+
+    updates: List[Dict[str, Any]] = []
+    plan = CodingTeamPlanInput(repo_path=str(tmp_path))
+    run_coding_team_orchestrator(
+        "j1",
+        tmp_path,
+        plan,
+        update_job_fn=lambda **kw: updates.append(kw),
+        get_job_fn=lambda jid: {},  # no snapshot → fresh path
+        cache_dir=tmp_path,
+        get_llm=lambda key: None,
+    )
+
+    stack_updates = [u for u in updates if "stack_specs" in u]
+    assert stack_updates, "fresh run must persist stack_specs for resume"
+    assert stack_updates[0]["stack_specs"] == [{"name": "backend", "tools_services": ["pytest"]}]
+
+
+# ----------------------------------------------------- task graph helpers (direct)
+
+
+def test_unassign_task_frees_agent_and_clears_assignment():
+    tg = TaskGraphService(job_id="j1")
+    tg.add_task("t1")
+    tg.assign_task_to_agent("t1", "a1")
+
+    tg.unassign_task("t1")
+
+    assert tg.get_task("t1").assigned_agent_id is None
+    assert tg.get_task_for_agent("a1") is None
+    tg.unassign_task("missing")  # unknown id is a no-op, must not raise
+
+
+def test_reset_in_flight_demotes_only_nonterminal():
+    tg = TaskGraphService(job_id="j1")
+    tg.add_task("t_inprog")
+    tg.assign_task_to_agent("t_inprog", "a1")
+    tg.add_task("t_review")
+    tg.assign_task_to_agent("t_review", "a2")
+    tg.set_task_in_review("t_review")
+    tg.add_task("t_merged")
+    tg.mark_branch_merged("t_merged")
+    tg.add_task("t_failed")
+    tg.update_task("t_failed", status=TaskStatus.FAILED)
+
+    tg.reset_in_flight()
+
+    assert tg.get_task("t_inprog").status == TaskStatus.TO_DO
+    assert tg.get_task("t_inprog").assigned_agent_id is None
+    assert tg.get_task("t_review").status == TaskStatus.TO_DO
+    assert tg.get_task("t_merged").status == TaskStatus.MERGED  # terminal untouched
+    assert tg.get_task("t_failed").status == TaskStatus.FAILED  # terminal untouched
+    assert tg._agent_to_task == {}
+
+
 def test_status_is_completed_when_no_failures(tmp_path, monkeypatch):
     class StubTL:
         def __init__(self, llm):

--- a/backend/agents/coding_team/tests/test_task_graph.py
+++ b/backend/agents/coding_team/tests/test_task_graph.py
@@ -146,3 +146,67 @@ def test_create_task_graph() -> None:
     assert tg.job_id == "job-1"
     tg.add_task("t1", title="T1")
     assert tg.get_task("t1") is not None
+
+
+def test_snapshot_restore_round_trips_subtasks() -> None:
+    """A task's subtasks survive a snapshot → restore round-trip (serialization + reconstruction)."""
+    from coding_team.models import Subtask
+
+    tg = TaskGraphService(job_id="j1")
+    tg.add_task(
+        "t1",
+        title="T1",
+        subtasks=[
+            Subtask(id="s1", title="S1", description="first", status=TaskStatus.MERGED),
+            Subtask(id="s2", title="S2", dependencies=["s1"]),
+        ],
+    )
+
+    tg2 = TaskGraphService(job_id="j1")
+    tg2.restore(tg.snapshot())
+
+    sub = tg2.get_task("t1").subtasks
+    assert [s.id for s in sub] == ["s1", "s2"]
+    assert sub[0].status == TaskStatus.MERGED
+    assert sub[1].dependencies == ["s1"]
+
+
+def test_get_next_eligible_subtask() -> None:
+    """Returns the first subtask whose subtask-deps are all MERGED; None when blocked/none/empty."""
+    from coding_team.models import Subtask
+
+    tg = TaskGraphService(job_id="j1")
+    assert tg.get_next_eligible_subtask("missing") is None  # unknown task
+    tg.add_task("t0", title="no subs")
+    assert tg.get_next_eligible_subtask("t0") is None  # task without subtasks
+    tg.add_task(
+        "t1",
+        title="T1",
+        subtasks=[
+            Subtask(id="s1", title="S1", status=TaskStatus.MERGED),
+            Subtask(id="s2", title="S2", dependencies=["s1"]),
+            Subtask(id="s3", title="S3", dependencies=["s2"]),  # blocked: s2 not merged
+        ],
+    )
+    nxt = tg.get_next_eligible_subtask("t1")
+    assert nxt.id == "s2"  # s1 merged → s2 eligible, s3 still blocked
+
+
+def test_missing_task_operations_are_safe_noops() -> None:
+    """Mutating operations on an unknown task id return falsy/None instead of raising."""
+    tg = TaskGraphService(job_id="j1")
+    assert tg.update_task("nope", status=TaskStatus.MERGED) is None
+    assert tg.mark_branch_merged("nope") is False
+    assert tg.set_task_in_review("nope") is False
+    assert tg.assign_task_to_agent("nope", "a1") is False
+
+
+def test_persist_callback_exception_is_swallowed() -> None:
+    """A failing persist callback must not break a graph mutation (_maybe_persist guards it)."""
+
+    def boom() -> None:
+        raise RuntimeError("persist down")
+
+    tg = TaskGraphService(job_id="j1", persist_callback=boom)
+    tg.add_task("t1", title="T1")  # must not raise despite the failing callback
+    assert tg.get_task("t1") is not None

--- a/backend/agents/coding_team/tests/test_task_graph.py
+++ b/backend/agents/coding_team/tests/test_task_graph.py
@@ -210,3 +210,29 @@ def test_persist_callback_exception_is_swallowed() -> None:
     tg = TaskGraphService(job_id="j1", persist_callback=boom)
     tg.add_task("t1", title="T1")  # must not raise despite the failing callback
     assert tg.get_task("t1") is not None
+
+
+def test_update_task_clears_assignment_and_frees_agent() -> None:
+    """update_task(assigned_agent_id=None) clears the back-reference AND frees the agent mapping."""
+    tg = TaskGraphService(job_id="j1")
+    tg.add_task("t1")
+    tg.assign_task_to_agent("t1", "a1")
+    assert tg.get_task_for_agent("a1").id == "t1"
+
+    tg.update_task("t1", status=TaskStatus.TO_DO, assigned_agent_id=None)
+
+    assert tg.get_task("t1").assigned_agent_id is None
+    assert tg.get_task_for_agent("a1") is None  # agent freed, not silently left busy (no-op bug)
+
+
+def test_update_task_omitting_assignment_leaves_it_untouched() -> None:
+    """Omitting assigned_agent_id must not clobber an existing assignment (sentinel default)."""
+    tg = TaskGraphService(job_id="j1")
+    tg.add_task("t1")
+    tg.assign_task_to_agent("t1", "a1")
+
+    tg.update_task("t1", feature_branch="feature/t1")  # assigned_agent_id not supplied
+
+    assert tg.get_task("t1").assigned_agent_id == "a1"  # preserved
+    assert tg.get_task_for_agent("a1").id == "t1"
+    assert tg.get_task("t1").feature_branch == "feature/t1"

--- a/backend/agents/coding_team/tests/test_task_graph.py
+++ b/backend/agents/coding_team/tests/test_task_graph.py
@@ -236,3 +236,18 @@ def test_update_task_omitting_assignment_leaves_it_untouched() -> None:
     assert tg.get_task("t1").assigned_agent_id == "a1"  # preserved
     assert tg.get_task_for_agent("a1").id == "t1"
     assert tg.get_task("t1").feature_branch == "feature/t1"
+
+
+def test_count_with_status() -> None:
+    """count_with_status tallies tasks in a given status (single source of truth for tallies)."""
+    tg = TaskGraphService(job_id="j1")
+    tg.add_task("t1")
+    tg.add_task("t2")
+    tg.add_task("t3")
+    tg.mark_branch_merged("t1")
+    tg.update_task("t2", status=TaskStatus.FAILED)
+
+    assert tg.count_with_status(TaskStatus.MERGED) == 1
+    assert tg.count_with_status(TaskStatus.FAILED) == 1
+    assert tg.count_with_status(TaskStatus.TO_DO) == 1
+    assert tg.count_with_status(TaskStatus.IN_REVIEW) == 0

--- a/backend/agents/coding_team/tests/test_tech_lead_plan_to_graph.py
+++ b/backend/agents/coding_team/tests/test_tech_lead_plan_to_graph.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
 from coding_team.models import CodingTeamPlanInput
+from coding_team.tech_lead_agent import agent as tl_mod
 from coding_team.tech_lead_agent.agent import TechLeadAgent
 
 
-def test_tech_lead_plan_to_task_graph_output_structure() -> None:
+def test_tech_lead_plan_to_task_graph_output_structure(monkeypatch) -> None:
     """Given CodingTeamPlanInput, Tech Lead output contains tasks (with deps) and stacks list."""
     plan = CodingTeamPlanInput(
         requirements_title="Test Project",
@@ -18,28 +17,33 @@ def test_tech_lead_plan_to_task_graph_output_structure() -> None:
         repo_path="/tmp/repo",
         architecture_overview="Backend FastAPI, frontend Angular.",
     )
-    mock_llm = MagicMock()
-    mock_llm.complete_json.return_value = {
-        "tasks": [
-            {
-                "id": "t1",
-                "title": "Backend API",
-                "description": "Implement endpoints",
-                "dependencies": [],
-            },
-            {
-                "id": "t2",
-                "title": "Frontend UI",
-                "description": "Implement UI",
-                "dependencies": ["t1"],
-            },
-        ],
-        "stacks": [
-            {"name": "backend", "tools_services": ["Python", "FastAPI"]},
-            {"name": "frontend", "tools_services": ["Angular", "TypeScript"]},
-        ],
-    }
-    agent = TechLeadAgent(llm=mock_llm)
+    # The Tech Lead drives a strands Agent via _agent_call_json; stub both so no real LLM runs.
+    monkeypatch.setattr(tl_mod, "Agent", lambda **kw: object())
+    monkeypatch.setattr(
+        tl_mod,
+        "_agent_call_json",
+        lambda agent, prompt: {
+            "tasks": [
+                {
+                    "id": "t1",
+                    "title": "Backend API",
+                    "description": "Implement endpoints",
+                    "dependencies": [],
+                },
+                {
+                    "id": "t2",
+                    "title": "Frontend UI",
+                    "description": "Implement UI",
+                    "dependencies": ["t1"],
+                },
+            ],
+            "stacks": [
+                {"name": "backend", "tools_services": ["Python", "FastAPI"]},
+                {"name": "frontend", "tools_services": ["Angular", "TypeScript"]},
+            ],
+        },
+    )
+    agent = TechLeadAgent(model=object())
     out = agent.run_plan_to_task_graph(plan)
     assert "tasks" in out
     assert "stacks" in out
@@ -56,16 +60,20 @@ def test_tech_lead_plan_to_task_graph_output_structure() -> None:
     assert stacks[1]["name"] == "frontend"
 
 
-def test_tech_lead_plan_to_task_graph_llm_failure_returns_defaults() -> None:
-    """When LLM fails, return empty tasks and default stack."""
+def test_tech_lead_plan_to_task_graph_llm_failure_returns_defaults(monkeypatch) -> None:
+    """When the LLM call fails, return empty tasks and a single default stack."""
     plan = CodingTeamPlanInput(
         requirements_title="X",
         requirements_description="",
         repo_path="/tmp",
     )
-    mock_llm = MagicMock()
-    mock_llm.complete_json.side_effect = RuntimeError("LLM error")
-    agent = TechLeadAgent(llm=mock_llm)
+
+    def boom(agent, prompt):
+        raise RuntimeError("LLM error")
+
+    monkeypatch.setattr(tl_mod, "Agent", lambda **kw: object())
+    monkeypatch.setattr(tl_mod, "_agent_call_json", boom)
+    agent = TechLeadAgent(model=object())
     out = agent.run_plan_to_task_graph(plan)
     assert out["tasks"] == []
     assert len(out["stacks"]) == 1

--- a/backend/agents/software_engineering_team/temporal/activities.py
+++ b/backend/agents/software_engineering_team/temporal/activities.py
@@ -7,7 +7,10 @@ they run in the worker process and update the job store. No threads are started.
 
 from __future__ import annotations
 
+import contextvars
 import logging
+import os
+import threading
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -478,6 +481,50 @@ def plan_project_activity(
         raise
 
 
+def _coding_heartbeat_interval_s() -> float:
+    """Interval (seconds) between background heartbeats for the coding-team activity.
+
+    Must stay comfortably below the activity's `heartbeat_timeout` (10 min). Override via
+    `CODING_TEAM_HEARTBEAT_INTERVAL_S`; blank/garbage/non-positive falls back to 30s.
+    """
+    raw = os.getenv("CODING_TEAM_HEARTBEAT_INTERVAL_S", "")
+    try:
+        val = float(raw)
+        return val if val > 0 else 30.0
+    except (TypeError, ValueError):
+        return 30.0
+
+
+def _start_background_heartbeater(interval_s: float, stop: threading.Event) -> threading.Thread:
+    """Start a daemon thread that emits an `activity.heartbeat()` every `interval_s` until `stop`.
+
+    The per-update heartbeat (`_heartbeat_update_callback`) only fires when the orchestrator calls
+    back; a single long blocking step (e.g. a multi-minute code-generation LLM call) would emit no
+    heartbeat and could trip `heartbeat_timeout`. This independent beater keeps the activity alive
+    across such gaps. It runs in a separate thread, so it copies the current context (which carries
+    the Temporal activity handle) and heartbeats within it. Heartbeat errors are swallowed: outside
+    an activity context (unit tests / local dev) the beat is simply a no-op and the loop continues
+    until stopped.
+
+    Preconditions:
+        - Called from within a running activity thread (so the copied context carries the handle).
+    Postconditions:
+        - Returns a started daemon thread that exits within one interval of `stop` being set.
+    """
+    ctx = contextvars.copy_context()
+
+    def _loop() -> None:
+        while not stop.wait(interval_s):
+            try:
+                ctx.run(activity.heartbeat)
+            except Exception:
+                pass
+
+    thread = threading.Thread(target=_loop, name="coding-team-heartbeat", daemon=True)
+    thread.start()
+    return thread
+
+
 def _heartbeat_update_callback(job_id: str) -> Callable[..., None]:
     """Build the coding-team update callback that emits a Temporal heartbeat before each job update.
 
@@ -546,14 +593,22 @@ def execute_coding_team_activity(
         from llm_service import get_client
         from software_engineering_team.shared.job_store import JOB_STATUS_COMPLETED, get_job
 
-        run_coding_team_orchestrator(
-            job_id,
-            str(path),
-            plan_input,
-            update_job_fn=_heartbeat_update_callback(job_id),
-            get_job_fn=lambda jid: get_job(jid),
-            get_llm=get_client,
-        )
+        # Keep the activity alive across long blocking steps (e.g. multi-minute code-gen LLM calls)
+        # that emit no update callback, in addition to the per-update heartbeat below.
+        stop_heartbeat = threading.Event()
+        heartbeat_thread = _start_background_heartbeater(_coding_heartbeat_interval_s(), stop_heartbeat)
+        try:
+            run_coding_team_orchestrator(
+                job_id,
+                str(path),
+                plan_input,
+                update_job_fn=_heartbeat_update_callback(job_id),
+                get_job_fn=lambda jid: get_job(jid),
+                get_llm=get_client,
+            )
+        finally:
+            stop_heartbeat.set()
+            heartbeat_thread.join(timeout=5)
         update_job(job_id, status=JOB_STATUS_COMPLETED, phase="completed")
 
         return ExecutionResult(merged_count=0).model_dump()

--- a/backend/agents/software_engineering_team/temporal/activities.py
+++ b/backend/agents/software_engineering_team/temporal/activities.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from temporalio import activity
 
@@ -478,6 +478,33 @@ def plan_project_activity(
         raise
 
 
+def _heartbeat_update_callback(job_id: str) -> Callable[..., None]:
+    """Build the coding-team update callback that emits a Temporal heartbeat before each job update.
+
+    The coding orchestrator calls its update callback many times per task (implement, build, lint,
+    review, per-round persist), so routing every call through a heartbeat keeps a healthy long
+    coding run well inside the activity's `heartbeat_timeout` — preventing a spurious timeout +
+    retry, which would re-plan and re-do work. The heartbeat is best-effort: outside a Temporal
+    activity context (e.g. in unit tests) `activity.heartbeat()` raises and is swallowed, so the
+    callback still performs the underlying `update_job`.
+
+    Preconditions:
+        - `job_id` identifies an existing job.
+    Postconditions:
+        - The returned callable forwards all kwargs to `update_job(job_id, **kwargs)` after a
+          best-effort heartbeat, regardless of whether the heartbeat succeeds.
+    """
+
+    def _update(**kw: Any) -> None:
+        try:
+            activity.heartbeat()
+        except Exception:
+            pass
+        update_job(job_id, **kw)
+
+    return _update
+
+
 @activity.defn(name="execute_coding_team")
 def execute_coding_team_activity(
     job_id: str,
@@ -523,7 +550,7 @@ def execute_coding_team_activity(
             job_id,
             str(path),
             plan_input,
-            update_job_fn=lambda **kw: update_job(job_id, **kw),
+            update_job_fn=_heartbeat_update_callback(job_id),
             get_job_fn=lambda jid: get_job(jid),
             get_llm=get_client,
         )

--- a/backend/agents/software_engineering_team/tests/test_temporal_activities.py
+++ b/backend/agents/software_engineering_team/tests/test_temporal_activities.py
@@ -218,6 +218,47 @@ def test_plan_project_activity_exception_path(monkeypatch, tmp_path, patched_job
     assert job["status"] == js.JOB_STATUS_FAILED
 
 
+def test_heartbeat_update_callback_emits_heartbeat(monkeypatch) -> None:
+    """The coding-team update callback emits a Temporal heartbeat, then forwards the update."""
+    from software_engineering_team.temporal import activities
+
+    beats = {"n": 0}
+    monkeypatch.setattr(
+        activities.activity, "heartbeat", lambda *a, **k: beats.__setitem__("n", beats["n"] + 1)
+    )
+    captured: Dict[str, Any] = {}
+    monkeypatch.setattr(
+        activities, "update_job", lambda jid, **kw: captured.update({"jid": jid, **kw})
+    )
+
+    cb = activities._heartbeat_update_callback("job-x")
+    cb(status_text="implementing")
+
+    assert beats["n"] == 1
+    assert captured["jid"] == "job-x"
+    assert captured["status_text"] == "implementing"
+
+
+def test_heartbeat_update_callback_swallows_heartbeat_error(monkeypatch) -> None:
+    """Outside an activity context heartbeat() raises; the callback swallows it and still updates."""
+    from software_engineering_team.temporal import activities
+
+    def boom(*a, **k):
+        raise RuntimeError("not in an activity context")
+
+    monkeypatch.setattr(activities.activity, "heartbeat", boom)
+    captured: Dict[str, Any] = {}
+    monkeypatch.setattr(
+        activities, "update_job", lambda jid, **kw: captured.update({"jid": jid, **kw})
+    )
+
+    cb = activities._heartbeat_update_callback("job-y")
+    cb(phase="coding")  # must not raise despite the heartbeat failure
+
+    assert captured["jid"] == "job-y"
+    assert captured["phase"] == "coding"
+
+
 def test_execute_coding_team_activity_exception_path(monkeypatch, tmp_path, patched_job_store) -> None:
     """Bogus adapter_result_dict triggers an exception inside the activity;
     the outer except marks the job FAILED and re-raises."""

--- a/backend/agents/software_engineering_team/tests/test_temporal_activities.py
+++ b/backend/agents/software_engineering_team/tests/test_temporal_activities.py
@@ -274,3 +274,64 @@ def test_execute_coding_team_activity_exception_path(monkeypatch, tmp_path, patc
         )
     job = js.get_job("ec-j")
     assert job["status"] == js.JOB_STATUS_FAILED
+
+
+def test_background_heartbeater_beats_until_stopped(monkeypatch) -> None:
+    """The background heartbeater emits heartbeats repeatedly until the stop event is set."""
+    import threading
+
+    from software_engineering_team.temporal import activities
+
+    beats = {"n": 0}
+    stop = threading.Event()
+
+    def hb(*a, **k):
+        beats["n"] += 1
+        if beats["n"] >= 3:
+            stop.set()
+
+    monkeypatch.setattr(activities.activity, "heartbeat", hb)
+    t = activities._start_background_heartbeater(0.005, stop)
+    t.join(timeout=2)
+
+    assert not t.is_alive()
+    assert beats["n"] >= 3
+
+
+def test_background_heartbeater_swallows_errors(monkeypatch) -> None:
+    """A raising heartbeat (e.g. outside an activity context) does not kill the beater loop."""
+    import threading
+
+    from software_engineering_team.temporal import activities
+
+    calls = {"n": 0}
+    stop = threading.Event()
+
+    def hb(*a, **k):
+        calls["n"] += 1
+        if calls["n"] >= 2:
+            stop.set()
+        raise RuntimeError("no activity context")
+
+    monkeypatch.setattr(activities.activity, "heartbeat", hb)
+    t = activities._start_background_heartbeater(0.005, stop)
+    t.join(timeout=2)
+
+    assert not t.is_alive()  # errors swallowed; loop continued and exited cleanly on stop
+    assert calls["n"] >= 2
+
+
+def test_coding_heartbeat_interval_env(monkeypatch) -> None:
+    """Interval: valid positive float honored; zero/negative/garbage/unset fall back to 30s."""
+    from software_engineering_team.temporal import activities
+
+    monkeypatch.setenv("CODING_TEAM_HEARTBEAT_INTERVAL_S", "12.5")
+    assert activities._coding_heartbeat_interval_s() == 12.5
+    monkeypatch.setenv("CODING_TEAM_HEARTBEAT_INTERVAL_S", "0")
+    assert activities._coding_heartbeat_interval_s() == 30.0
+    monkeypatch.setenv("CODING_TEAM_HEARTBEAT_INTERVAL_S", "-5")
+    assert activities._coding_heartbeat_interval_s() == 30.0
+    monkeypatch.setenv("CODING_TEAM_HEARTBEAT_INTERVAL_S", "garbage")
+    assert activities._coding_heartbeat_interval_s() == 30.0
+    monkeypatch.delenv("CODING_TEAM_HEARTBEAT_INTERVAL_S", raising=False)
+    assert activities._coding_heartbeat_interval_s() == 30.0


### PR DESCRIPTION
## Summary

In production the coding-team swarm could loop back to re-doing finished work (e.g. a docs task reporting *"the repo appears to be empty… I need to create the relevant specification/plan documents"*) and, on a Temporal retry, re-run planning from scratch. This fixes the compounding defects behind that behaviour.

## Defects fixed

1. **Un-assignment was a silent no-op (primary bug).** `update_task(assigned_agent_id=None)` is ignored by design (the `is not None` guard lets callers update other fields without clobbering the assignment), so a quality-gate-rejected task became `TO_DO` while *still mapped to its agent* — the next round could both re-serve it to that agent and assign it to a second free agent (two workers, one task). Added `TaskGraphService.unassign_task` and call it from `_return_for_revision`.

2. **`IN_REVIEW` tasks could be re-implemented.** Guarded `_implement_and_verify` so a worker only (re)implements a task that is actively `IN_PROGRESS`, never one awaiting Tech Lead review.

3. **Repo context was a one-time snapshot blind to markdown.** Included `.md`/`.txt`/`.rst` in `_read_repo_context` and refresh the context each round, so specs/plans/code written in earlier rounds are visible instead of recreated. (Active repo-inspection tools — `list_files`/`read_file` — are the durable fix and are tracked separately in #777.)

4. **Restarts always re-planned.** `run_coding_team_orchestrator` now resumes from the persisted task snapshot when present — restoring the graph, resetting in-flight (`IN_PROGRESS`/`IN_REVIEW`) tasks to unassigned `TO_DO`, and rebuilding stacks from the persisted stack specs — instead of re-running the planning LLM and re-doing finished work. Stacks are persisted on the fresh path to enable this. Added `TaskGraphService.reset_in_flight`.

5. **Temporal coding activity never heartbeat.** A healthy long run tripped the activity's 10-minute `heartbeat_timeout` and was retried (which re-planned). The orchestrator's update callback is now routed through a best-effort `activity.heartbeat()` (`_heartbeat_update_callback`), which combined with (4) means a genuine timeout resumes rather than restarting.

> Note: defect 3's *blind-revision* sibling (threading `revision_feedback` into the implement prompt) was already fixed on the base branch; this PR just confirms its regression test.

The unbounded round/cost budget is intentionally **out of scope** here (tracked separately).

## Tests

- New: resume-from-snapshot (skips planning, preserves MERGED, resets in-flight), fresh-path stack persistence, IN_REVIEW-not-reimplemented, un-assignment frees the agent, repo-context markdown visibility + per-round refresh, the real quality-gate path (pass / build-fail / review-reject / tool-error), `unassign_task`/`reset_in_flight`, and the heartbeat callback (emits + swallows errors).
- Repaired the pre-existing `test_tech_lead_plan_to_graph.py` (it used the removed `complete_json` LLM interface and failed on the base branch).
- `coding_team` suite: **206 passed**, line coverage **90.7%** (≥90% gate). `ruff check` clean.

Closes #770


---
_Generated by [Claude Code](https://claude.ai/code/session_01XM1YnQLK4rRLpqivNAr5PQ)_