### PR TITLE
Strategy Lab: forward the strands transport timeout instead of dropping it

### DIFF
--- a/backend/agents/investment_team/strategy_lab/agents/model_factory.py
+++ b/backend/agents/investment_team/strategy_lab/agents/model_factory.py
@@ -14,12 +14,18 @@ from __future__ import annotations
 
 import inspect
 import logging
+import math
 import os
 from typing import Any, Dict, Optional
 
 from llm_service.config import resolve_base_url, resolve_model, resolve_provider, resolve_timeout
 
 logger = logging.getLogger(__name__)
+
+# Last-resort transport timeout (seconds) when even ``resolve_timeout`` returns a
+# non-positive / non-finite value. Mirrors the platform default so the resolver's
+# "positive, finite float" postcondition holds unconditionally.
+_DEFAULT_TRANSPORT_TIMEOUT = 900.0
 
 
 def structured_output_enabled() -> bool:
@@ -45,9 +51,13 @@ def _resolve_strands_timeout(agent_key: str) -> float:
     platform-wide ``resolve_timeout`` (which honours ``LLM_TIMEOUT``).
 
     Preconditions: ``agent_key`` is a non-empty model key.
-    Postconditions: returns a positive float — garbage *or non-positive* env
-    values fall back (``float("-5")`` parses cleanly but a non-positive timeout
-    is a misconfiguration, not a valid transport bound).
+    Postconditions: returns a **positive, finite** float, unconditionally.
+    Garbage, non-positive, or non-finite (``inf`` parses cleanly and ``inf > 0``
+    is ``True``, so an infinite read timeout would never cancel a hung call) env
+    values fall back to ``resolve_timeout``; a non-positive/non-finite
+    ``resolve_timeout`` result in turn falls back to
+    ``_DEFAULT_TRANSPORT_TIMEOUT`` so the contract holds even if the platform
+    resolver misbehaves.
     """
     raw = os.environ.get("STRATEGY_LAB_LLM_TIMEOUT")
     if raw is not None and raw.strip() != "":
@@ -56,9 +66,19 @@ def _resolve_strands_timeout(agent_key: str) -> float:
         except ValueError:
             pass
         else:
-            if parsed > 0:
+            if parsed > 0 and math.isfinite(parsed):
                 return parsed
-    return resolve_timeout(agent_key)
+    resolved = resolve_timeout(agent_key)
+    if resolved > 0 and math.isfinite(resolved):
+        return resolved
+    logger.warning(
+        "resolve_timeout(%s) returned a non-positive/non-finite value %r; "
+        "falling back to the default transport timeout %.0fs.",
+        agent_key,
+        resolved,
+        _DEFAULT_TRANSPORT_TIMEOUT,
+    )
+    return _DEFAULT_TRANSPORT_TIMEOUT
 
 
 def _accepts_kwarg(target: Any, name: str) -> bool:
@@ -179,10 +199,11 @@ def get_strands_model(
     prompt-only JSON) and when the toggle is off, so callers can pass a schema
     unconditionally.
 
-    Preconditions: ``agent_key`` is a non-empty model key; ``timeout``, if
-    passed explicitly, is ``> 0`` (a resolved timeout is guaranteed positive by
-    :func:`_resolve_strands_timeout`); ``response_schema``, if given, is a
-    JSON-serializable schema dict.
+    Preconditions: ``agent_key`` is a non-empty model key; ``response_schema``,
+    if given, is a JSON-serializable schema dict. ``timeout``, if passed
+    explicitly, must be a positive, finite number of seconds — a non-positive or
+    non-finite value raises ``ValueError`` (a resolved timeout is guaranteed
+    positive and finite by :func:`_resolve_strands_timeout`).
     Postconditions: returns a constructed strands model. Adding a schema never
     changes which provider/model is selected — only whether the Ollama request
     carries a ``format`` constraint.
@@ -193,9 +214,12 @@ def get_strands_model(
     if timeout is None:
         timeout = _resolve_strands_timeout(agent_key)
     # Boundary enforcement of the construction helpers' ``timeout > 0``
-    # precondition: a non-positive transport timeout is a caller bug (an
-    # explicit bad kwarg), never a value we should forward to httpx/botocore.
-    assert timeout > 0, f"timeout must be > 0 (got {timeout!r})"
+    # precondition: a non-positive or non-finite transport timeout is a caller
+    # bug (an explicit bad kwarg), never a value we should forward to
+    # httpx/botocore. Use an explicit raise rather than ``assert`` so the guard
+    # survives ``python -O``.
+    if not math.isfinite(timeout) or timeout <= 0:
+        raise ValueError(f"timeout must be a positive, finite number of seconds (got {timeout!r})")
 
     use_schema = response_schema is not None and structured_output_enabled()
 

--- a/backend/agents/investment_team/strategy_lab/agents/model_factory.py
+++ b/backend/agents/investment_team/strategy_lab/agents/model_factory.py
@@ -69,11 +69,23 @@ def _resolve_strands_timeout(agent_key: str) -> float:
             if parsed > 0 and math.isfinite(parsed):
                 return parsed
     resolved = resolve_timeout(agent_key)
-    if resolved > 0 and math.isfinite(resolved):
+    # ``resolve_timeout`` is typed ``-> float``, but guard defensively: a
+    # misconfigured resolver returning a non-numeric (str/None) would make
+    # ``resolved > 0`` raise ``TypeError`` and break this function's
+    # unconditional "positive, finite float" postcondition. ``bool`` is excluded
+    # because ``True``/``False`` are not meaningful timeouts (and ``bool`` is an
+    # ``int`` subclass). The ``isinstance`` check also gates ``math.isfinite``,
+    # which itself raises ``TypeError`` on a non-number.
+    if (
+        isinstance(resolved, (int, float))
+        and not isinstance(resolved, bool)
+        and math.isfinite(resolved)
+        and resolved > 0
+    ):
         return resolved
     logger.warning(
-        "resolve_timeout(%s) returned a non-positive/non-finite value %r; "
-        "falling back to the default transport timeout %.0fs.",
+        "resolve_timeout(%s) returned an invalid value %r; falling back to the "
+        "default transport timeout %.0fs.",
         agent_key,
         resolved,
         _DEFAULT_TRANSPORT_TIMEOUT,

--- a/backend/agents/investment_team/strategy_lab/agents/model_factory.py
+++ b/backend/agents/investment_team/strategy_lab/agents/model_factory.py
@@ -12,6 +12,7 @@ are respected consistently with the rest of the platform.
 
 from __future__ import annotations
 
+import inspect
 import logging
 import os
 from typing import Any, Dict, Optional
@@ -44,46 +45,111 @@ def _resolve_strands_timeout(agent_key: str) -> float:
     platform-wide ``resolve_timeout`` (which honours ``LLM_TIMEOUT``).
 
     Preconditions: ``agent_key`` is a non-empty model key.
-    Postconditions: returns a positive float — garbage env values fall back.
+    Postconditions: returns a positive float — garbage *or non-positive* env
+    values fall back (``float("-5")`` parses cleanly but a non-positive timeout
+    is a misconfiguration, not a valid transport bound).
     """
     raw = os.environ.get("STRATEGY_LAB_LLM_TIMEOUT")
     if raw is not None and raw.strip() != "":
         try:
