### PR TITLE
Coding team: stop truncating LLM inputs

### DIFF
--- a/backend/agents/coding_team/api/main.py
+++ b/backend/agents/coding_team/api/main.py
@@ -466,7 +466,7 @@ def _git(
             timeout=timeout,
             env=env,
         )
-        msg = _scrub_auth_header_values((r.stderr or r.stdout).strip(), env)[:500]
+        msg = _scrub_auth_header_values((r.stderr or r.stdout).strip(), env)
         return r.returncode, scrub_token_from_text(msg)
     except subprocess.TimeoutExpired:
         return 124, f"git {' '.join(args)} timed out after {timeout}s"

--- a/backend/agents/coding_team/github_source/client.py
+++ b/backend/agents/coding_team/github_source/client.py
@@ -68,7 +68,7 @@ class GitHubAPIError(RuntimeError):
     def __init__(self, status: int, body: str = "") -> None:
         self.status = status
         self.body = body
-        super().__init__(f"GitHub API {status}: {body[:200]}")
+        super().__init__(f"GitHub API {status}: {body}")
 
 
 class NotAnIssueError(GitHubAPIError):

--- a/backend/agents/coding_team/orchestrator.py
+++ b/backend/agents/coding_team/orchestrator.py
@@ -9,7 +9,6 @@ Exposes run_coding_team_orchestrator for in-process call from software_engineeri
 from __future__ import annotations
 
 import logging
-import os
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -33,45 +32,21 @@ logger = logging.getLogger(__name__)
 CANCEL_KEY = "cancel_requested"
 MAX_TASK_REVISIONS = 20  # max times a task can be returned for revision before accepting
 
-# Upper bound on Tech Lead review evidence (summary + diff). A correct-but-large diff must not
-# deterministically overflow the reviewer's context and fail an otherwise-good task (cascading to
-# its dependents). Generous enough to pass realistic diffs uncut; pathological diffs are truncated
-# with a marker so the reviewer sees partial — not absent — evidence. Override via
-# CODING_TEAM_REVIEW_EVIDENCE_MAX_CHARS.
-_DEFAULT_REVIEW_EVIDENCE_MAX_CHARS = 50000
 
