### PR TITLE
Strategy Lab: remove expected-trade-count anomaly gate

### DIFF
--- a/backend/agents/investment_team/ARCHITECTURE_REVIEW.md
+++ b/backend/agents/investment_team/ARCHITECTURE_REVIEW.md
@@ -260,7 +260,6 @@ When `ideate_strategy()` returns a strategy dict, the only check is JSON validit
 
 The 8% annualized return threshold is the only quality gate. No detection of:
 - Suspiciously high returns (>200% annualized = likely bug or data issue)
-- Too few trades (<5 in a year = statistically meaningless)
 - Unrealistic win rates (>90% on swing trades = almost certainly overfitting)
 - Extreme profit factors (>10 = usually data snooping)
 

--- a/backend/agents/investment_team/scripts/audit_recent_runs.py
+++ b/backend/agents/investment_team/scripts/audit_recent_runs.py
@@ -58,14 +58,6 @@ _INDICATOR_NAMES = frozenset(
     }
 )
 
-_DEFAULT_EXPECTED_HOLD_DAYS: Dict[str, float] = {
-    "1d": 10.0,
-    "1h": 0.5,
-    "15m": 0.1,
-    "5m": 0.04,
-    "1m": 0.01,
-}
-
 _MULTIPLIER_TOL = 1e-6
 
 _POST_DESIGN_PHASES = frozenset({"synthesis", "verification"})
@@ -503,51 +495,6 @@ def check_narrative_fidelity(record: Dict[str, Any]) -> CheckResult:
     return CheckResult(name, "PASS")
 
 
-def check_trade_adequacy(record: Dict[str, Any]) -> CheckResult:
-    """Trade count must meet or exceed the expected count for the backtest window."""
-    name = "trade_adequacy"
-    config = _config(record)
-    start_date = config.get("start_date")
-    end_date = config.get("end_date")
-    timeframe = _spec(record).get("timeframe")
-    trades = _trades(record)
-
-    if not start_date or not end_date:
-        return CheckResult(name, "SKIP", "Missing backtest dates")
-    if not trades:
-        return CheckResult(name, "SKIP", "No trades")
-
-    try:
-        start_str = str(start_date).split("T")[0]
-        end_str = str(end_date).split("T")[0]
-        window_days = (date.fromisoformat(end_str) - date.fromisoformat(start_str)).days
-    except (ValueError, TypeError):
-        return CheckResult(name, "SKIP", "Unparseable backtest dates")
-    if window_days < 0:
-        return CheckResult(name, "SKIP", "Negative backtest window")
-    if window_days == 0:
-        window_days = 1
-
-    observed_holds = [h for t in trades if (h := _safe_float(t.get("hold_days"), 0.0)) and h > 0]
-    if observed_holds:
-        expected_hold = sum(observed_holds) / len(observed_holds)
-    else:
-        expected_hold = _DEFAULT_EXPECTED_HOLD_DAYS.get(str(timeframe), 0.0)
-    if not expected_hold or expected_hold <= 0:
-        return CheckResult(name, "SKIP", "Cannot determine expected hold days")
-
-    expected_count = max(1, round(window_days / expected_hold))
-    n_trades = len(trades)
-    if n_trades >= expected_count:
-        return CheckResult(name, "PASS")
-    return CheckResult(
-        name,
-        "FAIL",
-        f"n_trades={n_trades} < expected={expected_count} "
-        f"(window={window_days}d, hold={expected_hold:.1f}d)",
-    )
-
-
 def check_liquidity_realism(record: Dict[str, Any]) -> CheckResult:
     """Liquidity-realism gate must not have critical failures."""
     name = "liquidity_realism"
@@ -605,7 +552,6 @@ ALL_CHECKS: List[Callable[[Dict[str, Any]], CheckResult]] = [
     check_cost_robustness,
     check_regime_coverage,
     check_narrative_fidelity,
-    check_trade_adequacy,
     check_liquidity_realism,
     check_no_dead_code_rules,
 ]
