### PR TITLE
Fix SE test job hang: mirror 429 backoff disable into rootdir-overriding suites

### DIFF
--- a/backend/agents/nutrition_meal_planning_team/tests/conftest.py
+++ b/backend/agents/nutrition_meal_planning_team/tests/conftest.py
@@ -20,6 +20,9 @@ for _d in (_backend_dir, _agents_dir):
 # Disable LLM retries so tests that hit an unavailable LLM fail fast and fall
 # through to structural fallback paths rather than waiting minutes.
 os.environ.setdefault("LLM_MAX_RETRIES", "0")
+# Disable the slow 429 rate-limit backoff so no test can ever sleep the 300s+
+# schedule (this team overrides pytest's rootdir, hiding backend/conftest.py).
+os.environ.setdefault("LLM_RATE_LIMIT_MAX_RETRIES", "0")
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/backend/agents/software_engineering_team/conftest.py
+++ b/backend/agents/software_engineering_team/conftest.py
@@ -11,6 +11,9 @@ from pathlib import Path
 
 # Disable LLM retries so tests that hit an unavailable LLM fail fast.
 os.environ.setdefault("LLM_MAX_RETRIES", "0")
+# Disable the slow 429 rate-limit backoff so no test can ever sleep the 300s+
+# schedule (this team overrides pytest's rootdir, hiding backend/conftest.py).
+os.environ.setdefault("LLM_RATE_LIMIT_MAX_RETRIES", "0")
 
 # Add software_engineering_team and agents to path so imports resolve.
 # software_engineering_team must come first so its modules take precedence over agents/.

--- a/backend/agents/software_engineering_team/tests/conftest.py
+++ b/backend/agents/software_engineering_team/tests/conftest.py
@@ -13,6 +13,10 @@ import pytest
 # succeed; real HTTP calls will fail loudly.
 os.environ.setdefault("LLM_MAX_RETRIES", "0")
 os.environ.setdefault("JOB_SERVICE_URL", "http://127.0.0.1:1")
+# Disable the slow 429 rate-limit backoff so no test can ever sleep the 300s+
+# schedule.  Mirrored here because this team overrides pytest's rootdir, so the
+# matching default in ``backend/conftest.py`` is not auto-discovered.
+os.environ.setdefault("LLM_RATE_LIMIT_MAX_RETRIES", "0")
 
 # Re-export the in-memory FakeJobServiceClient + ``fake_job_client`` fixture so
 # unit tests in this team can use them.  The SE team's ``pyproject.toml``

--- a/backend/agents/software_engineering_team/tests/test_llm.py
+++ b/backend/agents/software_engineering_team/tests/test_llm.py
@@ -20,9 +20,16 @@ from llm_service import (
 
 
 def test_ollama_429_raises_rate_limit_error_after_retries() -> None:
-    """When Ollama returns 429 repeatedly, LLMRateLimitError is raised after max retries."""
+    """When Ollama returns 429 repeatedly, LLMRateLimitError is raised once the
+    rate-limit retry budget is exhausted.
+
+    The 429 path uses the dedicated *slow* rate-limit schedule (first wait 300s+),
+    so this test pins ``LLM_RATE_LIMIT_MAX_RETRIES`` and patches ``time.sleep`` to
+    a no-op: it exercises the retry-then-raise path without ever waiting the real
+    backoff, independent of the ambient conftest defaults.
+    """
     client = OllamaLLMClient(model="test", base_url="http://localhost:9999", timeout=5)
-    with patch("httpx.Client") as mock_client_cls:
+    with patch("httpx.Client") as mock_client_cls, patch("time.sleep") as mock_sleep:
         mock_response = MagicMock()
         mock_response.status_code = 429
         mock_response.headers = {}
@@ -31,12 +38,18 @@ def test_ollama_429_raises_rate_limit_error_after_retries() -> None:
         mock_client.stream.return_value.__enter__.return_value = mock_response
         mock_client_cls.return_value.__enter__.return_value = mock_client
 
-        with patch.dict(os.environ, {"LLM_MAX_RETRIES": "1"}, clear=False):
+        with patch.dict(
+            os.environ,
+            {"LLM_MAX_RETRIES": "1", "LLM_RATE_LIMIT_MAX_RETRIES": "1"},
+            clear=False,
+        ):
             with pytest.raises(LLMRateLimitError) as exc_info:
                 client.complete_json("test prompt")
 
     assert exc_info.value.status_code == 429
     assert "429" in str(exc_info.value) or "rate" in str(exc_info.value).lower()
+    # One 429 retry was taken on the slow schedule — but no real time was spent.
+    assert mock_sleep.called
 
 
 def test_ollama_weekly_limit_message_constant() -> None:


### PR DESCRIPTION
## Why

This stacks on top of #789 to fix the **Test – Software Engineering Team** CI job, which hangs ~13.5 min and gets cancelled by GitHub Actions (all other team jobs finish in <3 min).

### Root cause

#789 routes HTTP **429** retries onto a new, deliberately-slow schedule (`LLM_RATE_LIMIT_*`: default **5 retries**, first wait **300s**, doubling to a 3600s cap), and neutralizes it in tests with `os.environ.setdefault("LLM_RATE_LIMIT_MAX_RETRIES", "0")` — but **only** in `backend/conftest.py`.

The software-engineering and nutrition teams **override pytest's rootdir**, so `backend/conftest.py` is not auto-discovered for those suites; they manually mirror the env defaults (`LLM_MAX_RETRIES`, `JOB_SERVICE_URL`) in their own conftests. The new rate-limit default was never mirrored there.

As a result the pre-existing SE test `test_ollama_429_raises_rate_limit_error_after_retries` — which mocks `httpx.Client` to return 429 repeatedly and does **not** mock `time.sleep` — ran with the default 5×300s+ schedule and slept ~300s, then ~600s, hanging the job until cancellation. (The `ValueError: I/O operation on closed file` heartbeat tracebacks in the failing log are incidental background-thread noise that only surface because the process stays alive during the hang — a symptom, not the cause.)

## What changed

- Mirror `os.environ.setdefault("LLM_RATE_LIMIT_MAX_RETRIES", "0")` into the three conftests that override pytest's rootdir and already mirror `LLM_MAX_RETRIES`:
  - `software_engineering_team/tests/conftest.py` (the suite the failing test loads)
  - `software_engineering_team/conftest.py` (covers `cd software_engineering_team && pytest`)
  - `nutrition_meal_planning_team/tests/conftest.py` (same rootdir gap — defense in depth)
- Harden `test_ollama_429_raises_rate_limit_error_after_retries` to be self-contained: it now pins the rate-limit retry budget and patches `time.sleep`, so it exercises the retry-then-raise path without ever waiting real seconds, independent of ambient conftest defaults.

## Testing

```
$ LLM_PROVIDER=dummy pytest software_engineering_team/tests/test_llm.py -k 429 -v
1 passed in 0.14s          # was hanging ~300s+

$ LLM_PROVIDER=dummy pytest software_engineering_team/tests/test_llm.py -q
22 passed, 2 skipped in 4.37s
```

Ruff lint + format clean on all changed files.

## Notes

This PR targets the `llm-429-rate-limit-backoff` branch so its diff is only the fix; merging it makes #789's SE job green. No separate tracking issue exists for this CI fix, so `Closes #N` is omitted (and would be inert against a non-default base branch anyway) — happy to open one if preferred.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8dq56tZhYssep2JgvW53d)_