+def _build_review_evidence(summary: str, diff: str) -> str:
+    """Assemble review evidence (summary + full diff) for the Tech Lead review.
 
-def _review_evidence_max_chars() -> int:
-    """Evidence cap for Tech Lead review; env override, garbage/non-positive → default."""
-    raw = os.getenv("CODING_TEAM_REVIEW_EVIDENCE_MAX_CHARS", "")
-    try:
-        val = int(raw)
-        return val if val > 0 else _DEFAULT_REVIEW_EVIDENCE_MAX_CHARS
-    except (TypeError, ValueError):
-        return _DEFAULT_REVIEW_EVIDENCE_MAX_CHARS
+    The reviewer must see the complete change to judge it; the diff is never truncated. If the
+    evidence genuinely exceeds the model context, the review call fails and the caller fails that
+    single task cleanly (see ``_review_and_merge``) rather than silently reviewing partial evidence.
 
-
-def _build_review_evidence(summary: str, diff: str, max_chars: int) -> str:
-    """Assemble review evidence (summary + diff) bounded to *max_chars*.
-
-    Keeps the full summary (the most important signal) and appends as much of the diff as fits,
-    marking any truncation so the reviewer knows the evidence is partial rather than absent. A huge
-    diff is thereby truncated instead of overflowing the model context and failing the task.
-
-    Preconditions: max_chars > 0.
-    Postconditions: len(result) <= max_chars (modulo a short truncation marker).
+    Postconditions:
+        - The full summary and the full diff (when present) both appear verbatim in the result.
     """
-    assert max_chars > 0, "max_chars must be positive"
     if not diff:
-        return summary[:max_chars]
-    header = "\n\n--- DIFF ---\n"
-    marker = "\n... [diff truncated for review context] ..."
-    budget = max_chars - len(summary) - len(header)
-    if budget <= 0:
-        return summary[:max_chars]
-    if len(diff) <= budget:
-        return summary + header + diff
-    return summary + header + diff[: max(0, budget - len(marker))] + marker
+        return summary
+    return f"{summary}\n\n--- DIFF ---\n{diff}"
+
 
 # Repo-context file selection. The shared full-stack code extensions / exclude dirs live in
 # software_engineering_team.shared.repo_utils; this summariser additionally surfaces the doc and
@@ -420,7 +395,7 @@ class CodingTeamSwarm:
             update_fn(status_text=f"Build verification: {task.title}")
             build = run_build_verification(self.path, agent_type, task.id)
             if not build.success:
-                logger.warning("[%s] Build failed for task %s: %s", swe.agent_id, task.id, build.error[:200])
+                logger.warning("[%s] Build failed for task %s: %s", swe.agent_id, task.id, build.error)
                 return self._return_for_revision(task, [{"type": "build", "error": build.error}])
 
             # Linting
@@ -487,7 +462,7 @@ class CodingTeamSwarm:
             branch = task.feature_branch or f"feature/{task.id}"
             summary = task.changes_summary or "(no summary recorded)"
             diff = branch_diff(self.path, DEVELOPMENT_BRANCH, branch)
-            evidence = _build_review_evidence(summary, diff, _review_evidence_max_chars())
+            evidence = _build_review_evidence(summary, diff)
             review = self.tech_lead.run_code_review(
                 task_title=task.title,
                 task_description=task.description,

--- a/backend/agents/coding_team/senior_software_engineer_agent/agent.py
+++ b/backend/agents/coding_team/senior_software_engineer_agent/agent.py
@@ -22,12 +22,6 @@ from coding_team.senior_software_engineer_agent import prompts
 
 logger = logging.getLogger(__name__)
 
-# Upper bound on the task description embedded in the implement prompt. A pathologically large
-# description (e.g. a long issue body / accumulated spec) would otherwise deterministically overflow
-# the model context, and _handle_incomplete_implementation would then re-run the same overflowing
-# call up to MAX_TASK_REVISIONS times. Generous so realistic descriptions are passed in full.
-_IMPLEMENT_DESCRIPTION_MAX_CHARS = 16000
-
 
 def _parse_json_response(raw: str) -> Dict[str, Any]:
     """Parse a JSON response from an agent, stripping markdown fences if present."""
@@ -172,9 +166,9 @@ class SeniorSWEAgent:
             stack_name=stack_name,
             tools_services=tools_services,
             task_title=task.title,
-            task_description=task.description[:_IMPLEMENT_DESCRIPTION_MAX_CHARS],
+            task_description=task.description,
             acceptance_criteria=json.dumps(task.acceptance_criteria),
-            repo_context=repo_context[:4000] or "No existing code context provided.",
+            repo_context=repo_context or "No existing code context provided.",
         )
         feedback_text = _render_revision_feedback(task.revision_feedback)
         if feedback_text:

--- a/backend/agents/coding_team/tech_lead_agent/agent.py
+++ b/backend/agents/coding_team/tech_lead_agent/agent.py
@@ -43,19 +43,25 @@ def _review_retry_attempts() -> int:
 
 
 def _plan_text(plan: CodingTeamPlanInput) -> str:
-    """Build plan text for the LLM from plan input."""
+    """Build plan text for the LLM from plan input.
+
+    Every field is passed through in full: the plan, spec, and architecture are the primary
+    inputs the Tech Lead reasons over, and clipping them would hide requirements from the
+    Task Graph. Inputs are never truncated.
+
+    Postconditions:
+        - Each non-empty plan field appears verbatim (uncut) in the returned text.
+    """
     parts = [
         f"Title: {plan.requirements_title}",
-        f"Description: {plan.requirements_description[:8000]}"
-        if plan.requirements_description
-        else "",
+        f"Description: {plan.requirements_description}" if plan.requirements_description else "",
     ]
     if plan.project_overview:
-        parts.append("Project overview: " + json.dumps(plan.project_overview, indent=2)[:4000])
+        parts.append("Project overview: " + json.dumps(plan.project_overview, indent=2))
     if plan.final_spec_content:
-        parts.append("Spec: " + (plan.final_spec_content[:6000] or ""))
+        parts.append("Spec: " + plan.final_spec_content)
     if plan.architecture_overview:
-        parts.append("Architecture: " + plan.architecture_overview[:3000])
+        parts.append("Architecture: " + plan.architecture_overview)
     return "\n\n".join(p for p in parts if p)
 
 
@@ -128,9 +134,9 @@ class TechLeadAgent:
         user = prompts.GROOM_TASK_USER.format(
             task_id=task_id,
             task_title=task_title,
-            task_description=task_description[:3000],
+            task_description=task_description,
             task_dependencies=json.dumps(task_dependencies),
-            plan_context=plan_context[:6000],
+            plan_context=plan_context,
         )
         user += "\n\nRespond with valid JSON only, no markdown fences."
         try:

--- a/backend/agents/coding_team/tests/test_swarm_review.py
+++ b/backend/agents/coding_team/tests/test_swarm_review.py
@@ -448,8 +448,12 @@ def test_approved_merge_failure_marks_merged_anyway(tmp_path, monkeypatch):
 
 
 def test_full_evidence_reaches_reviewer(tmp_path, monkeypatch):
-    """The reviewer gets the real summary + the full diff — no placeholder, no truncation."""
-    big_diff = "D" * 20000
+    """The reviewer gets the real summary + the full diff — no placeholder, no truncation.
+
+    The diff is deliberately larger than any cap the team ever used, proving the evidence is
+    passed through whole.
+    """
+    big_diff = "D" * 120000
     monkeypatch.setattr(f"{GIT_UTILS}.branch_diff", lambda *a, **k: big_diff)
     monkeypatch.setattr(f"{GIT_UTILS}.merge_branch", lambda *a, **k: (True, "ok"))
     tech_lead = StubTechLead(approved=False)
@@ -960,44 +964,32 @@ def test_in_progress_implementation_is_bounded(tmp_path, monkeypatch):
     assert swarm._is_complete()  # loop terminates
 
 
-# ----------------------------------------------------- bounded review evidence
+# ----------------------------------------------------- full review evidence (never truncated)
 
 
-def test_build_review_evidence_passes_small_uncut():
-    ev = orch_mod._build_review_evidence("SUMMARY", "DIFFDATA", max_chars=1000)
+def test_build_review_evidence_includes_summary_and_diff():
+    ev = orch_mod._build_review_evidence("SUMMARY", "DIFFDATA")
     assert "SUMMARY" in ev and "DIFFDATA" in ev and "--- DIFF ---" in ev
 
 
-def test_build_review_evidence_truncates_large_diff():
-    big = "D" * 100000
-    ev = orch_mod._build_review_evidence("SUM", big, max_chars=5000)
-    assert len(ev) <= 5000  # bounded, does not overflow the reviewer context
+def test_build_review_evidence_passes_large_diff_uncut():
+    big = "D" * 200000
+    ev = orch_mod._build_review_evidence("SUM", big)
     assert ev.startswith("SUM")
-    assert "diff truncated" in ev
+    assert big in ev  # full diff passed through, never truncated
+    assert "diff truncated" not in ev
 
 
 def test_build_review_evidence_no_diff():
-    assert orch_mod._build_review_evidence("ONLY SUMMARY", "", max_chars=1000) == "ONLY SUMMARY"
+    assert orch_mod._build_review_evidence("ONLY SUMMARY", "") == "ONLY SUMMARY"
 
 
-def test_review_evidence_max_chars_env(monkeypatch):
-    default = orch_mod._DEFAULT_REVIEW_EVIDENCE_MAX_CHARS
-    monkeypatch.setenv("CODING_TEAM_REVIEW_EVIDENCE_MAX_CHARS", "1234")
-    assert orch_mod._review_evidence_max_chars() == 1234
-    monkeypatch.setenv("CODING_TEAM_REVIEW_EVIDENCE_MAX_CHARS", "0")
-    assert orch_mod._review_evidence_max_chars() == default
-    monkeypatch.setenv("CODING_TEAM_REVIEW_EVIDENCE_MAX_CHARS", "junk")
-    assert orch_mod._review_evidence_max_chars() == default
-    monkeypatch.delenv("CODING_TEAM_REVIEW_EVIDENCE_MAX_CHARS", raising=False)
-    assert orch_mod._review_evidence_max_chars() == default
+# ----------------------------------------------------- implement passes inputs in full
 
 
-# ----------------------------------------------------- implement description cap
-
-
-def test_implement_caps_large_task_description(tmp_path, monkeypatch):
-    """A pathologically large task description is capped in the implement prompt so it cannot
-    deterministically overflow the model context (and then be retried up to the cap)."""
+def test_implement_passes_full_task_description_and_repo_context(tmp_path, monkeypatch):
+    """A large task description and repo context reach the implement prompt in full — the
+    engineer's inputs are never truncated."""
     from coding_team.senior_software_engineer_agent import agent as swe_mod
 
     captured: Dict[str, str] = {}