@@ -618,7 +564,6 @@ _SHORT_NAMES = {
     "cost_robustness": "cost_rob",
     "regime_coverage": "regime",
     "narrative_fidelity": "narrative",
-    "trade_adequacy": "trade_adeq",
     "liquidity_realism": "liquidity",
     "no_dead_code_rules": "dead_code",
 }

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -1875,9 +1875,6 @@ class StrategyLabOrchestrator:
                 dsr_aware=config.walk_forward_enabled,
                 diagnostics=exec_result.execution_diagnostics,
                 coverage_report=metrics.coverage_report,
-                start_date=config.start_date,
-                end_date=config.end_date,
-                timeframe=spec.timeframe,
                 market_data=market_data,
             )
             self.record_gates(anomaly_gates, all_gate_results, refinement_round=round_num)
@@ -2475,9 +2472,6 @@ class StrategyLabOrchestrator:
             diagnostics=align_exec.execution_diagnostics,
             coverage_report=new_metrics.coverage_report,
             phase="verification",
-            start_date=config.start_date,
-            end_date=config.end_date,
-            timeframe=proposed_spec.timeframe,
             market_data=market_data,
         )
         self.record_gates(
@@ -2709,9 +2703,6 @@ class StrategyLabOrchestrator:
                 dsr_aware=False,
                 coverage_report=metrics.coverage_report,
                 phase="verification",
-                start_date=config.start_date,
-                end_date=config.end_date,
-                timeframe=spec.timeframe,
                 market_data=market_data,
             )
             fallback_criticals = [

--- a/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date, datetime
 from functools import cached_property
 from typing import ClassVar, Dict, Iterable, List, Optional
 
@@ -28,9 +27,6 @@ class BacktestAnomalyCtx:
     dsr_aware: bool
     diagnostics: Optional[BacktestExecutionDiagnostics]
     coverage_report: Optional[CoverageReport]
-    start_date: Optional[str] = None
-    end_date: Optional[str] = None
-    timeframe: Optional[str] = None
     market_data: Optional[Dict[str, List[OHLCVBar]]] = None
 
     # Per-trade reductions multiple rules need. Computed once and memoised on
@@ -145,9 +141,6 @@ class BacktestAnomalyDetector(GateResultsMixin):
         diagnostics: Optional[BacktestExecutionDiagnostics] = None,
         coverage_report: Optional[CoverageReport] = None,
         phase: StrategyLabPhase = "synthesis",
-        start_date: Optional[str] = None,
-        end_date: Optional[str] = None,
-        timeframe: Optional[str] = None,
         market_data: Optional[Dict[str, List[OHLCVBar]]] = None,
     ) -> List[QualityGateResult]:
         """Run anomaly checks and tag every result with ``phase``.
@@ -169,11 +162,6 @@ class BacktestAnomalyDetector(GateResultsMixin):
         result with a deterministic failure category and order counters.
         Other rules ignore them.
 
-        ``start_date`` / ``end_date`` / ``timeframe`` are required by the
-        frequency-aware trade-count gate. When omitted the gate falls back
-        to the legacy ``< 5 trades`` floor so callers that don't yet wire
-        them through keep their previous behaviour.
-
         ``market_data`` is required by the look-ahead pattern gate (needs
         entry-bar OHLC). When omitted the gate emits no result.
         """
@@ -189,9 +177,6 @@ class BacktestAnomalyDetector(GateResultsMixin):
                 dsr_aware=dsr_aware,
                 diagnostics=diagnostics,
                 coverage_report=coverage_report,
-                start_date=start_date,
-                end_date=end_date,
-                timeframe=timeframe,
                 market_data=market_data,
             )
             results = [r for rule in self._RULES for r in rule(self, ctx)]
@@ -201,66 +186,6 @@ class BacktestAnomalyDetector(GateResultsMixin):
     # Rules — each takes the per-call ``BacktestAnomalyCtx`` and yields zero
     # or more results. Listed in ``_RULES`` below.
     # ------------------------------------------------------------------
