### PR TITLE
Stop SE API tests leaking background workflow threads (I/O on closed file)

### DIFF
--- a/backend/agents/software_engineering_team/tests/conftest.py
+++ b/backend/agents/software_engineering_team/tests/conftest.py
@@ -2,10 +2,22 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import Any
 
 import pytest
+
+# Fire-and-forget daemon threads (job heartbeats, the stale-job monitor, the
+# background workflow workers) can emit a log record after pytest has torn down
+# a test's capture streams, surfacing as a noisy
+# "--- Logging error --- ValueError: I/O operation on closed file" traceback on
+# stderr. That is a teardown-race artifact, not a test failure: the handler's
+# emit() raises because the captured stream is already closed. Flip logging to
+# its documented production setting so a failed handler emit is swallowed instead
+# of dumping a traceback. (The heavy workers are still stubbed at the source in
+# the per-endpoint API tests; this only silences the residual race.)
+logging.raiseExceptions = False
 
 # Mirror the env defaults from ``backend/conftest.py`` (not auto-discovered
 # here because this team overrides pytest's rootdir).  The placeholder

--- a/backend/agents/software_engineering_team/tests/test_backend_code_v2_api.py
+++ b/backend/agents/software_engineering_team/tests/test_backend_code_v2_api.py
@@ -37,6 +37,21 @@ def _autouse_patched_job_store(patched_job_store):
     return patched_job_store
 
 
+@pytest.fixture(autouse=True)
+def _stub_background_workflow(monkeypatch):
+    """Replace the fire-and-forget workflow worker with a no-op.
+
+    The ``POST /backend-code-v2/run`` endpoint spawns a daemon thread that runs
+    the real (integration-only) backend workflow. These unit tests only assert
+    the endpoint contract, so without this stub the thread keeps executing after
+    the test returns and logs to closed pytest capture streams
+    ("ValueError: I/O operation on closed file"). Mirrors the
+    ``patch.object(_api_main, "_run_orchestrator_background")`` pattern used for
+    the /run-team endpoint tests.
+    """
+    monkeypatch.setattr(_api_main, "_run_backend_code_v2_background", lambda *a, **k: None)
+
+
 @pytest.fixture
 def client() -> TestClient:
     return TestClient(app)

--- a/backend/agents/software_engineering_team/tests/test_frontend_code_v2_api.py
+++ b/backend/agents/software_engineering_team/tests/test_frontend_code_v2_api.py
@@ -37,6 +37,21 @@ def _autouse_patched_job_store(patched_job_store):
     return patched_job_store
 
 
+@pytest.fixture(autouse=True)
+def _stub_background_workflow(monkeypatch):
+    """Replace the fire-and-forget workflow worker with a no-op.
+
+    The ``POST /frontend-code-v2/run`` endpoint spawns a daemon thread that runs
+    the real (integration-only) 6-phase frontend workflow. These unit tests only
+    assert the endpoint contract, so without this stub the thread keeps executing
+    after the test returns and logs to closed pytest capture streams
+    ("ValueError: I/O operation on closed file"). Mirrors the
+    ``patch.object(_api_main, "_run_orchestrator_background")`` pattern used for
+    the /run-team endpoint tests.
+    """
+    monkeypatch.setattr(_api_main, "_run_frontend_code_v2_background", lambda *a, **k: None)
+
+
 @pytest.fixture
 def client() -> TestClient:
     return TestClient(app)


### PR DESCRIPTION
## Why

After the 429 hang fix (#806) the **Test – Software Engineering Team** job passes (`1813 passed … in 83.76s`, 93% coverage), but its log is polluted with:

```
--- Logging error ---
ValueError: I/O operation on closed file.
  ...
  api/main.py:1667 in _run_frontend_code_v2_background
  frontend_code_v2_team/orchestrator.py ... run_workflow
  frontend_code_v2_team/phases/execution.py:261/288 in run_execution_with_review_gates
    logger.info("[%s] Starting execution with batch review flow ...")
```

### Root cause

`POST /frontend-code-v2/run` (and the identical `POST /backend-code-v2/run`) spawn a **fire-and-forget daemon thread** that runs the real, integration-only workflow (`FrontendCodeV2TeamLead.run_workflow` → execution phase). The endpoint contract tests in `test_frontend_code_v2_api.py` / `test_backend_code_v2_api.py` only assert the response and return immediately — they never stub that worker. So the daemon thread keeps executing the workflow after the test returns and calls `logger.info(...)` against pytest's already-closed per-test capture stream → `ValueError: I/O operation on closed file`. It's a teardown-race artifact, not a failure, which is why the job stays green.

This is the same class of leaked-daemon-thread noise seen earlier from the job heartbeat / stale-job monitor.

## What changed

- **Stub the worker at the source.** Add an `autouse` fixture in each v2 API test module that no-ops `_run_{frontend,backend}_code_v2_background`, mirroring the existing `patch.object(_api_main, "_run_orchestrator_background")` pattern used for the `/run-team` tests. The endpoint logic (thread spawn + response) is still exercised; the spawned thread just exits immediately instead of running integration-only code in a unit test.
- **Safety net.** Set `logging.raiseExceptions = False` in the SE `tests/conftest.py`. Other self-terminating daemon threads (job heartbeats, the stale-job monitor) can lose the same teardown race; this is logging's documented production setting for swallowing a failed handler `emit()` instead of dumping a traceback. It does not affect captured logs or test logic.

## Testing

```
# frontend + backend v2 API tests — green and noise-free
$ LLM_PROVIDER=dummy pytest .../test_frontend_code_v2_api.py .../test_backend_code_v2_api.py
14 passed in 1.54s        # 0 "I/O operation on closed file"

# combined with the /run-team + stale-monitor + orchestrator-thread tests
$ LLM_PROVIDER=dummy pytest .../test_api.py .../test_api_more_routes.py .../test_*code_v2_api.py
74 passed in 63.11s       # 0 "I/O operation on closed file"

# full SE suite still collects
1816 tests collected
```

Ruff lint + format clean on all three files. The fix is verified against the exact CI traceback: the no-op worker means the `_run_frontend_code_v2_background → run_workflow → run_execution_with_review_gates → logger.info` chain can never execute.

## Notes

Targets `llm-429-rate-limit-backoff` so it stacks cleanly on #789 alongside the already-merged #806; merging keeps #789's SE job both green **and** clean. No separate tracking issue exists, so `Closes #N` is omitted (and would be inert against a non-default base) — happy to open one if preferred.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8dq56tZhYssep2JgvW53d)_