@@ -1015,11 +1007,11 @@ def test_implement_caps_large_task_description(tmp_path, monkeypatch):
 
     monkeypatch.setattr(swe_mod, "Agent", FakeAgent)
     swe = SeniorSWEAgent(agent_id="a1", stack_spec=StackSpec(name="backend"), llm=object())
-    cap = swe_mod._IMPLEMENT_DESCRIPTION_MAX_CHARS
-    huge = "X" * (cap + 20000)
+    huge = "X" * 60000
+    big_ctx = "C" * 30000
     task = Task(id="t1", title="T1", description=huge)
 
-    swe.run_implement(task, tmp_path, repo_context="ctx")
+    swe.run_implement(task, tmp_path, repo_context=big_ctx)
 
-    assert huge not in captured["prompt"]  # full description not embedded
-    assert "X" * cap in captured["prompt"]  # capped slice is present
+    assert huge in captured["prompt"]  # full description embedded, uncut
+    assert big_ctx in captured["prompt"]  # full repo context embedded, uncut

--- a/backend/agents/coding_team/tests/test_tech_lead_plan_to_graph.py
+++ b/backend/agents/coding_team/tests/test_tech_lead_plan_to_graph.py
@@ -78,3 +78,50 @@ def test_tech_lead_plan_to_task_graph_llm_failure_returns_defaults(monkeypatch) 
     assert out["tasks"] == []
     assert len(out["stacks"]) == 1
     assert out["stacks"][0]["name"] == "default"
