### PR TITLE
Remove issue-number refs and phase-history narration from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,19 +37,19 @@ backend/
     job_matching_team/       # Scans open roles vs a job-seeker profile; ranks best-to-apply
     llm_service/             # Centralized LLM client (Ollama, Claude)
     agent_registry/          # Agent Console catalog: loads per-agent YAML manifests, serves /api/agents
-    agent_console/           # Agent Console Phase 3: Postgres-backed saved inputs, run history, diff, pruner
-    product_delivery/        # Persistent Product Delivery Loop (#243), in-process module mounted by
-                             # unified_api at /api/product-delivery. Phase 1 (#369): backlog tables
+    agent_console/           # Agent Console data layer: Postgres-backed saved inputs, run history, diff, pruner
+    product_delivery/        # Persistent Product Delivery Loop, in-process module mounted by
+                             # unified_api at /api/product-delivery. Backlog tables
                              # (products → initiatives → epics → stories → tasks + acceptance criteria
-                             # + feedback_items), ProductOwnerAgent (WSJF/RICE). Phase 2 (#396): sprints
-                             # + releases tables, sprint_planner_agent, _load_requirements_from_sprint
-                             # in the SE orchestrator. Phase 3 (#371): release_manager_agent ships sprint
-                             # completion → plan/releases/<version>.md + product_delivery_releases row,
-                             # auto-promotes Integration-phase failures into sprint-tagged
-                             # feedback_items (queryable via GET /feedback; operator triage feeds the
-                             # next groom — POST /groom does not consume feedback automatically);
-                             # POST/GET /releases routes; SE Integration-phase hook (legacy SE path
-                             # only — default use_coding_team=True path currently skips the hook).
+                             # + feedback_items), ProductOwnerAgent (WSJF/RICE); sprints + releases
+                             # tables, sprint_planner_agent, _load_requirements_from_sprint in the SE
+                             # orchestrator; release_manager_agent ships sprint completion →
+                             # plan/releases/<version>.md + product_delivery_releases row, auto-promotes
+                             # Integration-phase failures into sprint-tagged feedback_items (queryable
+                             # via GET /feedback; operator triage feeds the next groom — POST /groom
+                             # does not consume feedback automatically); POST/GET /releases routes;
+                             # SE Integration-phase hook (legacy SE path only — default
+                             # use_coding_team=True path currently skips the hook).
     shared_agent_invoke/     # Invoke shim mounted inside the sandbox image; exposes POST /_agents/{id}/invoke
     integrations/            # Shared integration contracts (Google login, Medium, etc.)
     artifact_registry/       # Shared artifact persistence
@@ -224,7 +224,7 @@ Environment variables for LLM: `LLM_PROVIDER`, `LLM_BASE_URL`, `LLM_MODEL`
 
 ### Project Rules
 
-- **Never reference GitHub issues in code, comments, or docs.** Do not mention issue numbers (e.g. `#243`, `#369`, `Issue #531`), issue URLs, or "see issue X" anywhere in source code, comments, docstrings, commit messages, changelogs, or documentation. Describe the change on its own terms — what it does and why — without pointing at an external tracker. This rule applies to *new* writing; existing references in this file and historical docs are grandfathered until the surrounding section is rewritten.
+- **Never reference GitHub issues in code, comments, or docs.** Do not mention issue numbers (e.g. `#NNN`, `Issue #NNN`), issue URLs, or "see issue X" anywhere in source code, comments, docstrings, commit messages, changelogs, or documentation. Describe the change on its own terms — what it does and why — without pointing at an external tracker. This rule applies to *new* writing; existing references in this file and historical docs are grandfathered until the surrounding section is rewritten.
 - **Always use `Closes #N` notation in pull requests.** Every PR must reference the associated GitHub issue in its body using GitHub's auto-close keywords (`Closes #N`, `Fixes #N`, or `Resolves #N`) so merging the PR automatically closes the linked issue. This is the *only* place issue numbers belong — PR bodies — and it is required, not optional. If a change has no associated issue, open one first.
 - **Design by Contract (DbC) is mandatory for all code and comments.** Every function, method, and module must make its contract explicit:
   - **Preconditions** — what callers must guarantee about inputs (types, ranges, invariants, required state). Enforce with `assert` or explicit validation that raises on violation at boundaries.


### PR DESCRIPTION
## Summary

Brings `CLAUDE.md` into compliance with the repo's own Project Rule against referencing GitHub issues in docs, and removes changelog-style "how it got here" narration so the file describes **current state** only.

### Changes
- **`product_delivery` / `agent_console` directory comments** — stripped `(#243)`, `Phase 1 (#369)`, `Phase 2 (#396)`, `Phase 3 (#371)`, and the `agent_console` "Phase 3:" label. Rewrote the phase-by-phase narration into a plain description of what exists today. Every concrete fact (tables, agents, routes, the `use_coding_team` hook caveat) is preserved.
- **Project Rule examples** — replaced the real-looking example issue numbers (`#243`, `#369`, `Issue #531`) with non-numeric placeholders (`#NNN`, `Issue #NNN`) so the rule stays illustrative without leaving any matchable reference.

### Verification
- `grep -nE '#[0-9]+|Issue #[0-9]+|\(shipped\)|removed in #|Phase [0-9]+' CLAUDE.md` → no matches.
- File size: 29,760 → 29,700 chars (this issue's cleanup; the headline "1–2k" estimate was against the older 52k version that earlier shrink work had already reduced).
- No factual content lost — only issue tags and evolution scaffolding removed.

### Acceptance criteria
- [x] Zero `#N` / `Issue #N` references remain in `CLAUDE.md`.
- [x] No `(shipped)` / "removed in" / "Phase N (#…)" historical narration remains.
- [x] Current behavior is still fully described (state, not history).

Closes #825

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdQEjBxihFqT3RpCXYySZU)_