### PR TITLE
Fix rule-probe exit synthesis so stop-loss no longer pre-empts the targeted exit

### DIFF
--- a/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/synthesizer.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/synthesizer.py
@@ -467,6 +467,24 @@ def _build_exit_probe(
         if entry_bars is None:
             last_failure = f"entry_prefix_not_synthesizable: {entry_reason}"
             continue
+        # Trim the entry prefix so its final bar is the one the compiled
+        # strategy actually opens its position on, then append the exit tail
+        # directly after it. Without this trim the remainder of the entry
+        # prefix stays stitched between the open bar and the exit tail — and
+        # for any recipe that drives the predicate with sustained directional
+        # motion (RSI decline, MACD trend, Bollinger breakout, a price-ref
+        # spike that snaps back to baseline, …) that remainder keeps moving
+        # price *against* the just-opened position. The strategy's own
+        # engine-enforced stop-loss then fires (repeatedly) inside the prefix,
+        # long before the synthesised exit-trigger bar, so the stop-loss probe
+        # sees "all closed before trigger bar" and the take-profit probe never
+        # keeps a position alive long enough to reach its target. Trimming the
+        # prefix lets the targeted exit rule fire as designed.
+        trimmed = _truncate_entry_prefix_for_exit(entry_bars, entry_trigger_idx, entry_rule.when)
+        if trimmed is None:
+            last_failure = "entry_prefix_open_bar_unverifiable"
+            continue
+        entry_bars, entry_trigger_idx = trimmed
         entry_close = entry_bars[entry_trigger_idx].close
         entry_side = entry_rule.side
         probe = _build_exit_probe_with_prefix(
@@ -488,6 +506,67 @@ def _build_exit_probe(
         synthesizable=False,
         unprobeable_reason=last_failure,
     )
+
+
+def _predicate_warmup_min(pred: Predicate) -> int:
+    """Compiled-strategy warm-up gate for ``pred`` — the smallest bar index
+    at which the strategy can act on this predicate.
+
+    Mirrors ``synthesis/compiler.py``: the compiled ``on_bar`` returns until
+    ``len(history) >= max(per-indicator lookback, _MIN_WINDOW)``. With one bar
+    of history per index, that gate first opens at index
+    ``max(per-indicator lookback, _COMPILER_MIN_WINDOW)``. Price-ref-only
+    predicates carry no indicator lookback and warm up at the floor.
+
+    Postconditions: returns ``>= _COMPILER_MIN_WINDOW``.
+    """
+    warmup = _COMPILER_MIN_WINDOW
+    for side in (pred.lhs, pred.rhs):
+        if isinstance(side, IndicatorRef):
+            warmup = max(warmup, _lookback_for_synth(side))
+    return warmup
+
+
+def _truncate_entry_prefix_for_exit(
+    entry_bars: List[OHLCVBar],
+    entry_trigger_idx: int,
+    pred: Predicate,
+) -> Optional[Tuple[List[OHLCVBar], int]]:
+    """Trim ``entry_bars`` so its final bar is the bar the compiled strategy
+    opens its position on, and return ``(trimmed_bars, open_idx)``.
+
+    The harness suppresses ``on_bar`` until the compiled strategy's warm-up
+    gate (``len(history) >= warmup_min``) is satisfied, so the strategy opens
+    on the *first post-warm-up* bar whose predicate holds — never on the
+    recipe's earlier ``entry_trigger_idx`` when that index sits inside the
+    warm-up window. ``open_idx`` models that bar as
+    ``max(entry_trigger_idx, warmup_min)`` where ``warmup_min`` is the
+    compiler's gate for this predicate's indicators
+    (``_lookback_for_synth`` floored at ``_COMPILER_MIN_WINDOW``). Tracking
+    the real warm-up (rather than a fixed floor) keeps the truncation aligned
+    with the strategy's open bar for longer-period indicators too, so the
+    prefix is never trimmed shorter than the strategy needs to open.
+
+    Preconditions:
+      - ``entry_bars`` is a non-empty recipe prefix; ``entry_trigger_idx`` is
+        a valid index into it where ``pred`` is known to hold.
+    Postconditions:
+      - On success the returned bars are ``entry_bars[: open_idx + 1]`` and
+        ``pred`` holds at ``open_idx`` (the trimmed prefix's last bar), so the
+        compiled strategy opens there and the exit tail the caller appends
+        immediately follows the open bar — no adverse prefix motion in
+        between.
+      - Returns ``None`` when ``open_idx`` is out of range or ``pred`` does
+        not hold at ``open_idx`` (a recipe whose signal is not sustained to
+        the warm-up floor). The caller marks the probe unprobeable rather than
+        shipping a prefix the strategy can't actually open on.
+    """
+    open_idx = max(entry_trigger_idx, _predicate_warmup_min(pred))
+    if open_idx >= len(entry_bars):
+        return None
+    if not _eval_predicate_at(pred, entry_bars, open_idx):
+        return None
+    return entry_bars[: open_idx + 1], open_idx
 
 
 def _build_exit_probe_with_prefix(

--- a/backend/agents/investment_team/tests/test_rule_probes_synthesis.py
+++ b/backend/agents/investment_team/tests/test_rule_probes_synthesis.py
@@ -352,3 +352,51 @@ def test_bars_to_df_columns_match_ohlcv():
     runs = generate_rule_probe_runs(_spec_with(entry_rules=[entry_rule]))
     df = _bars_to_df(runs[0].market_data)
     assert set(df.columns) == {"open", "high", "low", "close", "volume"}
+
+
+# ---------------------------------------------------------------------------
+# Exit-probe entry-prefix truncation (stop-loss must not pre-empt the
+# targeted exit rule on a sustained-directional entry recipe).
+# ---------------------------------------------------------------------------
+
+
+def test_exit_probe_truncates_sustained_entry_prefix():
+    """A sustained-decline long entry (RSI < 30) used to stitch the *entire*
+    ~80-bar declining recipe prefix in front of the exit tail. The strategy's
+    own stop-loss then fired inside that prefix (price kept falling after the
+    position opened), so the stop-loss probe saw exits "before the trigger
+    bar" and the take-profit probe never kept a position alive long enough to
+    reach its target.
+
+    The synthesiser now trims the prefix to the bar the compiled strategy
+    actually opens on, so the exit tail directly follows the open bar and the
+    bars between the open and the trigger are flat at the entry close (no
+    adverse drift to trip the stop early).
+    """
+    entry = EntryRule(
+        side="long",
+        when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op="<", rhs=30.0),
+    )
+    stop = StopLossRule(pct=0.05)
+    tp = TakeProfitRule(pct=0.10)
+    [_entry_probe, stop_probe, tp_probe] = generate_rule_probe_runs(
+        _spec_with(entry_rules=[entry], exit_rules=[stop, tp])
+    )
+
+    for probe in (stop_probe, tp_probe):
+        assert probe.synthesizable
+        md = probe.market_data
+        # Full RSI recipe prefix is ~80 bars; truncation keeps only the
+        # warm-up lead-in (~20 bars) plus the short exit tail, so the stitched
+        # series is far shorter than the untrimmed ~89-bar version.
+        assert len(md) < 40, f"{probe.rule_id}: prefix not truncated ({len(md)} bars)"
+        # The open bar is the last prefix bar; the three quiet tail bars that
+        # follow it (immediately before the trigger) sit flat at the entry
+        # close rather than continuing the recipe's decline.
+        trigger = probe.trigger_bar_index
+        open_close = md[trigger - 4].close
+        for quiet in md[trigger - 3 : trigger]:
+            assert abs(quiet.close - open_close) <= 0.05 * open_close, (
+                f"{probe.rule_id}: post-open bar drifts from entry close "
+                f"({quiet.close} vs {open_close})"
+            )


### PR DESCRIPTION
## Root cause

Strategy Lab strategies were consistently failing to get accepted because the **`RuleProbesGate`** emitted false-critical failures for the most common strategy shape — a directional/mean-reversion entry paired with a protective stop-loss and a take-profit. The reported logs were:

```
rule_id=exit[0]:stop_loss: found 12 trade(s) with exit_reason matching 'stop_loss'
  but all closed before trigger bar 2024-03-24; targeted rule likely not the actual exit cause.
rule_id=exit[1]:take_profit: no trade closed with exit_reason containing 'take_profit'.
```

The gate builds one synthetic OHLCV sequence per exit rule by stitching the entry rule's recipe prefix in front of an exit tail (`quality_gates/rule_probes/synthesizer.py:_build_exit_probe`). For any entry recipe that drives its predicate with **sustained directional price motion** — RSI decline, MACD trend, Bollinger breakout, or a price-ref spike that snaps back to baseline — the *entire* prefix (~80 bars) was left stitched between the bar the strategy opens on and the exit tail. That remainder keeps moving price **against** the just-opened position, so the strategy's own engine-enforced stop-loss fires inside the prefix, repeatedly, long before the synthesised exit-trigger bar:

- the **stop-loss probe** sees the stop fire during the prefix → *"all closed before trigger bar"*;
- the **take-profit probe** never keeps a position alive to its target (it gets stopped out first) → *"no trade closed with take_profit"*.

Both are **false criticals** — the strategy code is correct; the failure is an artifact of the probe data. They route through the synthesis loop's `_refine_or_exhaust(failure_phase="validation")` path, which cannot fix correct code, so the loop exhausts its refinement rounds and the lab never accepts a strategy.

This was reproduced end-to-end through the real gate (exact match to the reported logs) and the fix verified the same way.

## Fix

Trim the entry prefix to the bar the compiled strategy **actually opens on** (`max(entry_trigger_idx, warmup_min)`, where `warmup_min` mirrors `synthesis/compiler.py`'s per-indicator warm-up gate) before appending the exit tail. The tail's quiet bars then follow the open directly, so:

- the stop fires exactly at the synthesised trigger bar (stop-loss probe passes), and
- the take-profit keeps a position alive to its target (take-profit probe passes).

When the predicate does not hold at the post-warm-up open bar, the probe is marked unprobeable rather than shipping a prefix the strategy can't open on. The truncation tracks the real per-indicator warm-up, so it stays aligned for longer-period indicators (e.g. RSI(30)) too.

## Validation

- Reproduced the exact failure, then confirmed the fix resolves it for RSI(14) long stop+take-profit, price-ref long, take-profit-only, and stop-only specs (both probes now `info`/pass).
- **All 375** rule-probe / exit-rule-conformance / rule-firing-rate tests pass; `ruff` clean.
- Added a synthesizer-level regression test asserting the prefix is trimmed and the post-open bars are flat at the entry close.

## Follow-up (out of scope, noted)

A separate, pre-existing probe-data weakness surfaced during validation: for longer-period / short-side / cross recipes the fixed-length (~80-bar) synthetic prefix leaves too few post-warm-up bars for a round-trip, so the `entry[0]` probe (unchanged by this PR) reports "no trades recorded". This is a probe-calibration limitation (real backtests have thousands of bars) and is tracked separately from the stop-pre-emption fix here.

Closes #791