+
+
+def test_plan_text_passes_all_fields_uncut() -> None:
+    """Every plan field reaches the Task-Graph prompt in full — inputs are never truncated."""
+    big_desc = "D" * 50000
+    big_overview_value = "O" * 50000
+    big_spec = "S" * 50000
+    big_arch = "A" * 50000
+    plan = CodingTeamPlanInput(
+        requirements_title="Big Project",
+        requirements_description=big_desc,
+        project_overview={"doc": big_overview_value},
+        final_spec_content=big_spec,
+        repo_path="/tmp/repo",
+        architecture_overview=big_arch,
+    )
+    text = tl_mod._plan_text(plan)
+    assert big_desc in text
+    assert big_overview_value in text
+    assert big_spec in text
+    assert big_arch in text
+
+
+def test_run_groom_task_passes_full_inputs_to_llm(monkeypatch) -> None:
+    """A large task description and plan context reach the groom prompt in full, never truncated."""
+    captured: dict[str, str] = {}
+
+    def _capture(agent, prompt):
+        captured["prompt"] = prompt
+        return {}
+
+    monkeypatch.setattr(tl_mod, "Agent", lambda **kw: object())
+    monkeypatch.setattr(tl_mod, "_agent_call_json", _capture)
+    agent = TechLeadAgent(model=object())
+    big_desc = "D" * 50000
+    big_context = "C" * 50000
+
+    agent.run_groom_task(
+        task_id="t1",
+        task_title="T1",
+        task_description=big_desc,
+        task_dependencies=[],
+        plan_context=big_context,
+    )
+
+    assert big_desc in captured["prompt"]
+    assert big_context in captured["prompt"]


### PR DESCRIPTION
## Summary

The coding team clipped almost every input it fed to an LLM via naive string slicing — plan/spec/architecture documents, task descriptions, repo context, and the diff under review — plus a configurable review-evidence cap. These caps silently dropped information: a reviewer could reject an otherwise-good task because the diff was cut, an engineer could implement against a truncated spec, and the Tech Lead could plan from clipped requirements.

Inputs are now passed through **in full**.

## Changes

**Removed input truncation (LLM inputs):**
- `tech_lead_agent/agent.py` `_plan_text` — requirements description, project overview, spec content, architecture overview.
- `tech_lead_agent/agent.py` `run_groom_task` — task description, plan context.
- `senior_software_engineer_agent/agent.py` `run_implement` — task description (`_IMPLEMENT_DESCRIPTION_MAX_CHARS` removed) and the redundant repo-context cap.
- `orchestrator.py` review evidence — the `CODING_TEAM_REVIEW_EVIDENCE_MAX_CHARS` env var and the bounded `_build_review_evidence` helper are gone; the reviewer now gets the full summary + full diff (and the now-unused `import os`).

**Removed log/error-string trims:**
- build error log line, git command output, GitHub API error-body message.

**Deliberately kept (not document/review inputs):**
- GitHub's hard 256-char PR title limit (`_truncate_title`).
- The issue-pagination safety bound (`MAX_ISSUES_TRAVERSED`).
- The orchestrator's repo-context **summary** caps — a generated orientation aid; engineers can already read any file in full via the uncapped `read_file` tool.

## Behavior on genuine overflow

A pathological input that truly exceeds the model context now fails a single task cleanly via the existing `review.get("error")` path (no retry loop), instead of silently reviewing partial evidence. The implement path remains bounded by `_handle_incomplete_implementation` + `MAX_TASK_REVISIONS`, so removal does not reintroduce a cascading retry loop. This matches the existing "deliberately uncapped" `read_file` precedent.

## Tests

- Rewrote the review-evidence and implement-cap tests to assert **full pass-through** (oversized inputs reach the prompt uncut; a 120k-char diff reaches the reviewer whole).
- Added Tech Lead tests asserting `_plan_text` and `run_groom_task` pass oversized fields through in full.
- `ruff check` passes; coding-team line coverage stays above the 90% floor (91.24%, 218 passed).

Closes #783


---
_Generated by [Claude Code](https://claude.ai/code/session_01MYeQPuEFwhHEzfJ43zUgBB)_