-    def _check_trade_count_floor(self, ctx: BacktestAnomalyCtx) -> Iterable[QualityGateResult]:
-        """Frequency-aware trade-count adequacy gate.
-
-        Preconditions:
-          - ``ctx.trades`` is non-empty (the ``check`` zero-trade short-circuit
-            handles the empty case before this rule fires).
-        Postconditions:
-          - Returns an empty tuple in ``paper`` mode (legacy behaviour).
-          - When ``start_date`` / ``end_date`` / ``timeframe`` are missing,
-            falls back to the legacy ``< 5 trades → critical`` floor so
-            callers that haven't yet wired the new kwargs keep their prior
-            verdicts.
-          - When all three are supplied, the expected trade count is
-            ``window_days / expected_hold_days``: realised count below
-            ``25 %`` of expected → critical, ``25–50 %`` → warning, above
-            50 % → pass.
-        Invariants:
-          - Never returns more than one result.
-        """
-        if ctx.mode == "paper":
-            return ()
-
-        observed = len(ctx.trades)
-        expected = _expected_trade_count(
-            start_date=ctx.start_date,
-            end_date=ctx.end_date,
-            timeframe=ctx.timeframe,
-            trades=ctx.trades,
-        )
-        if expected is None:
-            # Legacy fallback: callers that don't yet pass dates/timeframe
-            # still get the original floor so behaviour is unchanged.
-            if observed < 5:
-                return (
-                    self._critical(
-                        f"Only {observed} trades — "
-                        "statistically meaningless for a multi-year backtest."
-                    ),
-                )
-            return ()
-
-        ratio = observed / expected if expected > 0 else 0.0
-        if ratio < 0.25:
-            return (
-                self._critical(
-                    f"Observed {observed} trades vs ~{expected} expected "
-                    f"({ratio:.0%} of expected) given window and holding period — "
-                    "well below the 25% floor for a meaningful sample."
-                ),
-            )
-        if ratio < 0.50:
-            return (
-                self._warning(
-                    f"Observed {observed} trades vs ~{expected} expected "
-                    f"({ratio:.0%} of expected) — review whether the signal "
-                    "is firing as designed."
-                ),
-            )
-        return ()
-
     def _check_annualized_return_ceiling(
         self, ctx: BacktestAnomalyCtx
     ) -> Iterable[QualityGateResult]:
