### PR TITLE
Stop truncating the Senior SWE repo-context briefing

### DIFF
--- a/backend/agents/coding_team/orchestrator.py
+++ b/backend/agents/coding_team/orchestrator.py
@@ -97,12 +97,27 @@ def _context_file_filters() -> tuple[frozenset[str], frozenset[str]]:
     return _CONTEXT_EXTENSIONS, _CONTEXT_EXCLUDE_DIRS
 
 
-def _read_repo_context(repo_path: Path, max_chars: int = 4000) -> str:
-    """Read a short summary of repo structure/code for Senior SWE context."""
+def _read_repo_context(repo_path: Path) -> str:
+    """Read the repo structure/code briefing for Senior SWE context.
+
+    Every file the briefing includes is rendered with its FULL contents — the
+    engineer reasons over this to implement a task, and clipping a file would
+    hide code from it (mirroring the team's "inputs are never truncated"
+    contract for the plan text, task description, and review diff). The 80-file
+    ceiling on ``sorted(repo_path.rglob("*"))`` is a deliberate cap on how many
+    files the briefing covers, not truncation of any file's content.
+
+    Preconditions:
+        - ``repo_path`` is an existing directory.
+    Postconditions:
+        - Each context-eligible file (matching ``_context_file_filters`` and
+          within the 80-file scan ceiling) appears with its complete contents,
+          never a prefix; no eligible file is dropped to fit a size budget.
+        - Returns ``"No files found"`` when no eligible file is present.
+    """
     extensions, exclude_dirs = _context_file_filters()
 
     parts: List[str] = []
-    total = 0
     try:
         for f in sorted(repo_path.rglob("*"))[:80]:
             if not f.is_file() or f.suffix not in extensions:
@@ -110,15 +125,11 @@ def _read_repo_context(repo_path: Path, max_chars: int = 4000) -> str:
             if any(skip in f.parts for skip in exclude_dirs):
                 continue
             try:
-                content = f.read_text(encoding="utf-8", errors="replace")[:500]
+                content = f.read_text(encoding="utf-8", errors="replace")
             except Exception:
                 continue
             rel = str(f.relative_to(repo_path))
-            chunk = f"--- {rel} ---\n{content}\n"
-            if total + len(chunk) > max_chars:
-                break
-            parts.append(chunk)
-            total += len(chunk)
+            parts.append(f"--- {rel} ---\n{content}\n")
     except Exception:
         pass
     return "\n".join(parts) if parts else "No files found"

--- a/backend/agents/coding_team/tests/test_swarm_review.py
+++ b/backend/agents/coding_team/tests/test_swarm_review.py
@@ -170,7 +170,9 @@ def test_review_error_fails_task_once_without_revision_loop(tmp_path, monkeypatc
     _patch_git(monkeypatch)
 
     class ErrTechLead(StubTechLead):
-        def run_code_review(self, task_title, task_description, acceptance_criteria, changes_summary):
+        def run_code_review(
+            self, task_title, task_description, acceptance_criteria, changes_summary
+        ):
             self.review_calls.append(changes_summary)
             return {
                 "approved": False,
@@ -281,7 +283,8 @@ def test_review_explicit_false_is_substantive_rejection(monkeypatch):
 
     monkeypatch.setattr(tl_mod, "Agent", lambda **kw: object())
     monkeypatch.setattr(
-        tl_mod, "_agent_call_json",
+        tl_mod,
+        "_agent_call_json",
         lambda agent, prompt: {"approved": False, "reason": "needs tests"},
     )
     tl = tl_mod.TechLeadAgent(model=object())
@@ -714,6 +717,30 @@ def test_read_repo_context_includes_markdown(tmp_path):
     ctx = orch_mod._read_repo_context(tmp_path)
     assert "spec.md" in ctx
     assert "The plan lives here." in ctx
+
+
+def test_read_repo_context_is_not_truncated(tmp_path):
+    """The briefing renders each included file in full and never drops a file to fit a size budget.
+
+    Guards against reintroducing the old per-file 500-char slice and the 4000-char total budget:
+    the engineer's repo context is an LLM input and is never truncated. The 80-file scan ceiling is
+    a deliberate cap, not truncation, so this stays within it.
+    """
+    # A single file well past the old 500-char per-file slice — its tail must survive.
+    big_tail = "TAIL_MARKER_" + ("Z" * 4000)
+    (tmp_path / "big.py").write_text("# header\n" + big_tail)
+
+    # Several files whose combined size blows past the old 4000-char budget; a late file (by sorted
+    # order) must still appear rather than being dropped once the budget filled.
+    for i in range(10):
+        (tmp_path / f"mod_{i:02d}.py").write_text(f"VALUE_{i:02d} = " + "'" + ("x" * 1000) + "'\n")
+
+    ctx = orch_mod._read_repo_context(tmp_path)
+
+    assert big_tail in ctx  # full file contents, not a 500-char prefix
+    assert len(ctx) > 4000  # no total-size budget cut the briefing short
+    assert "mod_09.py" in ctx  # the last file survived; no file dropped to fit a budget
+    assert "VALUE_09" in ctx
 
 
 def test_repo_context_refreshed_between_rounds(tmp_path, monkeypatch):


### PR DESCRIPTION
## What

The coding team is built around an explicit contract: an engineer's inputs are never truncated. The Tech Lead plan text, the Senior SWE task description, and the Tech Lead review diff are all passed to the LLM in full (with tests asserting it up to 200K chars). One function was the lone holdout — `orchestrator._read_repo_context`, the repo briefing fed into **every** Senior SWE prompt — and it silently discarded content that actually exists:

- `f.read_text(...)[:500]` shipped only the **first 500 chars** of each included file.
- A 4000-char running budget `break`'d mid-scan and **dropped every remaining file** once the budget filled.

On any non-trivial repo this hid most of the codebase from the engineer, with no marker that anything was cut.

## Change

- Render each included file in **full** (removed the per-file 500-char slice).
- Never stop part-way and drop files (removed the `max_chars` parameter and the 4000-char budget break).
- **Kept** the 80-file scan ceiling — that is a deliberate cap on *how many* files the briefing covers, not truncation of any file's content.
- Rewrote the docstring with an explicit pre/postcondition contract and added `test_read_repo_context_is_not_truncated` to lock it.

The two call sites already invoked `_read_repo_context(path)` with no size argument, so dropping the parameter needs no caller changes.

## Verification

- `ruff check` / `ruff format --check` clean on the changed files.
- `pytest agents/coding_team/tests` — **296 passed** (no test depended on the old 500/4000 limits).

No associated issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_019iSzanQGFc6DUbki2rbhxi)_