-            return float(raw)
+            parsed = float(raw)
         except ValueError:
             pass
+        else:
+            if parsed > 0:
+                return parsed
     return resolve_timeout(agent_key)
 
 
-def _construct_with_optional_timeout(model_cls, timeout: float, **kwargs):
-    """Construct ``model_cls`` forwarding a transport timeout if the SDK accepts it.
+def _accepts_kwarg(target: Any, name: str) -> bool:
+    """Return ``True`` iff ``target``'s signature declares an *explicit* keyword
+    parameter ``name``.
 
-    The installed strands ``OllamaModel`` / ``BedrockModel`` signatures vary by
-    version (``timeout=`` vs ``client_args={"timeout": ...}`` vs neither). We try
-    each shape in turn and fall back to constructing without a timeout so a
-    signature mismatch degrades to "envelope wall-clock guard only" rather than
-    breaking agent construction. Only a *signature* ``TypeError`` (an unexpected
-    keyword argument) triggers the fallback — a ``TypeError`` raised from inside
-    the constructor for an unrelated reason propagates so the real
-    misconfiguration is not masked.
+    A name reachable only through ``**kwargs`` (``VAR_KEYWORD``) does **not**
+    count. The strands model constructors accept arbitrary ``**model_config``
+    and merely *warn* on unknown keys (``validate_config_keys``) before silently
+    dropping them — so a kwarg routed there never reaches the transport.
+    Probing the constructor for a ``TypeError`` (the previous strategy) is
+    therefore useless: an unknown kwarg is swallowed, not rejected. Introspecting
+    for an explicitly-declared parameter is the only reliable signal that the
+    installed SDK will actually honour the argument.
 