@@ -572,7 +497,6 @@ class BacktestAnomalyDetector(GateResultsMixin):
 
     # Rules iterated in order by ``check``. Adding a rule is a one-line edit.
     _RULES: ClassVar[tuple] = (
-        _check_trade_count_floor,
         _check_annualized_return_ceiling,
         _check_win_rate,
         _check_profit_factor,
@@ -588,82 +512,6 @@ class BacktestAnomalyDetector(GateResultsMixin):
 # ──────────────────────────────────────────────────────────────────────────
 # Module-level helpers used by the rules above.
 # ──────────────────────────────────────────────────────────────────────────
-
-
-# Default expected holding period in CALENDAR DAYS per spec timeframe.
-# Daily-bar swing strategies hold roughly two weeks; intraday holds collapse
-# to fractions of a day. These defaults are the fallback when neither the
-# average observed hold period supplies a value.
-_DEFAULT_EXPECTED_HOLD_DAYS: Dict[str, float] = {
-    "1d": 10.0,
-    "1h": 0.5,
-    "15m": 0.1,
-    "5m": 0.04,
-    "1m": 0.01,
-}
-
-
-def _expected_trade_count(
-    *,
-    start_date: Optional[str],
-    end_date: Optional[str],
-    timeframe: Optional[str],
-    trades: List[TradeRecord],
-) -> Optional[int]:
-    """Estimate the expected number of trades over the backtest window.
-
-    Preconditions:
-      - ``trades`` is non-empty (callers skip the empty-ledger case before
-        invoking this helper).
-    Postconditions:
-      - Returns ``None`` whenever any required input is missing or unparseable
-        — the gate then falls back to its legacy floor.
-      - Returns ``max(1, round(window_days / expected_hold_days))`` when the
-        inputs are usable. ``expected_hold_days`` is the average observed
-        hold when at least one trade reports ``hold_days > 0``, otherwise the
-        per-timeframe default.
-    Invariants:
-      - Never returns a value ``<= 0``.
-    """
-    if not start_date or not end_date or not timeframe:
-        return None
-    window_days = _window_days(start_date, end_date)
-    if window_days is None or window_days <= 0:
-        return None
-
-    observed_holds = [t.hold_days for t in trades if t.hold_days and t.hold_days > 0]
-    if observed_holds:
-        expected_hold = sum(observed_holds) / len(observed_holds)
-    else:
-        expected_hold = _DEFAULT_EXPECTED_HOLD_DAYS.get(timeframe)
-    if not expected_hold or expected_hold <= 0:
-        return None
-
-    expected = round(window_days / expected_hold)
-    return max(1, expected)
-
-
-def _window_days(start_date: str, end_date: str) -> Optional[int]:
-    start = _parse_iso_date(start_date)
-    end = _parse_iso_date(end_date)
-    if start is None or end is None:
-        return None
-    return (end - start).days
-
-
-def _parse_iso_date(value: str) -> Optional[date]:
-    """Parse ``YYYY-MM-DD`` or full ISO datetime strings; returns ``None`` on
-    malformed input rather than raising so the gate can fall back gracefully.
-    """
-    if not value:
-        return None
-    try:
-        return date.fromisoformat(value[:10])
-    except (TypeError, ValueError):
-        try:
-            return datetime.fromisoformat(value).date()
-        except (TypeError, ValueError):
-            return None
 
 
 def _sign(value: float) -> int:

--- a/backend/agents/investment_team/tests/test_audit_recent_runs.py
+++ b/backend/agents/investment_team/tests/test_audit_recent_runs.py
@@ -660,77 +660,7 @@ class TestCheckNarrativeFidelity:
 
 
 # ---------------------------------------------------------------------------
-# Check 8: Trade adequacy
-# ---------------------------------------------------------------------------
-
-
-class TestCheckTradeAdequacy:
-    def test_pass(self) -> None:
-        from investment_team.scripts.audit_recent_runs import check_trade_adequacy
-
-        assert check_trade_adequacy(_synthetic_record()).status == "PASS"
-
-    def test_fail_too_few_trades(self) -> None:
-        from investment_team.scripts.audit_recent_runs import check_trade_adequacy
-
-        rec = _synthetic_record()
-        rec["backtest"]["trades"] = [
-            {"symbol": "AAPL", "position_value": 1000, "hold_days": 5},
-        ]
-        result = check_trade_adequacy(rec)
-        assert result.status == "FAIL"
-        assert "n_trades=1" in result.details
-
-    def test_skip_missing_dates(self) -> None:
-        from investment_team.scripts.audit_recent_runs import check_trade_adequacy
-
-        rec = _synthetic_record()
-        rec["backtest"]["config"] = {}
-        assert check_trade_adequacy(rec).status == "SKIP"
-
-    def test_skip_no_trades(self) -> None:
-        from investment_team.scripts.audit_recent_runs import check_trade_adequacy
-
-        rec = _synthetic_record()
-        rec["backtest"]["trades"] = []
-        assert check_trade_adequacy(rec).status == "SKIP"
-
-    def test_accepts_iso_datetime_strings(self) -> None:
-        from investment_team.scripts.audit_recent_runs import check_trade_adequacy
-
-        rec = _synthetic_record()
-        rec["backtest"]["config"] = {
-            "start_date": "2024-01-01T00:00:00+00:00",
-            "end_date": "2024-01-16T00:00:00+00:00",
-        }
-        result = check_trade_adequacy(rec)
-        assert result.status == "PASS"
-
-    def test_same_day_intraday_window(self) -> None:
-        from investment_team.scripts.audit_recent_runs import check_trade_adequacy
-
-        rec = _synthetic_record()
-        rec["backtest"]["config"] = {
-            "start_date": "2024-01-15",
-            "end_date": "2024-01-15",
-        }
-        result = check_trade_adequacy(rec)
-        assert result.status in ("PASS", "FAIL")
-        assert result.status != "SKIP"
-
-    def test_fallback_to_default_hold(self) -> None:
-        from investment_team.scripts.audit_recent_runs import check_trade_adequacy
-
-        rec = _synthetic_record()
-        rec["backtest"]["trades"] = [
-            {"symbol": "AAPL", "position_value": 1000, "hold_days": 0} for _ in range(40)
-        ]
-        result = check_trade_adequacy(rec)
-        assert result.status in ("PASS", "FAIL")
-
-
-# ---------------------------------------------------------------------------
-# Check 9: Liquidity realism
+# Check 8: Liquidity realism
 # ---------------------------------------------------------------------------
 
 
@@ -764,7 +694,7 @@ class TestCheckLiquidityRealism:
 
 
 # ---------------------------------------------------------------------------
-# Check 10: No dead-code rules
+# Check 9: No dead-code rules
 # ---------------------------------------------------------------------------
 
 

--- a/backend/agents/investment_team/tests/test_backtest_anomaly_realism.py
+++ b/backend/agents/investment_team/tests/test_backtest_anomaly_realism.py
@@ -1,13 +1,8 @@
 """Realism extensions of ``BacktestAnomalyDetector``.
 
-Covers two additions:
-
-* Frequency-aware trade-count adequacy — scales the floor by
-  ``window_days / expected_hold_days`` instead of the legacy hard
-  ``< 5 trades`` minimum.
-* Look-ahead pattern in returns — flags trades whose return sign agrees
-  suspiciously well with the entry bar's intrabar direction, a heuristic
-  for look-ahead bias that AST checks miss.
+Covers the look-ahead pattern in returns — flags trades whose return sign
+agrees suspiciously well with the entry bar's intrabar direction, a
+heuristic for look-ahead bias that AST checks miss.
 
 The legacy gates (Sharpe, win-rate, profit factor, hold time, ...) are
 covered by ``test_backtest_anomaly_dsr_aware.py`` and
@@ -70,123 +65,6 @@ def _trade(
         outcome="win" if return_pct > 0 else "loss",
         cumulative_pnl=net,
     )
-
-
-def _trade_count_results(results):
-    return [
-        r
-        for r in results
-        if "expected" in r.details and ("trades" in r.details or "Observed" in r.details)
-    ]
-
-
-# ---------------------------------------------------------------------------
-# Trade-count adequacy
-# ---------------------------------------------------------------------------
-
-
-def test_trade_count_adequacy_critical_when_under_25_pct_of_expected():
-    """5-year daily window with 2-week observed holds expects ~130 trades; 8
-    realised trades is ~6% of expected → critical."""
-    trades = [
-        _trade(
-            trade_num=i + 1,
-            entry_date=f"2020-{(i % 12) + 1:02d}-15",
-            exit_date=f"2020-{(i % 12) + 1:02d}-28",
-            hold_days=14,
-        )
-        for i in range(8)
-    ]
-    detector = BacktestAnomalyDetector()
-    results = detector.check(
-        _baseline_metrics(),
-        trades,
-        start_date="2020-01-01",
-        end_date="2025-01-01",
-        timeframe="1d",
-    )
-    tc = _trade_count_results(results)
-    assert len(tc) == 1
-    assert tc[0].severity == "critical"
-    assert "below the 25%" in tc[0].details or "25%" in tc[0].details
-
-
-def test_trade_count_adequacy_warning_between_25_and_50_pct():
-    """About 40 trades against ~130 expected is ~30% → warning, not critical."""
-    trades = [
-        _trade(
-            trade_num=i + 1,
-            entry_date=f"2021-{((i % 12) + 1):02d}-10",
-            exit_date=f"2021-{((i % 12) + 1):02d}-24",
-            hold_days=14,
-        )
-        for i in range(40)
-    ]
-    detector = BacktestAnomalyDetector()
-    results = detector.check(
-        _baseline_metrics(),
-        trades,
-        start_date="2020-01-01",
-        end_date="2025-01-01",
-        timeframe="1d",
-    )
-    tc = _trade_count_results(results)
-    assert len(tc) == 1
-    assert tc[0].severity == "warning"
-
-
-def test_trade_count_adequacy_passes_above_50_pct():
-    """About 100 trades vs ~130 expected (~77%) → no result emitted."""
-    trades = [
-        _trade(
-            trade_num=i + 1,
-            entry_date=f"202{((i // 24) % 5)}-{((i % 12) + 1):02d}-05",
-            exit_date=f"202{((i // 24) % 5)}-{((i % 12) + 1):02d}-19",
-            hold_days=14,
-        )
-        for i in range(100)
-    ]
-    detector = BacktestAnomalyDetector()
-    results = detector.check(
-        _baseline_metrics(),
-        trades,
-        start_date="2020-01-01",
-        end_date="2025-01-01",
-        timeframe="1d",
-    )
-    assert _trade_count_results(results) == []
-
-
-def test_trade_count_adequacy_falls_back_to_legacy_floor_when_kwargs_missing():
-    """Without dates/timeframe the gate must keep the legacy ``< 5`` floor so
-    older call sites that haven't been updated still produce the prior
-    verdict."""
-    trades = [
-        _trade(trade_num=i + 1, entry_date="2024-01-02", exit_date="2024-01-09") for i in range(3)
-    ]
-    detector = BacktestAnomalyDetector()
-    results = detector.check(_baseline_metrics(), trades)
-    legacy = [r for r in results if "statistically meaningless" in r.details]
-    assert len(legacy) == 1
-    assert legacy[0].severity == "critical"
-
-
-def test_trade_count_adequacy_skipped_in_paper_mode():
-    """Paper sessions run over short windows; the trade-count gate is skipped
-    entirely regardless of which kwargs were threaded in."""
-    trades = [_trade(trade_num=1, entry_date="2024-05-01", exit_date="2024-05-08")]
-    detector = BacktestAnomalyDetector()
-    results = detector.check(
-        _baseline_metrics(),
-        trades,
-        mode="paper",
-        start_date="2024-01-01",
-        end_date="2024-12-31",
-        timeframe="1d",
-    )
-    assert _trade_count_results(results) == []
-    legacy = [r for r in results if "statistically meaningless" in r.details]
-    assert legacy == []
 
 
 # ---------------------------------------------------------------------------
@@ -269,9 +147,6 @@ def test_lookahead_critical_when_perfect_intrabar_sign_match():
     results = detector.check(
         _baseline_metrics(),
         trades,
-        start_date="2024-01-01",
-        end_date="2024-12-31",
-        timeframe="1d",
         market_data=market,
     )
     look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
@@ -287,9 +162,6 @@ def test_lookahead_passes_when_agreement_under_threshold():
     results = detector.check(
         _baseline_metrics(),
         trades,
-        start_date="2024-01-01",
-        end_date="2024-12-31",
-        timeframe="1d",
         market_data=market,
     )
     look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
@@ -304,9 +176,6 @@ def test_lookahead_skipped_when_market_data_missing():
     results = detector.check(
         _baseline_metrics(),
         trades,
-        start_date="2024-01-01",
-        end_date="2024-12-31",
-        timeframe="1d",
         market_data=None,
     )
     look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
@@ -321,9 +190,6 @@ def test_lookahead_skipped_when_no_entry_bars_resolve():
     results = detector.check(
         _baseline_metrics(),
         trades,
-        start_date="2024-01-01",
-        end_date="2024-12-31",
-        timeframe="1d",
         market_data={"NOT_IN_LEDGER": [_bar("2024-01-02", open_=100.0, close=101.0)]},
     )
     look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
@@ -355,9 +221,6 @@ def test_lookahead_smallsample_perfect_match_is_critical():
     results = detector.check(
         _baseline_metrics(),
         trades,
-        start_date="2024-01-01",
-        end_date="2024-12-31",
-        timeframe="1d",
         market_data=market,
     )
     look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
@@ -388,9 +251,6 @@ def test_lookahead_warning_between_80_and_95_pct():
     results = detector.check(
         _baseline_metrics(),
         trades,
-        start_date="2024-01-01",
-        end_date="2024-12-31",
-        timeframe="1d",
         market_data=market,
     )
     look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
@@ -437,9 +297,6 @@ def test_lookahead_intraday_exact_match_uses_specific_bar_not_prefix():
     results = detector.check(
         _baseline_metrics(),
         trades,
-        start_date="2024-01-01",
-        end_date="2024-12-31",
-        timeframe="1h",
         market_data=bars_by_symbol,
     )
     look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
@@ -491,9 +348,6 @@ def test_lookahead_falls_back_to_day_aggregate_when_trade_date_is_date_only():
     results = detector.check(
         _baseline_metrics(),
         trades,
-        start_date="2024-01-01",
-        end_date="2024-12-31",
-        timeframe="1h",
         market_data=bars_by_symbol,
     )
     look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
@@ -513,9 +367,6 @@ def test_lookahead_returns_no_result_when_no_same_day_bars_exist():
     results = detector.check(
         _baseline_metrics(),
         trades,
-        start_date="2024-01-01",
-        end_date="2024-12-31",
-        timeframe="1d",
         market_data={"QQQ": [_bar("2099-12-31", open_=100.0, close=101.0)]},
     )
     look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
@@ -558,9 +409,6 @@ def test_lookahead_critical_for_short_only_strategy_picking_down_bars():
     results = detector.check(
         _baseline_metrics(),
         trades,
-        start_date="2024-01-01",
-        end_date="2024-12-31",
-        timeframe="1d",
         market_data=market,
     )
     look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
@@ -599,9 +447,6 @@ def test_lookahead_critical_on_mixed_long_short_ledger_with_aligned_bets():
     results = detector.check(
         _baseline_metrics(),
         trades,
-        start_date="2024-01-01",
-        end_date="2024-12-31",
-        timeframe="1d",
         market_data=market,
     )
     look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
@@ -649,9 +494,6 @@ def test_lookahead_critical_on_mixed_long_short_with_winners_and_losers():
     results = detector.check(
         _baseline_metrics(),
         trades,
-        start_date="2024-01-01",
-        end_date="2024-12-31",
-        timeframe="1d",
         market_data=market,
     )
     look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
@@ -698,9 +540,6 @@ def test_lookahead_passes_when_short_strategy_is_genuinely_signal_driven():
     results = detector.check(
         _baseline_metrics(),
         trades,
-        start_date="2024-01-01",
-        end_date="2024-12-31",
-        timeframe="1d",
         market_data=market,
     )
     look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
@@ -727,9 +566,6 @@ def test_lookahead_skips_trades_with_unrecognised_side():
     results = detector.check(
         _baseline_metrics(),
         trades,
-        start_date="2024-01-01",
-        end_date="2024-12-31",
-        timeframe="1d",
         market_data=market,
     )
     look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
@@ -780,9 +616,6 @@ def test_lookahead_emits_info_when_zero_trades_resolve_a_bar() -> None:
     results = detector.check(
         _baseline_metrics(),
         trades,
-        start_date="2024-01-01",
-        end_date="2024-12-31",
-        timeframe="1d",
         market_data={"NOT_IN_LEDGER": [_bar("2024-01-02", open_=100.0, close=101.0)]},
     )
     info = [
@@ -803,9 +636,6 @@ def test_lookahead_emits_degraded_sample_warning_when_under_half_resolve() -> No
     results = detector.check(
         _baseline_metrics(),
         trades,
-        start_date="2024-01-01",
-        end_date="2024-12-31",
-        timeframe="1d",
         market_data=market,
     )
     degraded = [r for r in results if r.severity == "warning" and "degraded sample" in r.details]
@@ -822,9 +652,6 @@ def test_lookahead_does_not_emit_degraded_warning_when_sample_is_small() -> None
     results = detector.check(
         _baseline_metrics(),
         trades,
-        start_date="2024-01-01",
-        end_date="2024-12-31",
-        timeframe="1d",
         market_data=market,
     )
     degraded = [r for r in results if r.severity == "warning" and "degraded sample" in r.details]
@@ -858,9 +685,6 @@ def test_lookahead_thresholds_key_off_trade_count_not_bar_observation_count() ->
     results = detector.check(
         _baseline_metrics(),
         trades,
-        start_date="2024-01-01",
-        end_date="2024-12-31",
-        timeframe="1d",
         market_data=market,
     )
     look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
@@ -892,9 +716,6 @@ def test_lookahead_combined_rate_uses_entry_and_exit_observations() -> None:
     results = detector.check(
         _baseline_metrics(),
         trades,
-        start_date="2024-01-01",
-        end_date="2024-12-31",
-        timeframe="1d",
         market_data=market,
     )
     look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]

--- a/backend/agents/investment_team/tests/test_liquidity_and_cost_stress.py
+++ b/backend/agents/investment_team/tests/test_liquidity_and_cost_stress.py
@@ -446,26 +446,6 @@ def test_zero_trade_baseline_carries_execution_diagnostics() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _trade(entry: str, exit_: str, net_pnl: float = 10.0, shares: float = 1.0) -> TradeRecord:
-    return TradeRecord(
-        trade_num=1,
-        entry_date=entry,
-        exit_date=exit_,
-        symbol="AAA",
-        side="long",
-        entry_price=100.0,
-        exit_price=100.0 + net_pnl,
-        shares=shares,
-        position_value=100.0,
-        gross_pnl=net_pnl,
-        net_pnl=net_pnl,
-        return_pct=net_pnl,
-        hold_days=2,
-        outcome="win" if net_pnl > 0 else "loss",
-        cumulative_pnl=net_pnl,
-    )
-
-
 def _healthy_metrics() -> BacktestResult:
     return BacktestResult(
         total_return_pct=5.0,
@@ -479,18 +459,6 @@ def _healthy_metrics() -> BacktestResult:
         deflated_sharpe=0.0,
         sortino_ratio=0.0,
     )
-
-
-def test_anomaly_paper_mode_skips_too_few_trades_gate() -> None:
-    detector = BacktestAnomalyDetector()
-    few_trades = [_trade(f"2024-01-{i + 1:02d}", f"2024-01-{i + 2:02d}") for i in range(3)]
-    paper = detector.check(_healthy_metrics(), few_trades, mode="paper")
-    backtest = detector.check(_healthy_metrics(), few_trades, mode="backtest")
-    # Backtest mode flags "Only 3 trades"; paper mode skips it.
-    paper_reasons = " ".join(r.details for r in paper if not r.passed)
-    backtest_reasons = " ".join(r.details for r in backtest if not r.passed)
-    assert "statistically meaningless" in backtest_reasons
-    assert "statistically meaningless" not in paper_reasons
 
 
 def test_anomaly_zero_trades_still_flagged_in_paper_mode() -> None:


### PR DESCRIPTION
## Summary

The backtest anomaly detector predicted an "expected" trade count from the backtest window and average holding period, then flagged a run whose realised trade count fell below 25% / 50% of that prediction (plus a legacy `< 5 trades` floor). Predicting how many trades a strategy will produce before running it is not meaningful — a strategy's behaviour is only knowable after backtesting and paper trading — so this gate is removed entirely.

The user-visible warning this produced:

> "Observed 24 trades vs ~184 expected (13% of expected) given window and holding period — well below the 25% floor for a meaningful sample."

## Changes

- **`strategy_lab/quality_gates/backtest_anomaly.py`** — delete the `_check_trade_count_floor` rule, drop it from `_RULES`, and delete its helpers (`_expected_trade_count`, `_window_days`, `_parse_iso_date`, `_DEFAULT_EXPECTED_HOLD_DAYS`). Remove the now-unused `start_date` / `end_date` / `timeframe` params from `check()` and `BacktestAnomalyCtx` (only this gate consumed them; `market_data` stays for the look-ahead rule).
- **`strategy_lab/orchestrator.py`** — drop those three kwargs from all three `anomaly_detector.check(...)` call sites.
- **`scripts/audit_recent_runs.py`** — remove the duplicated post-hoc `check_trade_adequacy` audit check and its constant/registrations.
- **Tests** — remove the trade-count tests in `test_backtest_anomaly_realism.py`, `test_audit_recent_runs.py`, and the obsolete `too_few_trades` test in `test_liquidity_and_cost_stress.py`; strip the dead kwargs from the surviving look-ahead tests.
- **`ARCHITECTURE_REVIEW.md`** — drop the stale "too few trades" recommendation.

## Not changed

The zero-trade short-circuit (strategy never opened a position — backed by execution diagnostics) and every other anomaly rule (return ceiling, win-rate, profit factor, Sharpe, hold-time, concentration, diversification, look-ahead, cost sensitivity) are untouched.

## Verification

- `ruff check` clean on all touched files (pinned v0.8.6 and latest).
- Targeted suites pass: `test_backtest_anomaly_realism`, `test_backtest_anomaly_dsr_aware`, `test_backtest_anomaly_zero_trade_diagnostics`, `test_audit_recent_runs`, `test_liquidity_and_cost_stress`, plus the orchestrator anomaly-path suites (`test_strategy_lab_walk_forward_integration`, `test_strategy_lab_zero_trade_repair`, `test_code_safety`, `test_coverage_probe_orchestrator_stage`) — 251 tests green.
- Repo-wide grep confirms no remaining references to the removed symbols or messages.

Closes #818

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ed7iUgqaf1v292UitweCLQ)_