-    Preconditions: ``model_cls`` is a strands Model class; ``timeout > 0``.
-    Postconditions: returns a constructed model instance.
+    Preconditions: ``target`` is introspectable (a class or callable); ``name``
+    is a non-empty string.
+    Postconditions: returns a ``bool``; never raises — an un-introspectable
+    target degrades to ``False``.
     """
-    for attempt_kwargs in (
-        {**kwargs, "timeout": timeout},
-        {**kwargs, "client_args": {"timeout": timeout}},
-    ):
-        try:
-            return model_cls(**attempt_kwargs)
-        except TypeError as exc:
-            if "unexpected keyword argument" not in str(exc):
-                raise
-            continue
+    try:
+        params = inspect.signature(target).parameters
+    except (TypeError, ValueError):
+        return False
+    param = params.get(name)
+    return param is not None and param.kind in (
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    )
+
+
+def _construct_ollama_with_timeout(model_cls, timeout: float, **kwargs):
+    """Construct a strands ``OllamaModel``, forwarding ``timeout`` as the
+    transport (httpx) read/connect timeout.
+
+    strands' ``OllamaModel`` passes ``ollama_client_args`` straight to
+    ``ollama.AsyncClient(host, **client_args)``, which forwards them to httpx —
+    where ``timeout`` is the read/connect timeout, the only mechanism that
+    actually cancels a hung HTTP call. A bare ``timeout=`` (or ``client_args=``)
+    kwarg is swallowed by the constructor's ``**model_config``, which only
+    *warns* and then drops it, so it must never be used. The current strands
+    range (>=1.35,<2.0) declares ``ollama_client_args``; ``client_args`` (the
+    client-args name strands' *other* model providers use) is probed only as a
+    defensive fallback should a release within the pinned range unify on it. The
+    timeout is forwarded through whichever the installed signature explicitly
+    declares, degrading to "no transport timeout" (envelope wall-clock guard
+    only) if neither exists.
+
+    Preconditions: ``model_cls`` is the strands ``OllamaModel`` class (or a
+    stand-in); ``timeout > 0``.
+    Postconditions: returns a constructed model. The returned model carries the
+    transport timeout iff ``model_cls`` exposes a client-args channel.
+    """
+    for param in ("ollama_client_args", "client_args"):
+        if _accepts_kwarg(model_cls, param):
+            return model_cls(**kwargs, **{param: {"timeout": timeout}})
     logger.warning(
-        "Strands model %s did not accept a transport timeout; relying on the "
-        "envelope wall-clock guard only.",
-        getattr(model_cls, "__name__", model_cls),
+        "Strands OllamaModel exposes no client-args channel for a transport "
+        "timeout; relying on the envelope wall-clock guard only."
+    )
+    return model_cls(**kwargs)
+
+
+def _construct_bedrock_with_timeout(model_cls, timeout: float, **kwargs):
+    """Construct a strands ``BedrockModel``, forwarding ``timeout`` as the
+    botocore read/connect timeout via ``boto_client_config``.
+
+    A bare ``timeout=`` kwarg is swallowed by the constructor's
+    ``**model_config`` (warned then dropped), so the timeout must travel through
+    the explicit ``boto_client_config`` parameter as a botocore ``Config``.
+    Degrades to "no transport timeout" if the SDK exposes no such parameter.
+
+    Preconditions: ``model_cls`` is the strands ``BedrockModel`` class (or a
+    stand-in); ``timeout > 0``.
+    Postconditions: returns a constructed model. The returned model carries the
+    transport timeout iff ``model_cls`` exposes a ``boto_client_config``
+    parameter.
+    """
+    if _accepts_kwarg(model_cls, "boto_client_config"):
+        # botocore is a hard dependency of the strands Bedrock path, so this
+        # import only runs when a real Bedrock model is being constructed.
+        from botocore.config import Config as BotocoreConfig
+
+        # botocore accepts float read/connect timeouts; forward ``timeout``
+        # verbatim. (Do NOT ``int()`` it — that truncates a sub-second timeout
+        # to ``0`` and diverges from the Ollama path, which preserves the float.)
+        client_config = BotocoreConfig(read_timeout=timeout, connect_timeout=timeout)
+        return model_cls(**kwargs, boto_client_config=client_config)
+    logger.warning(
+        "Strands BedrockModel exposes no boto_client_config channel for a "
+        "transport timeout; relying on the envelope wall-clock guard only."
     )
     return model_cls(**kwargs)
 
@@ -113,8 +179,10 @@ def get_strands_model(
     prompt-only JSON) and when the toggle is off, so callers can pass a schema
     unconditionally.
 
-    Preconditions: ``agent_key`` is a non-empty model key; ``response_schema``,
-    if given, is a JSON-serializable schema dict.
+    Preconditions: ``agent_key`` is a non-empty model key; ``timeout``, if
+    passed explicitly, is ``> 0`` (a resolved timeout is guaranteed positive by
+    :func:`_resolve_strands_timeout`); ``response_schema``, if given, is a
+    JSON-serializable schema dict.
     Postconditions: returns a constructed strands model. Adding a schema never
     changes which provider/model is selected — only whether the Ollama request
     carries a ``format`` constraint.
@@ -124,6 +192,10 @@ def get_strands_model(
     base_url = resolve_base_url()
     if timeout is None:
         timeout = _resolve_strands_timeout(agent_key)
+    # Boundary enforcement of the construction helpers' ``timeout > 0``
+    # precondition: a non-positive transport timeout is a caller bug (an
+    # explicit bad kwarg), never a value we should forward to httpx/botocore.
+    assert timeout > 0, f"timeout must be > 0 (got {timeout!r})"
 
     use_schema = response_schema is not None and structured_output_enabled()
 
@@ -131,7 +203,7 @@ def get_strands_model(
         from strands.models import BedrockModel
 
         logger.info("Strands model: Bedrock model_id=%s timeout=%.0fs", model_id, timeout)
-        return _construct_with_optional_timeout(BedrockModel, timeout, model_id=model_id)
+        return _construct_bedrock_with_timeout(BedrockModel, timeout, model_id=model_id)
 
     if provider == "dummy":
         raise ValueError(
@@ -173,6 +245,6 @@ def get_strands_model(
         # uses). Unknown config keys only warn — they never raise — so this is
         # safe across the supported strands range.
         extra["additional_args"] = {"format": response_schema}
-    return _construct_with_optional_timeout(
+    return _construct_ollama_with_timeout(
         OllamaModel, timeout, host=host, model_id=model_id, **extra
     )

--- a/backend/agents/investment_team/strategy_lab/agents/model_factory.py
+++ b/backend/agents/investment_team/strategy_lab/agents/model_factory.py
@@ -68,14 +68,20 @@ def _resolve_strands_timeout(agent_key: str) -> float:
         else:
             if parsed > 0 and math.isfinite(parsed):
                 return parsed
+    # ``resolve_timeout`` is a total function — it reads an env var (defaulting
+    # to "900") and catches the only failure mode (``float()`` ValueError),
+    # returning 900.0 — so it cannot raise. No ``try/except`` wraps it by design:
+    # per the project DbC rule we never try/except around a callee's contract
+    # failure to hide it; a future ``resolve_timeout`` that violated its
+    # ``-> float`` contract by raising should surface, not silently degrade.
     resolved = resolve_timeout(agent_key)
-    # ``resolve_timeout`` is typed ``-> float``, but guard defensively: a
-    # misconfigured resolver returning a non-numeric (str/None) would make
-    # ``resolved > 0`` raise ``TypeError`` and break this function's
-    # unconditional "positive, finite float" postcondition. ``bool`` is excluded
-    # because ``True``/``False`` are not meaningful timeouts (and ``bool`` is an
-    # ``int`` subclass). The ``isinstance`` check also gates ``math.isfinite``,
-    # which itself raises ``TypeError`` on a non-number.
+    # We still guard the returned *value* defensively: a misconfigured resolver
+    # returning a non-numeric (str/None) would make ``resolved > 0`` raise
+    # ``TypeError`` and break this function's "positive, finite float"
+    # postcondition. ``bool`` is excluded because ``True``/``False`` are not
+    # meaningful timeouts (and ``bool`` is an ``int`` subclass). The
+    # ``isinstance`` check also gates ``math.isfinite``, which itself raises
+    # ``TypeError`` on a non-number.
     if (
         isinstance(resolved, (int, float))
         and not isinstance(resolved, bool)
@@ -213,9 +219,10 @@ def get_strands_model(
 
     Preconditions: ``agent_key`` is a non-empty model key; ``response_schema``,
     if given, is a JSON-serializable schema dict. ``timeout``, if passed
-    explicitly, must be a positive, finite number of seconds — a non-positive or
-    non-finite value raises ``ValueError`` (a resolved timeout is guaranteed
-    positive and finite by :func:`_resolve_strands_timeout`).
+    explicitly, must be a positive, finite *number* of seconds — a non-numeric
+    value raises ``TypeError`` and a non-positive or non-finite value raises
+    ``ValueError`` (a resolved timeout is guaranteed positive and finite by
+    :func:`_resolve_strands_timeout`).
     Postconditions: returns a constructed strands model. Adding a schema never
     changes which provider/model is selected — only whether the Ollama request
     carries a ``format`` constraint.
@@ -226,10 +233,13 @@ def get_strands_model(
     if timeout is None:
         timeout = _resolve_strands_timeout(agent_key)
     # Boundary enforcement of the construction helpers' ``timeout > 0``
-    # precondition: a non-positive or non-finite transport timeout is a caller
-    # bug (an explicit bad kwarg), never a value we should forward to
-    # httpx/botocore. Use an explicit raise rather than ``assert`` so the guard
-    # survives ``python -O``.
+    # precondition: a bad transport timeout is a caller bug (an explicit bad
+    # kwarg), never a value we should forward to httpx/botocore. Check the type
+    # first so a non-numeric kwarg raises a clear ``TypeError`` (rather than an
+    # obscure one from ``math.isfinite``); use explicit raises rather than
+    # ``assert`` so the guards survive ``python -O``.
+    if not isinstance(timeout, (int, float)) or isinstance(timeout, bool):
+        raise TypeError(f"timeout must be a number of seconds (got {type(timeout).__name__})")
     if not math.isfinite(timeout) or timeout <= 0:
         raise ValueError(f"timeout must be a positive, finite number of seconds (got {timeout!r})")
 

--- a/backend/agents/investment_team/tests/test_misc_helpers.py
+++ b/backend/agents/investment_team/tests/test_misc_helpers.py
@@ -863,6 +863,19 @@ def test_get_strands_model_rejects_non_positive_or_nonfinite_explicit_timeout(
         model_factory.get_strands_model("strategy_design", timeout=bad)
 
 
+@pytest.mark.parametrize("bad", ["900", True, [900]])
+def test_get_strands_model_rejects_non_numeric_explicit_timeout(
+    monkeypatch: pytest.MonkeyPatch, bad: object
+) -> None:
+    """A non-numeric explicit ``timeout`` raises a clear ``TypeError`` at the
+    boundary rather than an obscure one from ``math.isfinite`` (``bool`` counts
+    as non-numeric here — ``True``/``False`` are not meaningful timeouts)."""
+    model_factory, _ = _patch_ollama_local(monkeypatch)
+
+    with pytest.raises(TypeError, match="must be a number"):
+        model_factory.get_strands_model("strategy_design", timeout=bad)
+
+
 def test_get_strands_model_forwards_transport_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     """The resolved timeout reaches the Ollama transport via ``ollama_client_args``.
 

--- a/backend/agents/investment_team/tests/test_misc_helpers.py
+++ b/backend/agents/investment_team/tests/test_misc_helpers.py
@@ -699,7 +699,8 @@ def test_get_strands_model_bedrock_branch(monkeypatch: pytest.MonkeyPatch) -> No
     assert isinstance(result, _StubBedrock)
     assert result.model_id == "anthropic.claude-3-haiku-20240307-v1:0"
     assert result.boto_client_config is not None
-    assert result.boto_client_config.read_timeout == 77
+    # The timeout is forwarded as a float verbatim (no int() truncation).
+    assert result.boto_client_config.read_timeout == 77.0
 
 
 def test_get_strands_model_ollama_cloud_without_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -830,12 +831,16 @@ def test_resolve_strands_timeout_non_positive_or_nonfinite_value_falls_back(
     assert model_factory._resolve_strands_timeout("strategy_design") == 321.0
 
 
-@pytest.mark.parametrize("bad_resolved", [0.0, -1.0, float("inf"), float("nan")])
+@pytest.mark.parametrize(
+    "bad_resolved",
+    [0.0, -1.0, float("inf"), float("nan"), "not-a-number", None, True],
+)
 def test_resolve_strands_timeout_guards_resolve_timeout_postcondition(
-    monkeypatch: pytest.MonkeyPatch, bad_resolved: float
+    monkeypatch: pytest.MonkeyPatch, bad_resolved: object
 ) -> None:
-    """A non-positive/non-finite ``resolve_timeout`` result falls back to the
-    default, so the function's positive-finite postcondition holds unconditionally."""
+    """A non-positive, non-finite, or non-numeric ``resolve_timeout`` result
+    falls back to the default, so the function's positive-finite postcondition
+    holds unconditionally (a non-numeric return must NOT raise ``TypeError``)."""
     from investment_team.strategy_lab.agents import model_factory
 
     monkeypatch.delenv("STRATEGY_LAB_LLM_TIMEOUT", raising=False)

--- a/backend/agents/investment_team/tests/test_misc_helpers.py
+++ b/backend/agents/investment_team/tests/test_misc_helpers.py
@@ -681,17 +681,24 @@ def test_get_strands_model_bedrock_branch(monkeypatch: pytest.MonkeyPatch) -> No
         model_factory, "resolve_model", lambda key: "anthropic.claude-3-haiku-20240307-v1:0"
     )
     monkeypatch.setattr(model_factory, "resolve_base_url", lambda: "")
+    monkeypatch.setenv("STRATEGY_LAB_LLM_TIMEOUT", "77")
 
+    # Declare ``boto_client_config`` explicitly so the factory's introspection
+    # forwards the transport timeout through it (the real strands BedrockModel
+    # signature shape).
     class _StubBedrock:
-        def __init__(self, **kwargs):
-            self.kwargs = kwargs
+        def __init__(self, *, model_id=None, boto_client_config=None):
+            self.model_id = model_id
+            self.boto_client_config = boto_client_config
 
     import strands.models as strands_models
 
     monkeypatch.setattr(strands_models, "BedrockModel", _StubBedrock)
     result = model_factory.get_strands_model()
     assert isinstance(result, _StubBedrock)
-    assert result.kwargs["model_id"] == "anthropic.claude-3-haiku-20240307-v1:0"
+    assert result.model_id == "anthropic.claude-3-haiku-20240307-v1:0"
+    assert result.boto_client_config is not None
+    assert result.boto_client_config.read_timeout == 77
 
 
 def test_get_strands_model_ollama_cloud_without_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -748,12 +755,14 @@ def _patch_ollama_local(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("OLLAMA_HOST", raising=False)
 
     class _RecordingOllama:
-        # Accept timeout so the factory's first construction attempt wins and
-        # we observe the real (timeout-carrying) kwargs the schema path emits.
-        def __init__(self, host=None, model_id=None, timeout=None, additional_args=None):
+        # Mirror the real strands ``OllamaModel`` signature shape: the transport
+        # timeout travels via ``ollama_client_args`` (NOT a bare ``timeout=``,
+        # which strands warns-and-drops), and the schema travels via
+        # ``additional_args``.
+        def __init__(self, host=None, model_id=None, ollama_client_args=None, additional_args=None):
             self.host = host
             self.model_id = model_id
-            self.timeout = timeout
+            self.ollama_client_args = ollama_client_args
             self.additional_args = additional_args
 
     import strands.models as strands_models
@@ -793,6 +802,55 @@ def test_get_strands_model_no_schema_leaves_format_unset(monkeypatch: pytest.Mon
     result = model_factory.get_strands_model("strategy_design")
 
     assert result.additional_args is None
+
+
+def test_resolve_strands_timeout_garbage_value_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-numeric ``STRATEGY_LAB_LLM_TIMEOUT`` falls back to ``resolve_timeout``."""
+    from investment_team.strategy_lab.agents import model_factory
+
+    monkeypatch.setenv("STRATEGY_LAB_LLM_TIMEOUT", "not-a-number")
+    monkeypatch.setattr(model_factory, "resolve_timeout", lambda key: 321.0)
+
+    assert model_factory._resolve_strands_timeout("strategy_design") == 321.0
+
+
+@pytest.mark.parametrize("bad", ["-5", "0", "-0.5"])
+def test_resolve_strands_timeout_non_positive_value_falls_back(
+    monkeypatch: pytest.MonkeyPatch, bad: str
+) -> None:
+    """A cleanly-parsing but non-positive timeout is a misconfiguration and
+    falls back (honouring the documented "returns a positive float" postcondition)."""
+    from investment_team.strategy_lab.agents import model_factory
+
+    monkeypatch.setenv("STRATEGY_LAB_LLM_TIMEOUT", bad)
+    monkeypatch.setattr(model_factory, "resolve_timeout", lambda key: 321.0)
+
+    assert model_factory._resolve_strands_timeout("strategy_design") == 321.0
+
+
+def test_get_strands_model_rejects_non_positive_explicit_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit non-positive ``timeout`` violates the construction precondition."""
+    model_factory, _ = _patch_ollama_local(monkeypatch)
+
+    with pytest.raises(AssertionError, match="timeout must be > 0"):
+        model_factory.get_strands_model("strategy_design", timeout=-1.0)
+
+
+def test_get_strands_model_forwards_transport_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The resolved timeout reaches the Ollama transport via ``ollama_client_args``.
+
+    Regression: a bare ``timeout=`` kwarg is swallowed by strands'
+    ``**model_config`` (warned and dropped), so the timeout must travel through
+    the client-args channel to actually cancel a hung HTTP call.
+    """
+    model_factory, _ = _patch_ollama_local(monkeypatch)
+    monkeypatch.setenv("STRATEGY_LAB_LLM_TIMEOUT", "123")
+
+    result = model_factory.get_strands_model("strategy_design")
+
+    assert result.ollama_client_args == {"timeout": 123.0}
 
 
 def test_get_strands_model_toggle_off_ignores_schema(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/agents/investment_team/tests/test_misc_helpers.py
+++ b/backend/agents/investment_team/tests/test_misc_helpers.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any, Dict
 
 import pytest
@@ -814,12 +815,13 @@ def test_resolve_strands_timeout_garbage_value_falls_back(monkeypatch: pytest.Mo
     assert model_factory._resolve_strands_timeout("strategy_design") == 321.0
 
 
-@pytest.mark.parametrize("bad", ["-5", "0", "-0.5"])
-def test_resolve_strands_timeout_non_positive_value_falls_back(
+@pytest.mark.parametrize("bad", ["-5", "0", "-0.5", "inf", "-inf", "nan"])
+def test_resolve_strands_timeout_non_positive_or_nonfinite_value_falls_back(
     monkeypatch: pytest.MonkeyPatch, bad: str
 ) -> None:
-    """A cleanly-parsing but non-positive timeout is a misconfiguration and
-    falls back (honouring the documented "returns a positive float" postcondition)."""
+    """A cleanly-parsing but non-positive OR non-finite timeout is a
+    misconfiguration and falls back (``inf > 0`` is ``True`` but an infinite read
+    timeout would never cancel a hung call)."""
     from investment_team.strategy_lab.agents import model_factory
 
     monkeypatch.setenv("STRATEGY_LAB_LLM_TIMEOUT", bad)
@@ -828,14 +830,32 @@ def test_resolve_strands_timeout_non_positive_value_falls_back(
     assert model_factory._resolve_strands_timeout("strategy_design") == 321.0
 
 
-def test_get_strands_model_rejects_non_positive_explicit_timeout(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize("bad_resolved", [0.0, -1.0, float("inf"), float("nan")])
+def test_resolve_strands_timeout_guards_resolve_timeout_postcondition(
+    monkeypatch: pytest.MonkeyPatch, bad_resolved: float
 ) -> None:
-    """An explicit non-positive ``timeout`` violates the construction precondition."""
+    """A non-positive/non-finite ``resolve_timeout`` result falls back to the
+    default, so the function's positive-finite postcondition holds unconditionally."""
+    from investment_team.strategy_lab.agents import model_factory
+
+    monkeypatch.delenv("STRATEGY_LAB_LLM_TIMEOUT", raising=False)
+    monkeypatch.setattr(model_factory, "resolve_timeout", lambda key: bad_resolved)
+
+    result = model_factory._resolve_strands_timeout("strategy_design")
+    assert result == model_factory._DEFAULT_TRANSPORT_TIMEOUT
+    assert result > 0 and math.isfinite(result)
+
+
+@pytest.mark.parametrize("bad", [-1.0, 0.0, float("inf"), float("nan")])
+def test_get_strands_model_rejects_non_positive_or_nonfinite_explicit_timeout(
+    monkeypatch: pytest.MonkeyPatch, bad: float
+) -> None:
+    """An explicit non-positive/non-finite ``timeout`` raises ``ValueError`` — an
+    explicit ``raise`` (not ``assert``) so the guard survives ``python -O``."""
     model_factory, _ = _patch_ollama_local(monkeypatch)
 
-    with pytest.raises(AssertionError, match="timeout must be > 0"):
-        model_factory.get_strands_model("strategy_design", timeout=-1.0)
+    with pytest.raises(ValueError, match="positive, finite"):
+        model_factory.get_strands_model("strategy_design", timeout=bad)
 
 
 def test_get_strands_model_forwards_transport_timeout(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/agents/investment_team/tests/test_strategy_lab_llm_envelope.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_llm_envelope.py
@@ -538,43 +538,108 @@ def test_design_invoke_charges_once_despite_transport_retry(
 
 
 # ---------------------------------------------------------------------------
-# model_factory._construct_with_optional_timeout
+# model_factory transport-timeout construction
 # ---------------------------------------------------------------------------
 
 
-def test_construct_forwards_timeout_when_accepted() -> None:
-    from investment_team.strategy_lab.agents.model_factory import _construct_with_optional_timeout
+def test_accepts_kwarg_ignores_var_keyword() -> None:
+    """A name reachable only via ``**kwargs`` must NOT count as accepted — the
+    strands constructors swallow such keys into ``**model_config`` and warn.
+    """
+    from investment_team.strategy_lab.agents.model_factory import _accepts_kwarg
+
+    class _Explicit:
+        def __init__(self, ollama_client_args=None) -> None: ...
+
+    class _OnlyVarKw:
+        def __init__(self, **model_config) -> None: ...
+
+    assert _accepts_kwarg(_Explicit, "ollama_client_args") is True
+    assert _accepts_kwarg(_OnlyVarKw, "ollama_client_args") is False
+    assert _accepts_kwarg(_Explicit, "nope") is False
+    # An un-introspectable target degrades to False rather than raising.
+    assert _accepts_kwarg(42, "anything") is False
+
+
+def test_ollama_construct_forwards_timeout_via_client_args() -> None:
+    from investment_team.strategy_lab.agents.model_factory import (
+        _construct_ollama_with_timeout,
+    )
 
     class _Model:
-        def __init__(self, host=None, timeout=None) -> None:
+        def __init__(self, host=None, model_id=None, ollama_client_args=None) -> None:
             self.host = host
-            self.timeout = timeout
+            self.model_id = model_id
+            self.ollama_client_args = ollama_client_args
 
-    model = _construct_with_optional_timeout(_Model, 12.5, host="h")
-    assert model.timeout == 12.5
+    model = _construct_ollama_with_timeout(_Model, 12.5, host="h", model_id="m")
+    assert model.ollama_client_args == {"timeout": 12.5}
     assert model.host == "h"
+    assert model.model_id == "m"
 
 
-def test_construct_falls_back_on_signature_mismatch() -> None:
-    from investment_team.strategy_lab.agents.model_factory import _construct_with_optional_timeout
+def test_ollama_construct_supports_legacy_client_args_name() -> None:
+    from investment_team.strategy_lab.agents.model_factory import (
+        _construct_ollama_with_timeout,
+    )
 
     class _Model:
-        def __init__(self, host=None) -> None:  # accepts neither timeout nor client_args
+        def __init__(self, host=None, client_args=None) -> None:
             self.host = host
+            self.client_args = client_args
 
-    model = _construct_with_optional_timeout(_Model, 12.5, host="h")
-    assert isinstance(model, _Model)
-    assert model.host == "h"
+    model = _construct_ollama_with_timeout(_Model, 7.0, host="h")
+    assert model.client_args == {"timeout": 7.0}
 
 
-def test_construct_propagates_unrelated_type_error() -> None:
-    from investment_team.strategy_lab.agents.model_factory import _construct_with_optional_timeout
+def test_ollama_construct_falls_back_when_no_channel() -> None:
+    from investment_team.strategy_lab.agents.model_factory import (
+        _construct_ollama_with_timeout,
+    )
 
     class _Model:
-        def __init__(self, host=None, timeout=None) -> None:
-            # A TypeError unrelated to the call signature must NOT be swallowed
-            # as a "timeout not supported" fallback.
-            raise TypeError("internal: host must be a tuple")
+        # No client-args channel; **kwargs must NOT be smuggled a timeout (the
+        # old bug: strands warns-and-drops unknown keys, so doing so would be a
+        # silent no-op rather than an applied timeout).
+        def __init__(self, host=None, **model_config) -> None:
+            self.host = host
+            self.model_config = model_config
 
-    with pytest.raises(TypeError, match="host must be a tuple"):
-        _construct_with_optional_timeout(_Model, 12.5, host="h")
+    model = _construct_ollama_with_timeout(_Model, 9.0, host="h")
+    assert model.host == "h"
+    assert "timeout" not in model.model_config
+    assert "ollama_client_args" not in model.model_config
+
+
+def test_bedrock_construct_forwards_timeout_via_boto_config() -> None:
+    from investment_team.strategy_lab.agents.model_factory import (
+        _construct_bedrock_with_timeout,
+    )
+
+    class _Model:
+        def __init__(self, model_id=None, boto_client_config=None) -> None:
+            self.model_id = model_id
+            self.boto_client_config = boto_client_config
+
+    # A fractional timeout must be preserved verbatim (regression: the old code
+    # did int(timeout), truncating 12.5 -> 12 and a sub-second value -> 0).
+    model = _construct_bedrock_with_timeout(_Model, 12.5, model_id="m")
+    assert model.model_id == "m"
+    assert model.boto_client_config is not None
+    assert model.boto_client_config.read_timeout == 12.5
+    assert model.boto_client_config.connect_timeout == 12.5
+
+
+def test_bedrock_construct_falls_back_when_no_channel() -> None:
+    from investment_team.strategy_lab.agents.model_factory import (
+        _construct_bedrock_with_timeout,
+    )
+
+    class _Model:
+        def __init__(self, model_id=None, **model_config) -> None:
+            self.model_id = model_id
+            self.model_config = model_config
+
+    model = _construct_bedrock_with_timeout(_Model, 30.0, model_id="m")
+    assert model.model_id == "m"
+    assert "boto_client_config" not in model.model_config


### PR DESCRIPTION
Closes #833

## Problem

Strategy Lab logged `Invalid configuration parameters: ['timeout']` on every model construction, and the transport read timeout was **silently dropped** — never reaching the HTTP client.

strands' `OllamaModel` / `BedrockModel` constructors absorb any unknown keyword into `**model_config`, where `validate_config_keys()` only *warns* and never raises. The old `_construct_with_optional_timeout` passed a bare `timeout=` kwarg and relied on catching `TypeError("unexpected keyword argument")` to fall back to the right shape — but that `TypeError` can never fire, so the first attempt always "succeeded", emitted the warning, and dropped the timeout. Only the envelope's secondary wall-clock guard remained, so a hung HTTP call was no longer cancelled at the transport level.

## Fix (`strategy_lab/agents/model_factory.py`)

Replace the broken `TypeError`-probe with `inspect.signature` introspection that only honours an **explicitly-declared** parameter (a name reachable solely via `**kwargs` does not count — strands warns-and-drops it), then route the timeout through each provider's real channel:

- **Ollama** → `ollama_client_args={"timeout": ...}` → `ollama.AsyncClient(host, **client_args)` → httpx
- **Bedrock** → `boto_client_config=botocore.Config(read_timeout=..., connect_timeout=...)`

This removes the warning **and** restores the transport read timeout.

### Review-driven hardening

An adversarial review pass surfaced three secondary issues, all fixed:

- **`int(timeout)` truncation** → botocore now receives the float verbatim (a sub-second timeout no longer collapses to `0`, and the Bedrock path matches the Ollama path).
- **DbC `timeout > 0`** → `_resolve_strands_timeout` now falls back on non-positive env values (honouring its documented positive-float postcondition), and `get_strands_model` asserts `timeout > 0` at the boundary.
- **Misleading docstring** → the `client_args` probe is now honestly documented as a defensive fallback (the client-args name strands' other providers use), not a claim that a current release uses it.

## Verification

- `model_factory.py` at **100%** line coverage; ruff lint + format clean.
- Full `investment_team` suite: **3363 passed, 10 skipped, 0 failures**.
- New regression tests prove the timeout reaches the transport (not merely that construction succeeds), cover both provider channels and their fallbacks, and lock in the precondition + no-truncation behavior.
- Isolated to the Strategy Lab factory; `llm_service.get_strands_model` is a separate code path and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)