### PR TITLE
Coding Team UI: live issue indicator, in-UI question answering, resil…

### DIFF
--- a/backend/agents/coding_team/api/main.py
+++ b/backend/agents/coding_team/api/main.py
@@ -520,9 +520,10 @@ def _answer_wait_heartbeat_fresh(data: Dict[str, Any]) -> bool:
     Preconditions:
         - ``data`` is a job record dict (possibly empty).
     Postconditions:
-        - Returns True iff ``answer_wait_heartbeat_at`` parses as an ISO timestamp within
-          ``_ANSWER_WAIT_HEARTBEAT_STALE_S`` seconds of now. Missing/garbage values → False
-          (treat as no live loop), never raises.
+        - Returns True iff ``answer_wait_heartbeat_at`` parses as an ISO timestamp whose age is in
+          ``[0, _ANSWER_WAIT_HEARTBEAT_STALE_S)``. A future-dated stamp (clock skew or corruption)
+          is NOT fresh — it must never make a dead loop look alive and block resume until that
+          future time passes. Missing/garbage values → False, never raises.
     """
     raw = (data or {}).get("answer_wait_heartbeat_at")
     if not raw:
@@ -533,7 +534,8 @@ def _answer_wait_heartbeat_fresh(data: Dict[str, Any]) -> bool:
         return False
     if beat.tzinfo is None:
         beat = beat.replace(tzinfo=timezone.utc)
-    return (datetime.now(timezone.utc) - beat).total_seconds() < _ANSWER_WAIT_HEARTBEAT_STALE_S
+    age = (datetime.now(timezone.utc) - beat).total_seconds()
+    return 0 <= age < _ANSWER_WAIT_HEARTBEAT_STALE_S
 
 
 def _start_orchestrator_thread(job_id: str, repo_path: str, plan: CodingTeamPlanInput) -> None:

--- a/backend/agents/coding_team/api/main.py
+++ b/backend/agents/coding_team/api/main.py
@@ -57,6 +57,7 @@ from coding_team.review_history_store import (  # noqa: E402
     record_review_start,
     update_review,
 )
+from coding_team.token_crypto import decrypt_token, encrypt_token  # noqa: E402
 from shared_observability import init_otel, instrument_fastapi_app  # noqa: E402
 from software_engineering_team.shared.git_utils import (  # noqa: E402
     DEVELOPMENT_BRANCH,
@@ -719,9 +720,12 @@ def _try_auto_resume(job_id: str, data: Dict[str, Any]) -> bool:
     is_github_job = bool(
         ctx.get("owner") and ctx.get("repo") and ctx.get("issue_number") is not None
     )
-    # Prefer the token persisted at job creation (the per-request PAT from the credential store);
-    # fall back to GITHUB_TOKEN env for deployments that set it.
-    token = (data.get("github_token") or os.environ.get("GITHUB_TOKEN")) if is_github_job else None
+    # Prefer the token persisted (encrypted) at job creation; fall back to GITHUB_TOKEN env.
+    token = (
+        (decrypt_token(data.get("github_token_encrypted")) or os.environ.get("GITHUB_TOKEN"))
+        if is_github_job
+        else None
+    )
     if is_github_job and not token:
         # Without a token the publish flow (PR, issue comments) cannot be resumed; fall back to
         # the explicit-resume hint rather than silently completing without a PR.
@@ -788,8 +792,8 @@ def resume_job(job_id: str) -> RunResponse:
     No-op-safe: if a thread is still running (or a wait loop heartbeats from another worker), it
     will resume on its own and this just reports status. GitHub-issue jobs are restarted through
     the full hook path so publication (PR, issue comments) is preserved; that path needs a GitHub
-    token, sourced from the one persisted on the job record at creation (falling back to the
-    ``GITHUB_TOKEN`` env).
+    token, sourced by decrypting the one persisted (as opaque ciphertext) on the job record at
+    creation (falling back to the ``GITHUB_TOKEN`` env).
 
     Authentication/authorization is enforced by the unified API security gateway in front of all
     team mounts; like every other coding-team route, this endpoint assumes that perimeter.
@@ -842,9 +846,12 @@ def resume_job(job_id: str) -> RunResponse:
     is_github_job = bool(
         ctx.get("owner") and ctx.get("repo") and ctx.get("issue_number") is not None
     )
-    # Prefer the token persisted at job creation (per-request PAT from the credential store);
-    # fall back to GITHUB_TOKEN env.
-    token = (data.get("github_token") or os.environ.get("GITHUB_TOKEN")) if is_github_job else None
+    # Prefer the token persisted (encrypted) at job creation; fall back to GITHUB_TOKEN env.
+    token = (
+        (decrypt_token(data.get("github_token_encrypted")) or os.environ.get("GITHUB_TOKEN"))
+        if is_github_job
+        else None
+    )
     if is_github_job and not token:
         raise HTTPException(
             status_code=400,
@@ -1019,16 +1026,8 @@ def post_run_from_github(request: RunFromGitHubRequest) -> RunFromGitHubResponse
 
     job_id = str(uuid.uuid4())
     create_job(job_id=job_id, repo_path=request.repo_path, plan_input=plan.model_dump())
-    update_job(
-        job_id,
-        # Persist the resolved token so a resume after the orchestrator thread dies (server restart,
-        # different worker process) can re-drive the GitHub publish flow. In the standard
-        # deployment the token is a per-request PAT from the unified API credential store and the
-        # coding-team container has no GITHUB_TOKEN env, so without this the job could never resume.
-        # Stored as a top-level field, NOT inside github_context: github_context is echoed into the
-        # /status and /jobs responses, while this field is never serialized into any response model.
-        github_token=token,
-        github_context={
+    job_fields: Dict[str, Any] = {
+        "github_context": {
             "owner": request.owner,
             "repo": request.repo,
             "issue_number": issue.number,
@@ -1036,7 +1035,18 @@ def post_run_from_github(request: RunFromGitHubRequest) -> RunFromGitHubResponse
             "base_branch": request.base_branch,
             "remote": request.remote,
         },
-    )
+    }
+    # Persist the token (encrypted) so a resume after the orchestrator thread dies (server restart,
+    # different worker process) can re-drive the GitHub publish flow. In the standard deployment the
+    # token is a per-request PAT from the credential store and the coding-team container has no
+    # GITHUB_TOKEN env, so without this the job could never resume. Only OPAQUE CIPHERTEXT is stored
+    # — never a usable PAT — because the raw job record is echoed verbatim by the generic
+    # GET /api/jobs/{team} route. When no encryption key is configured the token is not persisted
+    # and resume falls back to GITHUB_TOKEN env (or refuses); we never store plaintext.
+    encrypted = encrypt_token(token)
+    if encrypted:
+        job_fields["github_token_encrypted"] = encrypted
+    update_job(job_id, **job_fields)
 
     _start_hook_thread(job_id, request, plan, issue, token)
     return RunFromGitHubResponse(job_id=job_id, issue_number=issue.number, issue_url=issue.html_url)

--- a/backend/agents/coding_team/api/main.py
+++ b/backend/agents/coding_team/api/main.py
@@ -44,9 +44,11 @@ from coding_team.github_source import (  # noqa: E402
 from coding_team.github_source.client import _is_safe_ref  # noqa: E402
 from coding_team.job_store import (  # noqa: E402
     DEFAULT_CACHE_DIR,
+    claim_resume,
     create_job,
     get_job,
     list_jobs,
+    release_resume_claim,
     update_job,
 )
 from coding_team.job_store import submit_answers as store_submit_answers  # noqa: E402
@@ -731,8 +733,18 @@ def _try_auto_resume(job_id: str, data: Dict[str, Any]) -> bool:
         # the explicit-resume hint rather than silently completing without a PR.
         logger.warning("Auto-resume for GitHub job %s skipped: no GitHub token available.", job_id)
         return False
+    # Cross-worker claim FIRST: the process-local _claim_run_thread cannot stop a different worker
+    # process from also spawning. The shared-store claim is the authoritative gate; only the worker
+    # that wins it proceeds to the local claim and spawn.
+    if not claim_resume(job_id):
+        logger.info(
+            "Auto-resume for job %s skipped: another worker holds the resume claim.", job_id
+        )
+        return True
     if not _claim_run_thread(job_id):
-        # Another caller (or the original thread, racing registration) is starting it.
+        # The cross-worker claim is ours but this process is already spawning (a racing thread):
+        # release the shared claim so the in-flight spawn (or a later retry) isn't blocked.
+        release_resume_claim(job_id)
         return True
     try:
         if is_github_job:
@@ -741,6 +753,7 @@ def _try_auto_resume(job_id: str, data: Dict[str, Any]) -> bool:
             _start_orchestrator_thread(job_id, repo_path, plan)
     except Exception:
         logger.exception("Auto-resume for job %s failed to start the orchestrator thread.", job_id)
+        release_resume_claim(job_id)
         return False
     return True
 
@@ -862,17 +875,28 @@ def resume_job(job_id: str) -> RunResponse:
             ),
         )
 
-    # Atomically claim the right to start the thread so two concurrent /resume calls (or one racing
-    # an as-yet-unregistered original thread) cannot both spawn an orchestrator for this job.
+    # Cross-worker claim FIRST (shared store), then the process-local claim: together they stop two
+    # concurrent resume requests — in the same OR different worker processes — from both spawning an
+    # orchestrator for this job.
+    if not claim_resume(job_id):
+        return RunResponse(
+            job_id=job_id, status=data.get("status", "running"), message="Job already running."
+        )
     if not _claim_run_thread(job_id):
+        release_resume_claim(job_id)
         return RunResponse(
             job_id=job_id, status=data.get("status", "running"), message="Job already running."
         )
 
-    if is_github_job:
-        _start_github_resume_thread(job_id, ctx, repo_path, plan, token or "")
-    else:
-        _start_orchestrator_thread(job_id, repo_path, plan)
+    try:
+        if is_github_job:
+            _start_github_resume_thread(job_id, ctx, repo_path, plan, token or "")
+        else:
+            _start_orchestrator_thread(job_id, repo_path, plan)
+    except Exception:
+        # A failed spawn must release the shared claim so a later /resume can win.
+        release_resume_claim(job_id)
+        raise
     return RunResponse(job_id=job_id, status="running", message="Job resumed.")
 
 

--- a/backend/agents/coding_team/api/main.py
+++ b/backend/agents/coding_team/api/main.py
@@ -709,13 +709,13 @@ def _try_auto_resume(job_id: str, data: Dict[str, Any]) -> bool:
     is_github_job = bool(
         ctx.get("owner") and ctx.get("repo") and ctx.get("issue_number") is not None
     )
-    token = os.environ.get("GITHUB_TOKEN") if is_github_job else None
+    # Prefer the token persisted at job creation (the per-request PAT from the credential store);
+    # fall back to GITHUB_TOKEN env for deployments that set it.
+    token = (data.get("github_token") or os.environ.get("GITHUB_TOKEN")) if is_github_job else None
     if is_github_job and not token:
         # Without a token the publish flow (PR, issue comments) cannot be resumed; fall back to
         # the explicit-resume hint rather than silently completing without a PR.
-        logger.warning(
-            "Auto-resume for GitHub job %s skipped: GITHUB_TOKEN not configured.", job_id
-        )
+        logger.warning("Auto-resume for GitHub job %s skipped: no GitHub token available.", job_id)
         return False
     if not _claim_run_thread(job_id):
         # Another caller (or the original thread, racing registration) is starting it.
@@ -777,8 +777,9 @@ def resume_job(job_id: str) -> RunResponse:
 
     No-op-safe: if a thread is still running (or a wait loop heartbeats from another worker), it
     will resume on its own and this just reports status. GitHub-issue jobs are restarted through
-    the full hook path so publication (PR, issue comments) is preserved; that path requires
-    ``GITHUB_TOKEN`` — per-request tokens are deliberately never persisted on job records.
+    the full hook path so publication (PR, issue comments) is preserved; that path needs a GitHub
+    token, sourced from the one persisted on the job record at creation (falling back to the
+    ``GITHUB_TOKEN`` env).
 
     Authentication/authorization is enforced by the unified API security gateway in front of all
     team mounts; like every other coding-team route, this endpoint assumes that perimeter.
@@ -787,7 +788,7 @@ def resume_job(job_id: str) -> RunResponse:
         - The job exists and is not terminal (a finished run must never be silently re-executed).
     Postconditions:
         - Raises 404 (unknown job), 400 (terminal job, missing repo_path/plan, or a GitHub-issue
-          job without GITHUB_TOKEN); returns "already running" without spawning when a live
+          job with no usable token); returns "already running" without spawning when a live
           thread, fresh heartbeat, or concurrent claim exists; otherwise spawns the orchestrator
           (hook path for GitHub-issue jobs) and reports "Job resumed."
     """
@@ -815,14 +816,16 @@ def resume_job(job_id: str) -> RunResponse:
     is_github_job = bool(
         ctx.get("owner") and ctx.get("repo") and ctx.get("issue_number") is not None
     )
-    token = os.environ.get("GITHUB_TOKEN") if is_github_job else None
+    # Prefer the token persisted at job creation (per-request PAT from the credential store);
+    # fall back to GITHUB_TOKEN env.
+    token = (data.get("github_token") or os.environ.get("GITHUB_TOKEN")) if is_github_job else None
     if is_github_job and not token:
         raise HTTPException(
             status_code=400,
             detail=(
-                "GitHub-issue job cannot resume without GITHUB_TOKEN: the publish flow "
-                "(PR, issue comments) would be lost, and per-request tokens are not persisted. "
-                "Configure GITHUB_TOKEN, or restart via POST /run-from-github with a token."
+                "GitHub-issue job cannot resume: no GitHub token is available (none persisted on "
+                "the job record and GITHUB_TOKEN unset), and the publish flow (PR, issue comments) "
+                "would be lost without one."
             ),
         )
 
@@ -992,6 +995,13 @@ def post_run_from_github(request: RunFromGitHubRequest) -> RunFromGitHubResponse
     create_job(job_id=job_id, repo_path=request.repo_path, plan_input=plan.model_dump())
     update_job(
         job_id,
+        # Persist the resolved token so a resume after the orchestrator thread dies (server restart,
+        # different worker process) can re-drive the GitHub publish flow. In the standard
+        # deployment the token is a per-request PAT from the unified API credential store and the
+        # coding-team container has no GITHUB_TOKEN env, so without this the job could never resume.
+        # Stored as a top-level field, NOT inside github_context: github_context is echoed into the
+        # /status and /jobs responses, while this field is never serialized into any response model.
+        github_token=token,
         github_context={
             "owner": request.owner,
             "repo": request.repo,

--- a/backend/agents/coding_team/api/main.py
+++ b/backend/agents/coding_team/api/main.py
@@ -458,7 +458,9 @@ def _validate_answers(data: Dict[str, Any], request: SubmitAnswersRequest) -> Li
     # one), not bad client input — surface it as a controlled 500 instead of a bare KeyError so the
     # failure is attributed to the server and carries a clear message.
     if any("id" not in q for q in pending):
-        raise HTTPException(status_code=500, detail="Corrupted job record: pending question missing 'id'.")
+        raise HTTPException(
+            status_code=500, detail="Corrupted job record: pending question missing 'id'."
+        )
     pending_ids = {q["id"] for q in pending}
     required_ids = {q["id"] for q in pending if q.get("required", True)}
     # Reject duplicate answers for the same question up front: the set below collapses them, so the
@@ -806,18 +808,27 @@ def _try_auto_resume(job_id: str, data: Dict[str, Any]) -> bool:
         # waiting with no live thread, that recheck reclaims and resumes it.
         _schedule_resume_recheck(job_id, delay=RESUME_CLAIM_TTL_S + 5.0)
         return True
-    # Post-claim freshness check: the job could have been cancelled or completed between the
-    # caller's get_job snapshot and the claim. claim_resume only checks the claim stamp, not the
-    # job status, so re-read here and abort if the job is now terminal — rather than spawning an
-    # orchestrator that would immediately find the job terminal and potentially clobber its status.
+    # Post-claim freshness check: the job could have transitioned out of waiting_for_user between
+    # the caller's snapshot and the claim. claim_resume checks only the claim stamp, not the
+    # job status, so re-read here. If the job is no longer waiting (terminal OR a wait loop in
+    # another worker consumed the answers and moved the job to 'running'), release the claim and
+    # abort — spawning here would double-drive a running job or clobber a terminal one. If the
+    # read itself fails (store temporarily unavailable), the unknown state is treated conservatively:
+    # release the claim and return False so the caller gets the manual-resume hint.
     try:
         post_claim_data = get_job(job_id)
     except Exception:
-        post_claim_data = None
-    if post_claim_data and hitl.is_terminal(post_claim_data):
+        logger.exception(
+            "Auto-resume for job %s aborted: could not verify state after acquiring claim.", job_id
+        )
+        release_resume_claim(job_id)
+        return False
+    if post_claim_data and post_claim_data.get("status") != hitl.WAITING_STATUS:
         release_resume_claim(job_id)
         logger.warning(
-            "Auto-resume for job %s aborted: job became terminal after claim was acquired.", job_id
+            "Auto-resume for job %s aborted: status is '%s' after claim (no longer waiting).",
+            job_id,
+            post_claim_data.get("status"),
         )
         return False
     if not _claim_run_thread(job_id):
@@ -934,7 +945,9 @@ def resume_job(job_id: str) -> RunResponse:
         )
     plan_raw = data.get("plan_input") or {}
     if not isinstance(plan_raw, dict):
-        raise HTTPException(status_code=400, detail="Job has a corrupted plan_input and cannot be resumed.")
+        raise HTTPException(
+            status_code=400, detail="Job has a corrupted plan_input and cannot be resumed."
+        )
     repo_path = data.get("repo_path") or plan_raw.get("repo_path")
     if not repo_path:
         raise HTTPException(status_code=400, detail="Job has no plan_input/repo_path to resume.")
@@ -976,6 +989,23 @@ def resume_job(job_id: str) -> RunResponse:
         return RunResponse(
             job_id=job_id, status=data.get("status", "running"), message="Job already running."
         )
+    # Post-claim re-read: a wait loop in another worker may have consumed answers and advanced the
+    # job out of waiting_for_user between the initial GET and the claim. claim_resume checks only
+    # the stamp, not the status, so verify freshness here before spawning.
+    try:
+        post_claim = get_job(job_id)
+    except Exception as exc:
+        release_resume_claim(job_id)
+        raise HTTPException(
+            status_code=500, detail="Failed to verify job state after acquiring resume claim."
+        ) from exc
+    if not post_claim or post_claim.get("status") != hitl.WAITING_STATUS:
+        release_resume_claim(job_id)
+        return RunResponse(
+            job_id=job_id,
+            status=(post_claim or data).get("status", "running"),
+            message="Job already running.",
+        )
     if not _claim_run_thread(job_id):
         release_resume_claim(job_id)
         return RunResponse(
@@ -1008,7 +1038,7 @@ def get_jobs(active: bool = False) -> List[JobListItem]:
         - Missing fields fall back to ``None``/``False``; ``status`` defaults to
           ``"pending"`` for records that predate the field.
     """
-    jobs = list_jobs(running_only=active)
+    jobs = list_jobs(active_only=active)
     return [
         JobListItem(
             job_id=j.get("job_id", ""),
@@ -1040,7 +1070,7 @@ def _running_job_for_issue(owner: str, repo: str, issue_number: int) -> Optional
     scan is acceptable; if active-job volume ever grows materially, add an owner/repo/issue filter
     to ``list_jobs`` (or an in-memory index) rather than scanning here.
     """
-    for j in list_jobs(running_only=True):
+    for j in list_jobs(active_only=True):
         ctx = (j or {}).get("github_context") or {}
         if (
             str(ctx.get("owner") or "").casefold() == owner.casefold()
@@ -1070,7 +1100,7 @@ def _running_sibling_on_checkout(repo_path: str, own_job_id: str) -> Optional[Di
           never reported.
     """
     target = os.path.realpath(repo_path)
-    for j in list_jobs(running_only=True):
+    for j in list_jobs(active_only=True):
         if not j or j.get("job_id") == own_job_id:
             continue
         sibling_path = j.get("repo_path")

--- a/backend/agents/coding_team/api/main.py
+++ b/backend/agents/coding_team/api/main.py
@@ -24,6 +24,7 @@ if str(_agents_root) not in sys.path:
 from fastapi import FastAPI, HTTPException, Query  # noqa: E402
 from pydantic import BaseModel, Field  # noqa: E402
 
+from coding_team import hitl  # noqa: E402
 from coding_team.activity import ActivityBridge  # noqa: E402
 from coding_team.github_source import (  # noqa: E402
     GitHubAPIError,
@@ -622,6 +623,53 @@ def _start_github_resume_thread(
         raise
 
 
+# How long after deferring to a fresh heartbeat we re-check that the deferred-to wait loop really
+# consumed the answers. Slightly past the staleness window so a loop that died right after its
+# last heartbeat is unambiguously dead by the time the recheck runs.
+_RESUME_RECHECK_DELAY_S = _ANSWER_WAIT_HEARTBEAT_STALE_S + 5.0
+
+
+def _schedule_resume_recheck(job_id: str) -> None:
+    """Schedule a one-shot recheck for a resume that was deferred to a fresh heartbeat.
+
+    A fresh heartbeat usually means a live wait loop elsewhere will consume the stored answers —
+    but a worker that died right after its last beat leaves the job paused with no resume control
+    (the UI shows "resuming" and never retries). The recheck runs after the staleness window: if
+    the job is still paused with no live thread and a now-stale heartbeat, it resumes it for real.
+
+    Postconditions:
+        - A daemon timer is scheduled; its callback is a no-op when the job moved on (status no
+          longer waiting), a thread is alive here, or the heartbeat is fresh again (the loop
+          really is alive elsewhere). Scheduling failures are logged, never raised.
+    """
+
+    def _recheck() -> None:
+        try:
+            data = get_job(job_id) or {}
+            if data.get("status") != hitl.WAITING_STATUS:
+                return
+            if _is_run_thread_alive(job_id) or _answer_wait_heartbeat_fresh(data):
+                return
+            if _try_auto_resume(job_id, data):
+                logger.info(
+                    "Deferred resume recheck restarted the orchestrator for job %s.", job_id
+                )
+            else:
+                update_job(
+                    job_id,
+                    status_text="Answers received. Resume the job to continue processing.",
+                )
+        except Exception:
+            logger.exception("Deferred resume recheck failed for job %s.", job_id)
+
+    try:
+        t = threading.Timer(_RESUME_RECHECK_DELAY_S, _recheck)
+        t.daemon = True
+        t.start()
+    except Exception:
+        logger.exception("Could not schedule resume recheck for job %s.", job_id)
+
+
 def _try_auto_resume(job_id: str, data: Dict[str, Any]) -> bool:
     """Best-effort restart of a dead orchestrator after answers arrived.
 
@@ -635,12 +683,18 @@ def _try_auto_resume(job_id: str, data: Dict[str, Any]) -> bool:
         - ``data`` is the job record for ``job_id`` and the caller observed the run thread
           as not alive in this process.
     Postconditions:
-        - Returns True when the run is resuming (a live wait loop heartbeated recently, a thread
-          was spawned here, or another caller holds the start claim); False when the record lacks
-          a usable ``repo_path``/``plan_input``, a GitHub-issue job has no token to resume its
-          publish flow, or the thread could not be started. Never raises.
+        - Returns True when the run is resuming (a live wait loop heartbeated recently — with a
+          deferred recheck scheduled in case that loop died right after its last beat — a thread
+          was spawned here, or another caller holds the start claim); False when the job is
+          terminal, the record lacks a usable ``repo_path``/``plan_input``, a GitHub-issue job
+          has no token to resume its publish flow, or the thread could not be started.
+          Never raises.
     """
+    if hitl.is_terminal(data):
+        logger.warning("Auto-resume for job %s skipped: job is terminal.", job_id)
+        return False
     if _answer_wait_heartbeat_fresh(data):
+        _schedule_resume_recheck(job_id)
         return True
     plan_raw = data.get("plan_input") or {}
     repo_path = data.get("repo_path") or plan_raw.get("repo_path")
@@ -685,6 +739,9 @@ def submit_pending_answers(job_id: str, request: SubmitAnswersRequest) -> Status
     thread died (e.g. a server restart), the orchestrator is restarted automatically; only when
     that is impossible (no usable plan/repo_path) are the answers merely stored with a
     status_text directing the caller to POST /run/{job_id}/resume.
+
+    Authentication/authorization is enforced by the unified API security gateway in front of all
+    team mounts; like every other coding-team route, this endpoint assumes that perimeter.
     """
     data = get_job(job_id)
     if not data:
@@ -718,14 +775,30 @@ def submit_pending_answers(job_id: str, request: SubmitAnswersRequest) -> Status
 def resume_job(job_id: str) -> RunResponse:
     """Restart a paused coding-team job's orchestrator after answers were stored but its thread died.
 
-    No-op-safe: if a thread is still running, it will resume on its own and this just reports status.
-    Only the standalone (plan_input) path is resumable here; the GitHub-issue publish flow is not
-    re-driven (its hook thread is gone), so a restarted GitHub job continues the code work but you
-    must re-trigger publication.
+    No-op-safe: if a thread is still running (or a wait loop heartbeats from another worker), it
+    will resume on its own and this just reports status. GitHub-issue jobs are restarted through
+    the full hook path so publication (PR, issue comments) is preserved; that path requires
+    ``GITHUB_TOKEN`` — per-request tokens are deliberately never persisted on job records.
+
+    Authentication/authorization is enforced by the unified API security gateway in front of all
+    team mounts; like every other coding-team route, this endpoint assumes that perimeter.
+
+    Preconditions:
+        - The job exists and is not terminal (a finished run must never be silently re-executed).
+    Postconditions:
+        - Raises 404 (unknown job), 400 (terminal job, missing repo_path/plan, or a GitHub-issue
+          job without GITHUB_TOKEN); returns "already running" without spawning when a live
+          thread, fresh heartbeat, or concurrent claim exists; otherwise spawns the orchestrator
+          (hook path for GitHub-issue jobs) and reports "Job resumed."
     """
     data = get_job(job_id)
     if not data:
         raise HTTPException(status_code=404, detail="Job not found")
+    if hitl.is_terminal(data):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Job is {data.get('status', 'terminal')} and cannot be resumed.",
+        )
     if _is_run_thread_alive(job_id) or _answer_wait_heartbeat_fresh(data):
         # The thread registry is process-local; a fresh answer-wait heartbeat means the job's
         # wait loop is alive in another worker — resuming here would double-drive the job.
@@ -738,6 +811,21 @@ def resume_job(job_id: str) -> RunResponse:
         raise HTTPException(status_code=400, detail="Job has no plan_input/repo_path to resume.")
     plan = CodingTeamPlanInput.model_validate({**plan_raw, "repo_path": repo_path})
 
+    ctx = data.get("github_context") or {}
+    is_github_job = bool(
+        ctx.get("owner") and ctx.get("repo") and ctx.get("issue_number") is not None
+    )
+    token = os.environ.get("GITHUB_TOKEN") if is_github_job else None
+    if is_github_job and not token:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "GitHub-issue job cannot resume without GITHUB_TOKEN: the publish flow "
+                "(PR, issue comments) would be lost, and per-request tokens are not persisted. "
+                "Configure GITHUB_TOKEN, or restart via POST /run-from-github with a token."
+            ),
+        )
+
     # Atomically claim the right to start the thread so two concurrent /resume calls (or one racing
     # an as-yet-unregistered original thread) cannot both spawn an orchestrator for this job.
     if not _claim_run_thread(job_id):
@@ -745,7 +833,10 @@ def resume_job(job_id: str) -> RunResponse:
             job_id=job_id, status=data.get("status", "running"), message="Job already running."
         )
 
-    _start_orchestrator_thread(job_id, repo_path, plan)
+    if is_github_job:
+        _start_github_resume_thread(job_id, ctx, repo_path, plan, token or "")
+    else:
+        _start_orchestrator_thread(job_id, repo_path, plan)
     return RunResponse(job_id=job_id, status="running", message="Job resumed.")
 
 

--- a/backend/agents/coding_team/api/main.py
+++ b/backend/agents/coding_team/api/main.py
@@ -693,6 +693,16 @@ def _try_auto_resume(job_id: str, data: Dict[str, Any]) -> bool:
     if hitl.is_terminal(data):
         logger.warning("Auto-resume for job %s skipped: job is terminal.", job_id)
         return False
+    # Only a paused job is safely resumable: a non-paused (e.g. running) job has no heartbeat to
+    # prove it dead, so it may be alive in another worker. Every current caller already passes a
+    # waiting_for_user record; this is a defensive invariant so the function stays safe if reused.
+    if data.get("status") != hitl.WAITING_STATUS:
+        logger.warning(
+            "Auto-resume for job %s skipped: not paused (status=%s).",
+            job_id,
+            data.get("status"),
+        )
+        return False
     if _answer_wait_heartbeat_fresh(data):
         _schedule_resume_recheck(job_id)
         return True
@@ -785,12 +795,14 @@ def resume_job(job_id: str) -> RunResponse:
     team mounts; like every other coding-team route, this endpoint assumes that perimeter.
 
     Preconditions:
-        - The job exists and is not terminal (a finished run must never be silently re-executed).
+        - The job exists, is not terminal, and (once liveness can't be proven) is paused in the
+          ``waiting_for_user`` state — the only state a resume is both needed and provably safe.
     Postconditions:
-        - Raises 404 (unknown job), 400 (terminal job, missing repo_path/plan, or a GitHub-issue
-          job with no usable token); returns "already running" without spawning when a live
-          thread, fresh heartbeat, or concurrent claim exists; otherwise spawns the orchestrator
-          (hook path for GitHub-issue jobs) and reports "Job resumed."
+        - Raises 404 (unknown job), 400 (terminal job, a non-paused job that can't be proven
+          alive, missing repo_path/plan, or a GitHub-issue job with no usable token); returns
+          "already running" without spawning when a live thread, fresh heartbeat, or concurrent
+          claim exists; otherwise spawns the orchestrator (hook path for GitHub-issue jobs) and
+          reports "Job resumed."
     """
     data = get_job(job_id)
     if not data:
@@ -805,6 +817,20 @@ def resume_job(job_id: str) -> RunResponse:
         # wait loop is alive in another worker — resuming here would double-drive the job.
         return RunResponse(
             job_id=job_id, status=data.get("status", "running"), message="Job already running."
+        )
+    # Past the liveness no-op, we could not PROVE the job is alive — but proof is only possible for
+    # a paused job (its wait loop heartbeats). A job in any other non-terminal state (most
+    # dangerously ``running``, actively doing code work with no heartbeat) might still be alive in
+    # another worker, and a heartbeat goes stale 30s after a pause ends. Only a paused
+    # (waiting_for_user) job is safely resumable; restarting anything else risks a second
+    # orchestrator mutating the same checkout concurrently.
+    if data.get("status") != hitl.WAITING_STATUS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Job is {data.get('status', 'in an unknown state')}, not paused waiting for "
+                "answers; only a paused (waiting_for_user) job can be resumed."
+            ),
         )
     plan_raw = data.get("plan_input") or {}
     repo_path = data.get("repo_path") or plan_raw.get("repo_path")

--- a/backend/agents/coding_team/api/main.py
+++ b/backend/agents/coding_team/api/main.py
@@ -442,8 +442,9 @@ def _validate_answers(data: Dict[str, Any], request: SubmitAnswersRequest) -> Li
           ``pending_questions``.
     Postconditions:
         - Raises HTTP 400 if the job is not waiting, has no pending questions, any required question
-          is unanswered, an answer references an unknown question, or an 'other' selection carries
-          no text. Otherwise returns the answers as dicts ready for ``store_submit_answers``, each
+          is unanswered, two answers target the same question, an answer references an unknown
+          question, or an 'other' selection carries no text. Otherwise returns the answers as dicts
+          ready for ``store_submit_answers``, each
           carrying the ``question_text`` of the pending question it answers (so a later resume can
           match answers to re-asked questions by text).
     """
@@ -454,7 +455,17 @@ def _validate_answers(data: Dict[str, Any], request: SubmitAnswersRequest) -> Li
         raise HTTPException(status_code=400, detail="No pending questions to answer.")
     pending_ids = {q["id"] for q in pending}
     required_ids = {q["id"] for q in pending if q.get("required", True)}
-    answered_ids = {a.question_id for a in request.answers}
+    # Reject duplicate answers for the same question up front: the set below collapses them, so the
+    # batch would pass validation while every conflicting entry is still persisted — letting the
+    # orchestrator proceed with contradictory decisions for one required question.
+    answered_id_list = [a.question_id for a in request.answers]
+    duplicate_ids = sorted({qid for qid in answered_id_list if answered_id_list.count(qid) > 1})
+    if duplicate_ids:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Duplicate answers for questions: {', '.join(duplicate_ids)}",
+        )
+    answered_ids = set(answered_id_list)
     missing = required_ids - answered_ids
     if missing:
         raise HTTPException(

--- a/backend/agents/coding_team/api/main.py
+++ b/backend/agents/coding_team/api/main.py
@@ -261,6 +261,16 @@ class JobListItem(BaseModel):
     status: str
     repo_path: Optional[str] = None
     phase: Optional[str] = None
+    status_text: Optional[str] = None
+    updated_at: Optional[str] = None
+    waiting_for_answers: bool = Field(
+        default=False,
+        description="True when the job is paused waiting for the user to answer pending questions.",
+    )
+    github_context: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="GitHub issue/PR metadata (owner, repo, issue_number, issue_url) when the run was started from an issue.",
+    )
 
 
 class RunFromGitHubRequest(BaseModel):
@@ -429,7 +439,9 @@ def _validate_answers(data: Dict[str, Any], request: SubmitAnswersRequest) -> Li
     Postconditions:
         - Raises HTTP 400 if the job is not waiting, has no pending questions, any required question
           is unanswered, an answer references an unknown question, or an 'other' selection carries
-          no text. Otherwise returns the answers as dicts ready for ``store_submit_answers``.
+          no text. Otherwise returns the answers as dicts ready for ``store_submit_answers``, each
+          carrying the ``question_text`` of the pending question it answers (so a later resume can
+          match answers to re-asked questions by text).
     """
     if not data.get("waiting_for_answers"):
         raise HTTPException(status_code=400, detail="Job is not waiting for answers.")
@@ -476,9 +488,15 @@ def _validate_answers(data: Dict[str, Any], request: SubmitAnswersRequest) -> Li
                 status_code=400,
                 detail=f"Question {a.question_id}: no option selected and no text provided.",
             )
+    # Persist the question text alongside each answer: the orchestrator's resume hydration
+    # (_hydrate_resolved_from_record) and the HITL coverage check match strictly by question
+    # text, so answers stored without it would be discarded — and the question re-asked — on
+    # any resume after the original thread died.
+    text_by_qid = {q["id"]: q.get("question_text", "") for q in pending}
     return [
         {
             "question_id": a.question_id,
+            "question_text": text_by_qid.get(a.question_id, ""),
             "selected_option_id": a.selected_option_id,
             "other_text": a.other_text,
         }
@@ -486,60 +504,44 @@ def _validate_answers(data: Dict[str, Any], request: SubmitAnswersRequest) -> Li
     ]
 
 
-@app.post("/run/{job_id}/answers", response_model=StatusResponse)
-def submit_pending_answers(job_id: str, request: SubmitAnswersRequest) -> StatusResponse:
-    """Submit answers to a paused coding-team job's pending questions and resume it.
+# A paused orchestrator's wait loop heartbeats every poll (~5s); anything older than this many
+# seconds means no live wait loop exists anywhere — including other worker processes, which the
+# process-local thread registry cannot see.
+_ANSWER_WAIT_HEARTBEAT_STALE_S = 30.0
 
-    The orchestrator's blocked wait loop clears on the stored answers (thread alive). If the thread
-    died (e.g. a server restart), the answers are stored and the caller should POST /run/{job_id}/resume.
+
+def _answer_wait_heartbeat_fresh(data: Dict[str, Any]) -> bool:
+    """True when a live answer-wait loop (possibly in another worker process) heartbeated recently.
+
+    Preconditions:
+        - ``data`` is a job record dict (possibly empty).
+    Postconditions:
+        - Returns True iff ``answer_wait_heartbeat_at`` parses as an ISO timestamp within
+          ``_ANSWER_WAIT_HEARTBEAT_STALE_S`` seconds of now. Missing/garbage values → False
+          (treat as no live loop), never raises.
     """
-    data = get_job(job_id)
-    if not data:
-        raise HTTPException(status_code=404, detail="Job not found")
-    answers = _validate_answers(data, request)
-    store_submit_answers(job_id, answers)
-    if not _is_run_thread_alive(job_id):
-        logger.info(
-            "Orchestrator thread for job %s is not running; answers stored. "
-            "Call POST /run/%s/resume to restart it.",
-            job_id,
-            job_id,
-        )
-        update_job(
-            job_id,
-            status_text="Answers received. Resume the job to continue processing.",
-        )
-    return get_status(job_id)
+    raw = (data or {}).get("answer_wait_heartbeat_at")
+    if not raw:
+        return False
+    try:
+        beat = datetime.fromisoformat(str(raw))
+    except ValueError:
+        return False
+    if beat.tzinfo is None:
+        beat = beat.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - beat).total_seconds() < _ANSWER_WAIT_HEARTBEAT_STALE_S
 
 
-@app.post("/run/{job_id}/resume", response_model=RunResponse)
-def resume_job(job_id: str) -> RunResponse:
-    """Restart a paused coding-team job's orchestrator after answers were stored but its thread died.
+def _start_orchestrator_thread(job_id: str, repo_path: str, plan: CodingTeamPlanInput) -> None:
+    """Spawn the daemon orchestrator thread for a job whose run-thread claim is held.
 
-    No-op-safe: if a thread is still running, it will resume on its own and this just reports status.
-    Only the standalone (plan_input) path is resumable here; the GitHub-issue publish flow is not
-    re-driven (its hook thread is gone), so a restarted GitHub job continues the code work but you
-    must re-trigger publication.
+    Preconditions:
+        - The caller holds the run-thread claim for ``job_id`` (via ``_claim_run_thread``).
+    Postconditions:
+        - A daemon thread is running the orchestrator; the claim is released by the thread's
+          ``finally`` (or here, if the thread never started — in which case the exception
+          propagates so the job stays resumable).
     """
-    data = get_job(job_id)
-    if not data:
-        raise HTTPException(status_code=404, detail="Job not found")
-    if _is_run_thread_alive(job_id):
-        return RunResponse(
-            job_id=job_id, status=data.get("status", "running"), message="Job already running."
-        )
-    plan_raw = data.get("plan_input") or {}
-    repo_path = data.get("repo_path") or plan_raw.get("repo_path")
-    if not repo_path:
-        raise HTTPException(status_code=400, detail="Job has no plan_input/repo_path to resume.")
-    plan = CodingTeamPlanInput.model_validate({**plan_raw, "repo_path": repo_path})
-
-    # Atomically claim the right to start the thread so two concurrent /resume calls (or one racing
-    # an as-yet-unregistered original thread) cannot both spawn an orchestrator for this job.
-    if not _claim_run_thread(job_id):
-        return RunResponse(
-            job_id=job_id, status=data.get("status", "running"), message="Job already running."
-        )
 
     def run() -> None:
         _register_run_thread(job_id)
@@ -572,19 +574,206 @@ def resume_job(job_id: str) -> RunResponse:
         # here so the job stays resumable instead of being wedged in _starting_run_jobs.
         _clear_run_thread(job_id)
         raise
+
+
+def _start_github_resume_thread(
+    job_id: str, ctx: Dict[str, Any], repo_path: str, plan: CodingTeamPlanInput, token: str
+) -> None:
+    """Spawn a resume of a GitHub-issue job through the full hook path (comments, branch prep, PR).
+
+    A plain orchestrator restart would silently drop publication (no PR, no issue comments), so
+    GitHub-issue jobs must resume through ``_run_with_github_hooks``. The spawned thread registers
+    itself in the run-thread registry immediately — before any GitHub I/O — so liveness checks see
+    it and the claim is released.
+
+    Preconditions:
+        - The caller holds the run-thread claim for ``job_id``; ``ctx`` carries ``owner``, ``repo``
+          and ``issue_number``; ``token`` is a non-empty GitHub token.
+    Postconditions:
+        - A daemon thread is running the hook-path resume; on thread-start failure the claim is
+          released and the exception propagates. A failed issue re-fetch inside the thread marks
+          the job failed rather than silently degrading to the hook-less path.
+    """
+    request = RunFromGitHubRequest(
+        owner=str(ctx["owner"]),
+        repo=str(ctx["repo"]),
+        repo_path=repo_path,
+        issue_number=int(ctx["issue_number"]),
+        base_branch=ctx.get("base_branch"),
+        remote=str(ctx.get("remote") or "origin"),
+    )
+
+    def run() -> None:
+        _register_run_thread(job_id)
+        try:
+            with GitHubClient(token=token) as client:
+                issue = client.get_issue(request.owner, request.repo, int(ctx["issue_number"]))
+            _run_with_github_hooks(job_id, request, plan, issue, token)
+        except Exception as e:
+            logger.exception("GitHub-path resume failed for job %s: %s", job_id, e)
+            update_job(job_id, status="failed", error=f"resume failed: {e}")
+        finally:
+            _clear_run_thread(job_id)
+
+    try:
+        threading.Thread(target=run, daemon=True).start()
+    except Exception:
+        _clear_run_thread(job_id)
+        raise
+
+
+def _try_auto_resume(job_id: str, data: Dict[str, Any]) -> bool:
+    """Best-effort restart of a dead orchestrator after answers arrived.
+
+    The thread registry is process-local, so "not alive here" does not mean "not alive anywhere":
+    a paused wait loop in another worker process heartbeats the job record every poll, and a fresh
+    heartbeat means that loop will consume the just-stored answers itself — spawning a second
+    orchestrator would double-drive the job and its checkout. GitHub-issue jobs resume through the
+    full hook path so publication (PR, issue comments) is preserved.
+
+    Preconditions:
+        - ``data`` is the job record for ``job_id`` and the caller observed the run thread
+          as not alive in this process.
+    Postconditions:
+        - Returns True when the run is resuming (a live wait loop heartbeated recently, a thread
+          was spawned here, or another caller holds the start claim); False when the record lacks
+          a usable ``repo_path``/``plan_input``, a GitHub-issue job has no token to resume its
+          publish flow, or the thread could not be started. Never raises.
+    """
+    if _answer_wait_heartbeat_fresh(data):
+        return True
+    plan_raw = data.get("plan_input") or {}
+    repo_path = data.get("repo_path") or plan_raw.get("repo_path")
+    if not repo_path:
+        return False
+    try:
+        plan = CodingTeamPlanInput.model_validate({**plan_raw, "repo_path": repo_path})
+    except Exception:
+        logger.exception("Auto-resume for job %s skipped: invalid plan_input.", job_id)
+        return False
+    ctx = data.get("github_context") or {}
+    is_github_job = bool(
+        ctx.get("owner") and ctx.get("repo") and ctx.get("issue_number") is not None
+    )
+    token = os.environ.get("GITHUB_TOKEN") if is_github_job else None
+    if is_github_job and not token:
+        # Without a token the publish flow (PR, issue comments) cannot be resumed; fall back to
+        # the explicit-resume hint rather than silently completing without a PR.
+        logger.warning(
+            "Auto-resume for GitHub job %s skipped: GITHUB_TOKEN not configured.", job_id
+        )
+        return False
+    if not _claim_run_thread(job_id):
+        # Another caller (or the original thread, racing registration) is starting it.
+        return True
+    try:
+        if is_github_job:
+            _start_github_resume_thread(job_id, ctx, repo_path, plan, token or "")
+        else:
+            _start_orchestrator_thread(job_id, repo_path, plan)
+    except Exception:
+        logger.exception("Auto-resume for job %s failed to start the orchestrator thread.", job_id)
+        return False
+    return True
+
+
+@app.post("/run/{job_id}/answers", response_model=StatusResponse)
+def submit_pending_answers(job_id: str, request: SubmitAnswersRequest) -> StatusResponse:
+    """Submit answers to a paused coding-team job's pending questions and resume it.
+
+    The orchestrator's blocked wait loop clears on the stored answers (thread alive). If the
+    thread died (e.g. a server restart), the orchestrator is restarted automatically; only when
+    that is impossible (no usable plan/repo_path) are the answers merely stored with a
+    status_text directing the caller to POST /run/{job_id}/resume.
+    """
+    data = get_job(job_id)
+    if not data:
+        raise HTTPException(status_code=404, detail="Job not found")
+    answers = _validate_answers(data, request)
+    store_submit_answers(job_id, answers)
+    if not _is_run_thread_alive(job_id):
+        # Write the optimistic status BEFORE spawning so the endpoint never clobbers a newer
+        # status_text the freshly started orchestrator may have already written.
+        update_job(job_id, status_text="Answers received; resuming the run.")
+        if _try_auto_resume(job_id, data):
+            logger.info(
+                "Orchestrator thread for job %s was not running; restarted it after answers.",
+                job_id,
+            )
+        else:
+            logger.info(
+                "Orchestrator thread for job %s is not running and could not be auto-resumed; "
+                "answers stored. Call POST /run/%s/resume to restart it.",
+                job_id,
+                job_id,
+            )
+            update_job(
+                job_id,
+                status_text="Answers received. Resume the job to continue processing.",
+            )
+    return get_status(job_id)
+
+
+@app.post("/run/{job_id}/resume", response_model=RunResponse)
+def resume_job(job_id: str) -> RunResponse:
+    """Restart a paused coding-team job's orchestrator after answers were stored but its thread died.
+
+    No-op-safe: if a thread is still running, it will resume on its own and this just reports status.
+    Only the standalone (plan_input) path is resumable here; the GitHub-issue publish flow is not
+    re-driven (its hook thread is gone), so a restarted GitHub job continues the code work but you
+    must re-trigger publication.
+    """
+    data = get_job(job_id)
+    if not data:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if _is_run_thread_alive(job_id) or _answer_wait_heartbeat_fresh(data):
+        # The thread registry is process-local; a fresh answer-wait heartbeat means the job's
+        # wait loop is alive in another worker — resuming here would double-drive the job.
+        return RunResponse(
+            job_id=job_id, status=data.get("status", "running"), message="Job already running."
+        )
+    plan_raw = data.get("plan_input") or {}
+    repo_path = data.get("repo_path") or plan_raw.get("repo_path")
+    if not repo_path:
+        raise HTTPException(status_code=400, detail="Job has no plan_input/repo_path to resume.")
+    plan = CodingTeamPlanInput.model_validate({**plan_raw, "repo_path": repo_path})
+
+    # Atomically claim the right to start the thread so two concurrent /resume calls (or one racing
+    # an as-yet-unregistered original thread) cannot both spawn an orchestrator for this job.
+    if not _claim_run_thread(job_id):
+        return RunResponse(
+            job_id=job_id, status=data.get("status", "running"), message="Job already running."
+        )
+
+    _start_orchestrator_thread(job_id, repo_path, plan)
     return RunResponse(job_id=job_id, status="running", message="Job resumed.")
 
 
 @app.get("/jobs", response_model=List[JobListItem])
-def get_jobs() -> List[JobListItem]:
-    """List coding_team jobs."""
-    jobs = list_jobs()
+def get_jobs(active: bool = False) -> List[JobListItem]:
+    """List coding_team jobs.
+
+    Postconditions:
+        - With ``active=true``, only non-terminal jobs (pending/running/waiting_for_user) are
+          returned, filtered at the job service so terminal jobs' full records (task graphs,
+          thinking text) never cross the wire just to be discarded.
+        - Every item carries the job's ``github_context`` (when present) and its
+          ``waiting_for_answers`` flag, so list consumers can identify paused
+          GitHub-issue runs without a per-job status call.
+        - Missing fields fall back to ``None``/``False``; ``status`` defaults to
+          ``"pending"`` for records that predate the field.
+    """
+    jobs = list_jobs(running_only=active)
     return [
         JobListItem(
             job_id=j.get("job_id", ""),
             status=j.get("status", "pending"),
             repo_path=j.get("repo_path"),
             phase=j.get("phase"),
+            status_text=j.get("status_text"),
+            updated_at=j.get("updated_at"),
+            waiting_for_answers=bool(j.get("waiting_for_answers", False)),
+            github_context=j.get("github_context"),
         )
         for j in jobs
     ]
@@ -596,12 +785,16 @@ def get_jobs() -> List[JobListItem]:
 
 
 def _running_job_for_issue(owner: str, repo: str, issue_number: int) -> Optional[str]:
-    """Return the job_id of any non-terminal job already working this issue."""
+    """Return the job_id of any non-terminal job already working this issue.
+
+    Owner/repo compare case-insensitively — GitHub treats them as case-insensitive, so two
+    casings of the same repository are the same repository here too.
+    """
     for j in list_jobs(running_only=True):
         ctx = (j or {}).get("github_context") or {}
         if (
-            ctx.get("owner") == owner
-            and ctx.get("repo") == repo
+            str(ctx.get("owner") or "").casefold() == owner.casefold()
+            and str(ctx.get("repo") or "").casefold() == repo.casefold()
             and ctx.get("issue_number") == issue_number
         ):
             return j.get("job_id")
@@ -1758,7 +1951,7 @@ def _defer_terminal_success(job_id: str):
     The orchestrator marks its job ``completed`` when the code work finishes,
     but the GitHub hook keeps mutating the shared checkout afterwards
     (fast-forward, push, PR creation, marker clear) and the busy-checkout
-    guard keys liveness off pending/running. Mapping the orchestrator's
+    guard keys liveness off the job store's non-terminal statuses. Mapping the orchestrator's
     terminal success to ``(running, publishing)`` keeps the job visible to
     the guard for that whole window; ``_run_with_github_hooks`` sets the real
     terminal status only once it is fully done with the checkout. Failure

--- a/backend/agents/coding_team/api/main.py
+++ b/backend/agents/coding_team/api/main.py
@@ -464,7 +464,11 @@ def _validate_answers(data: Dict[str, Any], request: SubmitAnswersRequest) -> Li
     # batch would pass validation while every conflicting entry is still persisted — letting the
     # orchestrator proceed with contradictory decisions for one required question.
     answered_id_list = [a.question_id for a in request.answers]
-    duplicate_ids = sorted({qid for qid in answered_id_list if answered_id_list.count(qid) > 1})
+    seen: set[str] = set()
+    dupes: set[str] = set()
+    for qid in answered_id_list:
+        (dupes if qid in seen else seen).add(qid)
+    duplicate_ids = sorted(dupes)
     if duplicate_ids:
         raise HTTPException(
             status_code=400,
@@ -759,8 +763,16 @@ def _try_auto_resume(job_id: str, data: Dict[str, Any]) -> bool:
         return False
     # Cross-worker claim FIRST: the process-local _claim_run_thread cannot stop a different worker
     # process from also spawning. The shared-store claim is the authoritative gate; only the worker
-    # that wins it proceeds to the local claim and spawn.
-    if not claim_resume(job_id):
+    # that wins it proceeds to the local claim and spawn. claim_resume() is the one job-store
+    # read-modify-write here and may raise on a transport error; this function promises "Never
+    # raises", so degrade a store failure to a False (manual-resume hint) rather than letting it
+    # escape into submit_pending_answers after the answers were already stored.
+    try:
+        claimed = claim_resume(job_id)
+    except Exception:
+        logger.exception("Auto-resume for job %s skipped: resume-claim store error.", job_id)
+        return False
+    if not claimed:
         logger.info(
             "Auto-resume for job %s skipped: another worker holds the resume claim.", job_id
         )
@@ -901,8 +913,17 @@ def resume_job(job_id: str) -> RunResponse:
 
     # Cross-worker claim FIRST (shared store), then the process-local claim: together they stop two
     # concurrent resume requests — in the same OR different worker processes — from both spawning an
-    # orchestrator for this job.
-    if not claim_resume(job_id):
+    # orchestrator for this job. A store transport error here must surface as a controlled 500: a
+    # bare propagation 500s opaquely, and swallowing it to False would falsely report "already
+    # running" when no claim was actually taken.
+    try:
+        claimed = claim_resume(job_id)
+    except Exception as e:
+        logger.exception("Resume for job %s: resume-claim store error.", job_id)
+        raise HTTPException(
+            status_code=500, detail="Failed to acquire the resume claim due to a job-store error."
+        ) from e
+    if not claimed:
         return RunResponse(
             job_id=job_id, status=data.get("status", "running"), message="Job already running."
         )
@@ -964,6 +985,11 @@ def _running_job_for_issue(owner: str, repo: str, issue_number: int) -> Optional
 
     Owner/repo compare case-insensitively — GitHub treats them as case-insensitive, so two
     casings of the same repository are the same repository here too.
+
+    Performance: this is an O(active-jobs) linear scan over the non-terminal set on each
+    run-from-issue request. That set is small in practice (a handful of concurrent runs), so the
+    scan is acceptable; if active-job volume ever grows materially, add an owner/repo/issue filter
+    to ``list_jobs`` (or an in-memory index) rather than scanning here.
     """
     for j in list_jobs(running_only=True):
         ctx = (j or {}).get("github_context") or {}

--- a/backend/agents/coding_team/api/main.py
+++ b/backend/agents/coding_team/api/main.py
@@ -534,6 +534,11 @@ def _validate_answers(data: Dict[str, Any], request: SubmitAnswersRequest) -> Li
 # process-local thread registry cannot see.
 _ANSWER_WAIT_HEARTBEAT_STALE_S = 30.0
 
+# Tolerated clock skew between worker hosts: a heartbeat stamped up to this many seconds in the
+# future (relative to the checking worker) is still treated as fresh. This covers NTP drift in
+# multi-host deployments without blocking resume indefinitely on a far-future/corrupt stamp.
+_HEARTBEAT_CLOCK_SKEW_TOLERANCE_S = 10.0
+
 
 def _answer_wait_heartbeat_fresh(data: Dict[str, Any]) -> bool:
     """True when a live answer-wait loop (possibly in another worker process) heartbeated recently.
@@ -542,9 +547,10 @@ def _answer_wait_heartbeat_fresh(data: Dict[str, Any]) -> bool:
         - ``data`` is a job record dict (possibly empty).
     Postconditions:
         - Returns True iff ``answer_wait_heartbeat_at`` parses as an ISO timestamp whose age is in
-          ``[0, _ANSWER_WAIT_HEARTBEAT_STALE_S)``. A future-dated stamp (clock skew or corruption)
-          is NOT fresh — it must never make a dead loop look alive and block resume until that
-          future time passes. Missing/garbage values → False, never raises.
+          ``(-_HEARTBEAT_CLOCK_SKEW_TOLERANCE_S, _ANSWER_WAIT_HEARTBEAT_STALE_S)``. Stamps more
+          than ``_HEARTBEAT_CLOCK_SKEW_TOLERANCE_S`` seconds in the future (implausible skew or
+          corruption) are NOT fresh — they must never block resume indefinitely. Missing/garbage
+          values → False, never raises.
     """
     raw = (data or {}).get("answer_wait_heartbeat_at")
     if not raw:
@@ -556,7 +562,7 @@ def _answer_wait_heartbeat_fresh(data: Dict[str, Any]) -> bool:
     if beat.tzinfo is None:
         beat = beat.replace(tzinfo=timezone.utc)
     age = (datetime.now(timezone.utc) - beat).total_seconds()
-    return 0 <= age < _ANSWER_WAIT_HEARTBEAT_STALE_S
+    return age > -_HEARTBEAT_CLOCK_SKEW_TOLERANCE_S and age < _ANSWER_WAIT_HEARTBEAT_STALE_S
 
 
 def _start_orchestrator_thread(job_id: str, repo_path: str, plan: CodingTeamPlanInput) -> None:
@@ -637,6 +643,13 @@ def _start_github_resume_thread(
             # Registration is inside the try so the finally always releases the claim — even if
             # _register_run_thread itself fails — instead of leaving it wedged in _starting_run_jobs.
             _register_run_thread(job_id)
+            # Advance the job out of waiting_for_user BEFORE the GitHub network I/O. The
+            # cross-worker resume claim (claim_resume) has a TTL of RESUME_CLAIM_TTL_S; if the
+            # issue fetch or branch prep takes longer than that, another worker could treat the
+            # expired claim as abandoned and spawn a second hook path. Moving the status to
+            # "running" here makes _try_auto_resume and resume_job decline (they only proceed for
+            # waiting_for_user), so the re-claiming window closes before the slow I/O begins.
+            update_job(job_id, status="running", status_text="Resuming via GitHub hook…")
             with GitHubClient(token=token) as client:
                 issue = client.get_issue(request.owner, request.repo, int(ctx["issue_number"]))
             _run_with_github_hooks(job_id, request, plan, issue, token)
@@ -793,6 +806,20 @@ def _try_auto_resume(job_id: str, data: Dict[str, Any]) -> bool:
         # waiting with no live thread, that recheck reclaims and resumes it.
         _schedule_resume_recheck(job_id, delay=RESUME_CLAIM_TTL_S + 5.0)
         return True
+    # Post-claim freshness check: the job could have been cancelled or completed between the
+    # caller's get_job snapshot and the claim. claim_resume only checks the claim stamp, not the
+    # job status, so re-read here and abort if the job is now terminal — rather than spawning an
+    # orchestrator that would immediately find the job terminal and potentially clobber its status.
+    try:
+        post_claim_data = get_job(job_id)
+    except Exception:
+        post_claim_data = None
+    if post_claim_data and hitl.is_terminal(post_claim_data):
+        release_resume_claim(job_id)
+        logger.warning(
+            "Auto-resume for job %s aborted: job became terminal after claim was acquired.", job_id
+        )
+        return False
     if not _claim_run_thread(job_id):
         # The cross-worker claim is ours but this process is already spawning (a racing thread):
         # release the shared claim so the in-flight spawn (or a later retry) isn't blocked.

--- a/backend/agents/coding_team/api/main.py
+++ b/backend/agents/coding_team/api/main.py
@@ -453,6 +453,11 @@ def _validate_answers(data: Dict[str, Any], request: SubmitAnswersRequest) -> Li
     pending = data.get("pending_questions", [])
     if not pending:
         raise HTTPException(status_code=400, detail="No pending questions to answer.")
+    # A pending question without an "id" is a corrupted job record (the orchestrator always stamps
+    # one), not bad client input — surface it as a controlled 500 instead of a bare KeyError so the
+    # failure is attributed to the server and carries a clear message.
+    if any("id" not in q for q in pending):
+        raise HTTPException(status_code=500, detail="Corrupted job record: pending question missing 'id'.")
     pending_ids = {q["id"] for q in pending}
     required_ids = {q["id"] for q in pending if q.get("required", True)}
     # Reject duplicate answers for the same question up front: the set below collapses them, so the
@@ -633,6 +638,12 @@ def _start_github_resume_thread(
             _clear_run_thread(job_id)
 
     try:
+        # Mirror _start_orchestrator_thread: a dead prior attempt may have left a mid-review
+        # current_activity behind (its finally never ran), which would render a frozen sub-bar
+        # through the resumed run's early phases. Wipe it first. This is the first job-service
+        # write after the claim, inside the claim-releasing try, so a store-outage raise here is
+        # handled by the except below rather than wedging the job.
+        update_job(job_id, current_activity=None)
         threading.Thread(target=run, daemon=True).start()
     except Exception:
         _clear_run_thread(job_id)

--- a/backend/agents/coding_team/api/main.py
+++ b/backend/agents/coding_team/api/main.py
@@ -570,8 +570,10 @@ def _start_orchestrator_thread(job_id: str, repo_path: str, plan: CodingTeamPlan
     """
 
     def run() -> None:
-        _register_run_thread(job_id)
         try:
+            # Registration is inside the try so the finally always releases the claim — even if
+            # _register_run_thread itself fails — instead of leaving it wedged in _starting_run_jobs.
+            _register_run_thread(job_id)
             run_coding_team_orchestrator(
                 job_id,
                 repo_path,
@@ -630,8 +632,10 @@ def _start_github_resume_thread(
     )
 
     def run() -> None:
-        _register_run_thread(job_id)
         try:
+            # Registration is inside the try so the finally always releases the claim — even if
+            # _register_run_thread itself fails — instead of leaving it wedged in _starting_run_jobs.
+            _register_run_thread(job_id)
             with GitHubClient(token=token) as client:
                 issue = client.get_issue(request.owner, request.repo, int(ctx["issue_number"]))
             _run_with_github_hooks(job_id, request, plan, issue, token)

--- a/backend/agents/coding_team/api/main.py
+++ b/backend/agents/coding_team/api/main.py
@@ -44,6 +44,7 @@ from coding_team.github_source import (  # noqa: E402
 from coding_team.github_source.client import _is_safe_ref  # noqa: E402
 from coding_team.job_store import (  # noqa: E402
     DEFAULT_CACHE_DIR,
+    RESUME_CLAIM_TTL_S,
     claim_resume,
     create_job,
     get_job,
@@ -664,13 +665,15 @@ def _start_github_resume_thread(
 _RESUME_RECHECK_DELAY_S = _ANSWER_WAIT_HEARTBEAT_STALE_S + 5.0
 
 
-def _schedule_resume_recheck(job_id: str) -> None:
-    """Schedule a one-shot recheck for a resume that was deferred to a fresh heartbeat.
+def _schedule_resume_recheck(job_id: str, delay: float = _RESUME_RECHECK_DELAY_S) -> None:
+    """Schedule a one-shot recheck for a resume that was deferred to another live owner.
 
-    A fresh heartbeat usually means a live wait loop elsewhere will consume the stored answers —
-    but a worker that died right after its last beat leaves the job paused with no resume control
-    (the UI shows "resuming" and never retries). The recheck runs after the staleness window: if
-    the job is still paused with no live thread and a now-stale heartbeat, it resumes it for real.
+    Two deferral cases share this safety net: deferring to a fresh answer-wait heartbeat (a wait
+    loop elsewhere should consume the answers) and deferring to another worker's resume claim. In
+    both, the owner could die right after we deferred, leaving the job paused with no resume control
+    (the UI shows "resuming" forever). The recheck runs after ``delay``: if the job is still paused
+    with no live thread and no fresh heartbeat, it resumes it for real. Callers pass a ``delay`` past
+    whichever liveness window applies (the heartbeat staleness window, or the resume-claim TTL).
 
     Postconditions:
         - A daemon timer is scheduled; its callback is a no-op when the job moved on (status no
@@ -698,7 +701,7 @@ def _schedule_resume_recheck(job_id: str) -> None:
             logger.exception("Deferred resume recheck failed for job %s.", job_id)
 
     try:
-        t = threading.Timer(_RESUME_RECHECK_DELAY_S, _recheck)
+        t = threading.Timer(delay, _recheck)
         t.daemon = True
         t.start()
     except Exception:
@@ -742,6 +745,10 @@ def _try_auto_resume(job_id: str, data: Dict[str, Any]) -> bool:
         _schedule_resume_recheck(job_id)
         return True
     plan_raw = data.get("plan_input") or {}
+    if not isinstance(plan_raw, dict):
+        # A corrupted record could carry a non-dict plan_input; .get() on it would raise
+        # AttributeError and break the "Never raises" contract. Treat it as no usable plan.
+        plan_raw = {}
     repo_path = data.get("repo_path") or plan_raw.get("repo_path")
     if not repo_path:
         return False
@@ -780,6 +787,11 @@ def _try_auto_resume(job_id: str, data: Dict[str, Any]) -> bool:
         logger.info(
             "Auto-resume for job %s skipped: another worker holds the resume claim.", job_id
         )
+        # The winner could die after claiming but before advancing the job out of waiting_for_user;
+        # its lease then expires (RESUME_CLAIM_TTL_S) with nobody retrying, leaving the job paused
+        # until the next user request. Schedule a recheck past the lease TTL: if the job is still
+        # waiting with no live thread, that recheck reclaims and resumes it.
+        _schedule_resume_recheck(job_id, delay=RESUME_CLAIM_TTL_S + 5.0)
         return True
     if not _claim_run_thread(job_id):
         # The cross-worker claim is ours but this process is already spawning (a racing thread):
@@ -816,10 +828,14 @@ def submit_pending_answers(job_id: str, request: SubmitAnswersRequest) -> Status
     answers = _validate_answers(data, request)
     store_submit_answers(job_id, answers)
     if not _is_run_thread_alive(job_id):
+        # Re-read the record after storing answers: the job may have been cancelled between the
+        # initial get_job and now. _try_auto_resume's terminal check must see that current state, or
+        # it could spawn a fresh orchestrator for an already-terminal job and overwrite its status.
+        current = get_job(job_id) or data
         # Write the optimistic status BEFORE spawning so the endpoint never clobbers a newer
         # status_text the freshly started orchestrator may have already written.
         update_job(job_id, status_text="Answers received; resuming the run.")
-        if _try_auto_resume(job_id, data):
+        if _try_auto_resume(job_id, current):
             logger.info(
                 "Orchestrator thread for job %s was not running; restarted it after answers.",
                 job_id,
@@ -890,6 +906,8 @@ def resume_job(job_id: str) -> RunResponse:
             ),
         )
     plan_raw = data.get("plan_input") or {}
+    if not isinstance(plan_raw, dict):
+        raise HTTPException(status_code=400, detail="Job has a corrupted plan_input and cannot be resumed.")
     repo_path = data.get("repo_path") or plan_raw.get("repo_path")
     if not repo_path:
         raise HTTPException(status_code=400, detail="Job has no plan_input/repo_path to resume.")

--- a/backend/agents/coding_team/hitl.py
+++ b/backend/agents/coding_team/hitl.py
@@ -59,6 +59,15 @@ _ANSWER_WAIT_POLL_INTERVAL_S = 5.0
 _TERMINAL_STATUSES = frozenset({"failed", "cancelled", "completed", "completed_with_failures"})
 
 
+def heartbeat_timestamp() -> str:
+    """Current UTC ISO-8601 timestamp for an answer-wait liveness heartbeat.
+
+    Postconditions:
+        - Returns a timezone-aware ISO-8601 string parseable by ``datetime.fromisoformat``.
+    """
+    return datetime.now(timezone.utc).isoformat()
+
+
 def answer_wait_timeout_s() -> float:
     """Wall-clock cap (seconds) for a single HITL pause.
 
@@ -388,7 +397,7 @@ def wait_for_answers(
             return False
         if heartbeat_fn is not None:
             try:
-                heartbeat_fn(datetime.now(timezone.utc).isoformat())
+                heartbeat_fn(heartbeat_timestamp())
             except Exception:
                 logger.debug("answer-wait heartbeat write failed for job %s", job_id, exc_info=True)
         sleep(poll_interval_s)

--- a/backend/agents/coding_team/hitl.py
+++ b/backend/agents/coding_team/hitl.py
@@ -28,6 +28,7 @@ import logging
 import os
 import time
 import uuid
+from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -361,6 +362,7 @@ def wait_for_answers(
     poll_interval_s: float = _ANSWER_WAIT_POLL_INTERVAL_S,
     sleep: Callable[[float], None] = time.sleep,
     now: Callable[[], float] = time.monotonic,
+    heartbeat_fn: Optional[Callable[[str], None]] = None,
 ) -> bool:
     """Block until the job's ``waiting_for_answers`` flag clears, the job goes terminal, or timeout.
 
@@ -371,6 +373,10 @@ def wait_for_answers(
         - Returns True iff ``waiting_for_answers`` became False (answers submitted) before the job
           went terminal or the timeout elapsed; returns False on terminal/timeout. Never proceeds on
           its own — the only True path is an explicit answer submission clearing the flag.
+        - When ``heartbeat_fn`` is provided, it is invoked with a current UTC ISO timestamp once per
+          poll iteration while waiting, so other processes can distinguish a live (but blocked)
+          wait loop from a dead one. Heartbeat failures are swallowed — proving liveness must never
+          break the wait itself.
     """
     timeout = timeout_s if timeout_s is not None else answer_wait_timeout_s()
     start = now()
@@ -380,6 +386,11 @@ def wait_for_answers(
             return True
         if is_terminal(data):
             return False
+        if heartbeat_fn is not None:
+            try:
+                heartbeat_fn(datetime.now(timezone.utc).isoformat())
+            except Exception:
+                logger.debug("answer-wait heartbeat write failed for job %s", job_id, exc_info=True)
         sleep(poll_interval_s)
     logger.warning("Coding team job %s timed out waiting for user answers", job_id)
     return False

--- a/backend/agents/coding_team/hitl.py
+++ b/backend/agents/coding_team/hitl.py
@@ -54,6 +54,11 @@ _GENERIC_OPTION_LABELS: frozenset = frozenset({
 
 _DEFAULT_ANSWER_WAIT_TIMEOUT_S = 3600.0
 _ANSWER_WAIT_POLL_INTERVAL_S = 5.0
+# Public alias: the cadence at which the answer-wait lease (heartbeat) is renewed. Callers that
+# must keep the lease fresh outside the wait loop (e.g. during a slow on_pause callback) reuse
+# this so the renewal cadence and the wait-loop cadence stay in lockstep, well under the answer
+# endpoint's staleness window.
+ANSWER_WAIT_POLL_INTERVAL_S = _ANSWER_WAIT_POLL_INTERVAL_S
 
 # Job statuses that mean "this job will never resume on its own"; the wait loop must stop polling.
 _TERMINAL_STATUSES = frozenset({"failed", "cancelled", "completed", "completed_with_failures"})

--- a/backend/agents/coding_team/job_store.py
+++ b/backend/agents/coding_team/job_store.py
@@ -16,6 +16,11 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_CACHE_DIR: Path = Path(os.getenv("AGENT_CACHE", ".agent_cache"))
 
+# Every status under which a job may still resume on its own. This is the single definition of
+# "active": a paused job (waiting_for_user) is still in flight — its checkout is owned, its issue
+# is being worked — and every liveness/admission consumer must see it.
+NON_TERMINAL_STATUSES: tuple[str, ...] = ("pending", "running", "waiting_for_user")
+
 
 def _client(cache_dir: str | Path = DEFAULT_CACHE_DIR) -> JobServiceClient:
     return JobServiceClient(team="coding_team")
@@ -85,8 +90,14 @@ def list_jobs(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
     running_only: bool = False,
 ) -> List[Dict[str, Any]]:
-    """List coding_team jobs. If running_only, only pending or running."""
-    statuses = ["pending", "running"] if running_only else None
+    """List coding_team jobs.
+
+    Postconditions:
+        - With ``running_only`` True, returns only jobs in a NON_TERMINAL_STATUSES status —
+          including ``waiting_for_user``: a paused job still owns its checkout and issue, so
+          admission guards and list consumers must not treat it as gone.
+    """
+    statuses = list(NON_TERMINAL_STATUSES) if running_only else None
     return _client(cache_dir).list_jobs(statuses=statuses)
 
 

--- a/backend/agents/coding_team/job_store.py
+++ b/backend/agents/coding_team/job_store.py
@@ -166,3 +166,34 @@ def get_submitted_answers(
     """Return the answers submitted for this job (empty when none/unknown)."""
     data = _client(cache_dir).get_job(job_id)
     return list(data.get("submitted_answers") or []) if data else []
+
+
+# ---------------------------------------------------------------------------
+# Cross-worker resume ownership
+#
+# The process-local run-thread registry cannot stop two *different worker processes* from each
+# spawning an orchestrator for the same paused job. These helpers claim ownership in the SHARED job
+# store via the job service's atomic, row-locked increment: the unique caller whose increment takes
+# ``resume_claim`` from 0 to 1 wins; concurrent callers (in any process) get 2, 3, … and lose. The
+# counter is reset to 0 each time the job re-enters the paused state (the orchestrator's
+# pause-publish), so every fresh pause is independently claimable, and released on a failed spawn.
+# ---------------------------------------------------------------------------
+
+_RESUME_CLAIM_FIELD = "resume_claim"
+
+
+def claim_resume(job_id: str, cache_dir: str | Path = DEFAULT_CACHE_DIR) -> bool:
+    """Atomically claim cross-worker ownership of a resume.
+
+    Postconditions:
+        - Returns True iff this caller's atomic increment took ``resume_claim`` from 0 to 1 (i.e.
+          it is the sole owner of the resume); False when another worker already claimed it or the
+          job is gone. Never raises beyond the underlying transport.
+    """
+    job = _client(cache_dir).apply_and_get(job_id, increment={_RESUME_CLAIM_FIELD: 1})
+    return bool(job) and job.get(_RESUME_CLAIM_FIELD) == 1
+
+
+def release_resume_claim(job_id: str, cache_dir: str | Path = DEFAULT_CACHE_DIR) -> None:
+    """Reset the resume claim so a failed spawn (or abandoned attempt) doesn't wedge future resumes."""
+    _client(cache_dir).update_job(job_id, heartbeat=False, **{_RESUME_CLAIM_FIELD: 0})

--- a/backend/agents/coding_team/job_store.py
+++ b/backend/agents/coding_team/job_store.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import logging
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -169,31 +170,77 @@ def get_submitted_answers(
 
 
 # ---------------------------------------------------------------------------
-# Cross-worker resume ownership
+# Cross-worker resume ownership (a recoverable TTL lease)
 #
 # The process-local run-thread registry cannot stop two *different worker processes* from each
-# spawning an orchestrator for the same paused job. These helpers claim ownership in the SHARED job
-# store via the job service's atomic, row-locked increment: the unique caller whose increment takes
-# ``resume_claim`` from 0 to 1 wins; concurrent callers (in any process) get 2, 3, … and lose. The
-# counter is reset to 0 each time the job re-enters the paused state (the orchestrator's
-# pause-publish), so every fresh pause is independently claimable, and released on a failed spawn.
+# spawning an orchestrator for the same paused job. ``claim_resume`` grants ownership in the SHARED
+# job store as a TTL lease, so it is both mutually exclusive AND recoverable if the winning worker
+# dies:
+#
+#   * Mutual exclusion: an atomic, row-locked ``apply`` increments a monotonic ``resume_claim_seq``
+#     and stamps ``resume_claim_at``; the caller wins iff its increment took the seq from the value
+#     it read to exactly that value + 1 (optimistic compare-and-set). Concurrent callers in any
+#     process read the same prior seq and only one increment can produce ``prior + 1``.
+#   * Recoverability: ``resume_claim_at`` is a lease timestamp, not renewed during the resumed run.
+#     A claim whose stamp is older than ``RESUME_CLAIM_TTL_S`` is treated as abandoned (its winner
+#     died before the run progressed), so a later claim reclaims it instead of wedging. A still-fresh
+#     stamp means a live worker is mid-resume → decline. The brief acquire→status=running window is
+#     far shorter than the TTL, and no claim is attempted once the job leaves ``waiting_for_user``.
 # ---------------------------------------------------------------------------
 
-_RESUME_CLAIM_FIELD = "resume_claim"
+_RESUME_CLAIM_SEQ_FIELD = "resume_claim_seq"
+_RESUME_CLAIM_AT_FIELD = "resume_claim_at"
+RESUME_CLAIM_TTL_S = 60.0
+
+
+def _claim_lease_fresh(stamp: Any, now: datetime) -> bool:
+    """True when ``stamp`` is a parseable timestamp whose age is within the lease TTL.
+
+    A future-dated or unparseable stamp is NOT fresh: it must never make a dead claim look alive
+    (clock skew / corruption would otherwise wedge the lease until that future time passes).
+    """
+    if not stamp:
+        return False
+    try:
+        ts = datetime.fromisoformat(str(stamp))
+    except ValueError:
+        return False
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    age = (now - ts).total_seconds()
+    return 0 <= age < RESUME_CLAIM_TTL_S
 
 
 def claim_resume(job_id: str, cache_dir: str | Path = DEFAULT_CACHE_DIR) -> bool:
-    """Atomically claim cross-worker ownership of a resume.
+    """Atomically and recoverably claim cross-worker ownership of a resume.
 
     Postconditions:
-        - Returns True iff this caller's atomic increment took ``resume_claim`` from 0 to 1 (i.e.
-          it is the sole owner of the resume); False when another worker already claimed it or the
-          job is gone. Never raises beyond the underlying transport.
+        - Returns True iff this caller acquired the lease: the prior claim was absent or expired
+          (its stamp older than ``RESUME_CLAIM_TTL_S``) AND this caller's atomic seq increment was
+          the unique one that produced ``prior_seq + 1``. Returns False when a live worker holds a
+          fresh lease, another concurrent caller won, or the job is gone. Never raises beyond the
+          underlying transport.
     """
-    job = _client(cache_dir).apply_and_get(job_id, increment={_RESUME_CLAIM_FIELD: 1})
-    return bool(job) and job.get(_RESUME_CLAIM_FIELD) == 1
+    client = _client(cache_dir)
+    job = client.get_job(job_id)
+    if not job:
+        return False
+    now = datetime.now(timezone.utc)
+    if _claim_lease_fresh(job.get(_RESUME_CLAIM_AT_FIELD), now):
+        return False  # a live worker is mid-resume
+    prior_seq = job.get(_RESUME_CLAIM_SEQ_FIELD) or 0
+    updated = client.apply_and_get(
+        job_id,
+        increment={_RESUME_CLAIM_SEQ_FIELD: 1},
+        merge_fields={_RESUME_CLAIM_AT_FIELD: now.isoformat()},
+    )
+    return bool(updated) and updated.get(_RESUME_CLAIM_SEQ_FIELD) == prior_seq + 1
 
 
 def release_resume_claim(job_id: str, cache_dir: str | Path = DEFAULT_CACHE_DIR) -> None:
-    """Reset the resume claim so a failed spawn (or abandoned attempt) doesn't wedge future resumes."""
-    _client(cache_dir).update_job(job_id, heartbeat=False, **{_RESUME_CLAIM_FIELD: 0})
+    """Release the lease (clear its stamp) so a failed/abandoned spawn doesn't block the TTL window.
+
+    Leaves ``resume_claim_seq`` untouched — it is monotonic; clearing only the stamp makes the job
+    immediately re-claimable without resetting the compare-and-set version.
+    """
+    _client(cache_dir).update_job(job_id, heartbeat=False, **{_RESUME_CLAIM_AT_FIELD: None})

--- a/backend/agents/coding_team/job_store.py
+++ b/backend/agents/coding_team/job_store.py
@@ -24,6 +24,9 @@ NON_TERMINAL_STATUSES: tuple[str, ...] = ("pending", "running", "waiting_for_use
 
 
 def _client(cache_dir: str | Path = DEFAULT_CACHE_DIR) -> JobServiceClient:
+    # cache_dir is accepted for API compatibility with callers that were written when this module
+    # was file-backed. JobServiceClient uses HTTP (configured via JOB_SERVICE_URL) and does not
+    # use a local filesystem cache, so cache_dir is intentionally not forwarded.
     return JobServiceClient(team="coding_team")
 
 
@@ -89,16 +92,16 @@ def update_job_task_graph(
 
 def list_jobs(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
-    running_only: bool = False,
+    active_only: bool = False,
 ) -> List[Dict[str, Any]]:
     """List coding_team jobs.
 
     Postconditions:
-        - With ``running_only`` True, returns only jobs in a NON_TERMINAL_STATUSES status —
+        - With ``active_only`` True, returns only jobs in a NON_TERMINAL_STATUSES status —
           including ``waiting_for_user``: a paused job still owns its checkout and issue, so
           admission guards and list consumers must not treat it as gone.
     """
-    statuses = list(NON_TERMINAL_STATUSES) if running_only else None
+    statuses = list(NON_TERMINAL_STATUSES) if active_only else None
     return _client(cache_dir).list_jobs(statuses=statuses)
 
 
@@ -221,6 +224,11 @@ def _claim_lease_fresh(stamp: Any, now: datetime) -> bool:
 def claim_resume(job_id: str, cache_dir: str | Path = DEFAULT_CACHE_DIR) -> bool:
     """Atomically and recoverably claim cross-worker ownership of a resume.
 
+    Preconditions:
+        - Callers must confirm the job is in ``waiting_for_user`` state before calling; this
+          function only enforces the claim stamp, not the job status. Invoking on a running or
+          terminal job is a logic error in the caller — it may acquire a lease for a job that
+          no longer needs resuming.
     Postconditions:
         - Returns True iff this caller acquired the lease: the prior claim was absent or expired
           (its stamp older than ``RESUME_CLAIM_TTL_S``) AND this caller's atomic seq increment was

--- a/backend/agents/coding_team/job_store.py
+++ b/backend/agents/coding_team/job_store.py
@@ -192,12 +192,19 @@ _RESUME_CLAIM_SEQ_FIELD = "resume_claim_seq"
 _RESUME_CLAIM_AT_FIELD = "resume_claim_at"
 RESUME_CLAIM_TTL_S = 60.0
 
+# Tolerated clock skew between worker hosts: a claim stamped up to this many seconds in the
+# future (relative to the checking worker) is still treated as fresh. Covers NTP drift without
+# wedging the lease on a far-future/corrupt stamp (those still expire naturally).
+_CLAIM_CLOCK_SKEW_TOLERANCE_S = 10.0
+
 
 def _claim_lease_fresh(stamp: Any, now: datetime) -> bool:
     """True when ``stamp`` is a parseable timestamp whose age is within the lease TTL.
 
-    A future-dated or unparseable stamp is NOT fresh: it must never make a dead claim look alive
-    (clock skew / corruption would otherwise wedge the lease until that future time passes).
+    A stamp more than ``_CLAIM_CLOCK_SKEW_TOLERANCE_S`` seconds in the future is NOT fresh:
+    implausible skew or corruption must not wedge the lease until a far-future time passes.
+    Stamps within the bounded skew window are accepted as fresh to tolerate NTP drift in
+    multi-host deployments.
     """
     if not stamp:
         return False
@@ -208,7 +215,7 @@ def _claim_lease_fresh(stamp: Any, now: datetime) -> bool:
     if ts.tzinfo is None:
         ts = ts.replace(tzinfo=timezone.utc)
     age = (now - ts).total_seconds()
-    return 0 <= age < RESUME_CLAIM_TTL_S
+    return age > -_CLAIM_CLOCK_SKEW_TOLERANCE_S and age < RESUME_CLAIM_TTL_S
 
 
 def claim_resume(job_id: str, cache_dir: str | Path = DEFAULT_CACHE_DIR) -> bool:

--- a/backend/agents/coding_team/job_store.py
+++ b/backend/agents/coding_team/job_store.py
@@ -242,5 +242,16 @@ def release_resume_claim(job_id: str, cache_dir: str | Path = DEFAULT_CACHE_DIR)
 
     Leaves ``resume_claim_seq`` untouched — it is monotonic; clearing only the stamp makes the job
     immediately re-claimable without resetting the compare-and-set version.
+
+    Best-effort and never raises: a job-store transport error while clearing the stamp is logged and
+    swallowed, not propagated. Release is cleanup, not a result — if it fails, the lease simply
+    self-heals when its TTL expires. Crucially, callers rely on this: ``_try_auto_resume`` documents
+    "never raises", and ``resume_job`` calls this inside an ``except`` block that re-raises the
+    original error — a release failure must never mask either.
     """
-    _client(cache_dir).update_job(job_id, heartbeat=False, **{_RESUME_CLAIM_AT_FIELD: None})
+    try:
+        _client(cache_dir).update_job(job_id, heartbeat=False, **{_RESUME_CLAIM_AT_FIELD: None})
+    except Exception:
+        logger.exception(
+            "release_resume_claim failed for job %s; the lease will expire via its TTL.", job_id
+        )

--- a/backend/agents/coding_team/orchestrator.py
+++ b/backend/agents/coding_team/orchestrator.py
@@ -407,7 +407,20 @@ def _run_pause_cycle(
     # user doesn't look continuously active (the API contract is that last_activity_at excludes
     # heartbeats, and stall/age indicators depend on it). Nothing real happens while waiting, so the
     # value is stable for the whole pause.
-    pinned_activity_at = (get_job_fn(job_id) or {}).get("last_activity_at")
+    # Thread 10: wrap the post-pause get_job so a transient store error doesn't crash the
+    # orchestrator after the pause flag is already written (which would leave waiting_for_answers
+    # True while the thread handler marks the job failed). On failure, continue with None —
+    # heartbeats simply won't pin last_activity_at (see Thread 12 guard below).
+    try:
+        pinned_activity_at = (get_job_fn(job_id) or {}).get("last_activity_at")
+    except Exception:
+        logger.debug(
+            "Failed to read pinned_activity_at after pause update for job %s; "
+            "answer-wait heartbeats will not pin last_activity_at.",
+            job_id,
+            exc_info=True,
+        )
+        pinned_activity_at = None
     if on_pause is not None:
         # on_pause can post a GitHub comment whose client uses ~30s timeouts with retries, which
         # can exceed the answer endpoint's heartbeat-staleness window. Periodic wait-loop heartbeats
@@ -415,13 +428,19 @@ def _run_pause_cycle(
         # go stale mid-callback and let another worker conclude the orchestrator died and spawn a
         # second run. Keep renewing the lease in the background for the callback's full duration.
         _renew_stop = threading.Event()
+        # Thread 12: only forward last_activity_at when we have a concrete value; passing None
+        # would overwrite the field with null on every heartbeat, breaking the contract that
+        # last_activity_at reflects real work, not liveness pings.
+        _pinned_kw = (
+            {"last_activity_at": pinned_activity_at} if pinned_activity_at is not None else {}
+        )
 
         def _renew_lease() -> None:
             while not _renew_stop.wait(hitl.ANSWER_WAIT_POLL_INTERVAL_S):
                 try:
                     update_fn(
                         answer_wait_heartbeat_at=hitl.heartbeat_timestamp(),
-                        last_activity_at=pinned_activity_at,
+                        **_pinned_kw,
                     )
                 except Exception:  # noqa: BLE001 — renewal must never abort the pause
                     logger.debug(
@@ -433,25 +452,47 @@ def _run_pause_cycle(
         _renew_thread = threading.Thread(
             target=_renew_lease, name=f"pause-lease-{job_id}", daemon=True
         )
-        _renew_thread.start()
+        # Thread 14: a system resource exhaustion may prevent the thread from starting; swallow
+        # that error and continue without the renewer (the initial heartbeat from the pause-publish
+        # update will cover short on_pause callbacks; a long callback may let the lease go stale).
+        _renew_started = False
+        try:
+            _renew_thread.start()
+            _renew_started = True
+        except RuntimeError:
+            logger.warning(
+                "Could not start pause-lease renewal thread for job %s; "
+                "on_pause callback runs without background heartbeat renewal.",
+                job_id,
+                exc_info=True,
+            )
         try:
             on_pause(structured)
         except Exception as e:  # noqa: BLE001 — surfacing the pause must never abort the job
             logger.warning("on_pause callback failed for job %s: %s", job_id, e)
         finally:
             _renew_stop.set()
-            _renew_thread.join(timeout=5.0)
+            if _renew_started:
+                _renew_thread.join(timeout=5.0)
     # The heartbeat lets the answers endpoint (possibly in another worker process) tell a live,
     # blocked wait loop apart from a dead one before it considers auto-resuming the job.
+    # Thread 12: same guard — omit last_activity_at from the wait-loop heartbeat when unknown.
+    _pinned_kw = {"last_activity_at": pinned_activity_at} if pinned_activity_at is not None else {}
     got = hitl.wait_for_answers(
         job_id,
         get_job_fn,
-        heartbeat_fn=lambda ts: update_fn(
-            answer_wait_heartbeat_at=ts, last_activity_at=pinned_activity_at
-        ),
+        heartbeat_fn=lambda ts: update_fn(answer_wait_heartbeat_at=ts, **_pinned_kw),
     )
     if not got:
-        data = get_job_fn(job_id) or {}
+        # Thread 11: wrap the terminal-check read; a store error here means we cannot distinguish
+        # a timed-out wait from a cancellation, so default to the safer "mark failed" path.
+        try:
+            data = get_job_fn(job_id) or {}
+        except Exception:
+            logger.debug(
+                "Failed to read job status after wait timeout for job %s", job_id, exc_info=True
+            )
+            data = {}
         if hitl.is_terminal(data):
             logger.info(
                 "Job %s ended while waiting for answers (status=%s)", job_id, data.get("status")
@@ -465,7 +506,18 @@ def _run_pause_cycle(
                 waiting_for_answers=False,
             )
         return [], False
-    submitted = (get_job_fn(job_id) or {}).get("submitted_answers") or []
+    # Thread 11: wrap the submitted-answers read; if it fails after answers were received, log and
+    # continue with an empty list so the job is cleared from the paused state (the update below
+    # clears waiting_for_answers) rather than crashing with the pause flag still set.
+    try:
+        submitted = (get_job_fn(job_id) or {}).get("submitted_answers") or []
+    except Exception:
+        logger.warning(
+            "Failed to read submitted_answers for job %s; proceeding with empty answers.",
+            job_id,
+            exc_info=True,
+        )
+        submitted = []
     resolved = hitl.answers_to_resolved(submitted, structured)
     update_fn(
         status="running",

--- a/backend/agents/coding_team/orchestrator.py
+++ b/backend/agents/coding_team/orchestrator.py
@@ -396,7 +396,13 @@ def _run_pause_cycle(
             on_pause(structured)
         except Exception as e:  # noqa: BLE001 — surfacing the pause must never abort the job
             logger.warning("on_pause callback failed for job %s: %s", job_id, e)
-    got = hitl.wait_for_answers(job_id, get_job_fn)
+    # The heartbeat lets the answers endpoint (possibly in another worker process) tell a live,
+    # blocked wait loop apart from a dead one before it considers auto-resuming the job.
+    got = hitl.wait_for_answers(
+        job_id,
+        get_job_fn,
+        heartbeat_fn=lambda ts: update_fn(answer_wait_heartbeat_at=ts),
+    )
     if not got:
         data = get_job_fn(job_id) or {}
         if hitl.is_terminal(data):

--- a/backend/agents/coding_team/orchestrator.py
+++ b/backend/agents/coding_team/orchestrator.py
@@ -399,10 +399,35 @@ def _run_pause_cycle(
         answer_wait_heartbeat_at=hitl.heartbeat_timestamp(),
     )
     if on_pause is not None:
+        # on_pause can post a GitHub comment whose client uses ~30s timeouts with retries, which
+        # can exceed the answer endpoint's heartbeat-staleness window. Periodic wait-loop heartbeats
+        # don't start until on_pause returns, so without renewal the single initial heartbeat could
+        # go stale mid-callback and let another worker conclude the orchestrator died and spawn a
+        # second run. Keep renewing the lease in the background for the callback's full duration.
+        _renew_stop = threading.Event()
+
+        def _renew_lease() -> None:
+            while not _renew_stop.wait(hitl.ANSWER_WAIT_POLL_INTERVAL_S):
+                try:
+                    update_fn(answer_wait_heartbeat_at=hitl.heartbeat_timestamp())
+                except Exception:  # noqa: BLE001 — renewal must never abort the pause
+                    logger.debug(
+                        "answer-wait lease renewal during on_pause failed for job %s",
+                        job_id,
+                        exc_info=True,
+                    )
+
+        _renew_thread = threading.Thread(
+            target=_renew_lease, name=f"pause-lease-{job_id}", daemon=True
+        )
+        _renew_thread.start()
         try:
             on_pause(structured)
         except Exception as e:  # noqa: BLE001 — surfacing the pause must never abort the job
             logger.warning("on_pause callback failed for job %s: %s", job_id, e)
+        finally:
+            _renew_stop.set()
+            _renew_thread.join(timeout=5.0)
     # The heartbeat lets the answers endpoint (possibly in another worker process) tell a live,
     # blocked wait loop apart from a dead one before it considers auto-resuming the job.
     got = hitl.wait_for_answers(

--- a/backend/agents/coding_team/orchestrator.py
+++ b/backend/agents/coding_team/orchestrator.py
@@ -401,6 +401,13 @@ def _run_pause_cycle(
         # waiting out the prior lease's TTL (the seq counter is left monotonic).
         resume_claim_at=None,
     )
+    # The answer-wait heartbeats below are liveness pings, NOT real orchestrator activity, but they
+    # route through the normal update path which stamps last_activity_at on every write. Pin it to
+    # its just-published value and pass it back on each heartbeat so a job that waits hours for a
+    # user doesn't look continuously active (the API contract is that last_activity_at excludes
+    # heartbeats, and stall/age indicators depend on it). Nothing real happens while waiting, so the
+    # value is stable for the whole pause.
+    pinned_activity_at = (get_job_fn(job_id) or {}).get("last_activity_at")
     if on_pause is not None:
         # on_pause can post a GitHub comment whose client uses ~30s timeouts with retries, which
         # can exceed the answer endpoint's heartbeat-staleness window. Periodic wait-loop heartbeats
@@ -412,7 +419,10 @@ def _run_pause_cycle(
         def _renew_lease() -> None:
             while not _renew_stop.wait(hitl.ANSWER_WAIT_POLL_INTERVAL_S):
                 try:
-                    update_fn(answer_wait_heartbeat_at=hitl.heartbeat_timestamp())
+                    update_fn(
+                        answer_wait_heartbeat_at=hitl.heartbeat_timestamp(),
+                        last_activity_at=pinned_activity_at,
+                    )
                 except Exception:  # noqa: BLE001 — renewal must never abort the pause
                     logger.debug(
                         "answer-wait lease renewal during on_pause failed for job %s",
@@ -436,7 +446,9 @@ def _run_pause_cycle(
     got = hitl.wait_for_answers(
         job_id,
         get_job_fn,
-        heartbeat_fn=lambda ts: update_fn(answer_wait_heartbeat_at=ts),
+        heartbeat_fn=lambda ts: update_fn(
+            answer_wait_heartbeat_at=ts, last_activity_at=pinned_activity_at
+        ),
     )
     if not got:
         data = get_job_fn(job_id) or {}

--- a/backend/agents/coding_team/orchestrator.py
+++ b/backend/agents/coding_team/orchestrator.py
@@ -384,12 +384,19 @@ def _run_pause_cycle(
     structured = hitl.convert_to_structured_questions(questions, source=source)
     if not structured:
         return [], True
+    # Record the wait-loop lease (the first heartbeat) ATOMICALLY with the pause flag: the same
+    # update publishes ``waiting_for_answers=True`` and a fresh ``answer_wait_heartbeat_at``, so a
+    # concurrent answer that lands on another worker can never observe the pause without also
+    # observing a live heartbeat. Doing the heartbeat after on_pause (which may post a slow GitHub
+    # comment) or only on the first wait_for_answers tick would leave a window where another worker
+    # sees the flag but no heartbeat, declares the orchestrator dead, and double-drives the job.
     update_fn(
         status=hitl.WAITING_STATUS,
         phase="paused",
         status_text=f"Waiting for {len(structured)} decision(s) from the user",
         waiting_for_answers=True,
         pending_questions=structured,
+        answer_wait_heartbeat_at=hitl.heartbeat_timestamp(),
     )
     if on_pause is not None:
         try:

--- a/backend/agents/coding_team/orchestrator.py
+++ b/backend/agents/coding_team/orchestrator.py
@@ -397,6 +397,9 @@ def _run_pause_cycle(
         waiting_for_answers=True,
         pending_questions=structured,
         answer_wait_heartbeat_at=hitl.heartbeat_timestamp(),
+        # Reset the cross-worker resume claim so THIS pause is independently claimable: the first
+        # answer-driven resume increments it 0→1 and wins, concurrent ones in other workers lose.
+        resume_claim=0,
     )
     if on_pause is not None:
         # on_pause can post a GitHub comment whose client uses ~30s timeouts with retries, which

--- a/backend/agents/coding_team/orchestrator.py
+++ b/backend/agents/coding_team/orchestrator.py
@@ -397,9 +397,9 @@ def _run_pause_cycle(
         waiting_for_answers=True,
         pending_questions=structured,
         answer_wait_heartbeat_at=hitl.heartbeat_timestamp(),
-        # Reset the cross-worker resume claim so THIS pause is independently claimable: the first
-        # answer-driven resume increments it 0→1 and wins, concurrent ones in other workers lose.
-        resume_claim=0,
+        # Clear the cross-worker resume-claim lease so THIS pause is immediately claimable without
+        # waiting out the prior lease's TTL (the seq counter is left monotonic).
+        resume_claim_at=None,
     )
     if on_pause is not None:
         # on_pause can post a GitHub comment whose client uses ~30s timeouts with retries, which

--- a/backend/agents/coding_team/review_history_store.py
+++ b/backend/agents/coding_team/review_history_store.py
@@ -37,9 +37,7 @@ _STORE = "coding_team"
 # Columns `update_review` is permitted to write. The SET clause is composed only
 # from these constants — never from caller-supplied identifiers — so the query
 # can never carry user-controlled SQL.
-_UPDATABLE_COLUMNS = frozenset(
-    {"status", "status_text", "review_summary", "error", "completed_at"}
-)
+_UPDATABLE_COLUMNS = frozenset({"status", "status_text", "review_summary", "error", "completed_at"})
 
 
 def _now() -> datetime:
@@ -120,13 +118,19 @@ def update_review(
         # column rather than risk an injected identifier. Cannot happen with the
         # hardcoded columns above; using an ``if`` (not ``assert``) keeps the
         # guard active even under ``python -O``.
-        logger.error("code_review_runs: refusing update with non-allowlisted column(s): %s", unexpected)
+        logger.error(
+            "code_review_runs: refusing update with non-allowlisted column(s): %s", unexpected
+        )
         return
     # Compose the SET clause with psycopg.sql.Identifier so column names are
     # quoted as identifiers (never string-interpolated), making the injection
     # safety structurally evident; values stay parameterized via %s placeholders.
-    set_clause = sql.SQL(", ").join(sql.SQL("{} = %s").format(sql.Identifier(col)) for col in columns)
-    query = sql.SQL("UPDATE code_review_runs SET {set_clause} WHERE job_id = %s").format(set_clause=set_clause)
+    set_clause = sql.SQL(", ").join(
+        sql.SQL("{} = %s").format(sql.Identifier(col)) for col in columns
+    )
+    query = sql.SQL("UPDATE code_review_runs SET {set_clause} WHERE job_id = %s").format(
+        set_clause=set_clause
+    )
     params: list[Any] = [val for _, val in assignments]
     params.append(job_id)
     try:

--- a/backend/agents/coding_team/tests/test_api_hitl.py
+++ b/backend/agents/coding_team/tests/test_api_hitl.py
@@ -399,15 +399,107 @@ def test_resume_github_job_uses_hook_path(monkeypatch):
     assert hook_calls == {"job_id": "j1", "owner": "acme", "token": "tok-123"}
 
 
+def test_resume_github_job_uses_persisted_token_without_env(monkeypatch):
+    """The standard deployment has no GITHUB_TOKEN env: resume must use the token persisted on the
+    job record at creation, not require the env var."""
+    hook_calls = {}
+
+    class _FakeClient:
+        def __init__(self, token=None):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def get_issue(self, owner, repo, number):
+            return {"number": number}
+
+    ctx = {"owner": "acme", "repo": "widgets", "issue_number": 42}
+    job = _job(
+        status="waiting_for_user",
+        plan_input={"requirements_title": "T"},
+        github_context=ctx,
+        github_token="persisted-pat",
+    )
+    monkeypatch.setattr(api, "get_job", lambda jid: job)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api.threading, "Thread", _SyncThread)
+    monkeypatch.setattr(api, "GitHubClient", _FakeClient)
+    monkeypatch.setattr(
+        api,
+        "_run_with_github_hooks",
+        lambda job_id, request, plan, issue, token: hook_calls.update({"token": token}),
+    )
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    r = client.post("/run/j1/resume")
+    assert r.status_code == 200
+    assert hook_calls["token"] == "persisted-pat"
+
+
+def test_auto_resume_github_job_uses_persisted_token_without_env(monkeypatch):
+    """Answer-submit auto-resume of a dead GitHub job also uses the persisted token."""
+    hook_calls = {}
+
+    class _FakeClient:
+        def __init__(self, token=None):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def get_issue(self, owner, repo, number):
+            return {"number": number}
+
+    ctx = {"owner": "acme", "repo": "widgets", "issue_number": 42}
+    job = _job(github_context=ctx, github_token="persisted-pat")
+    monkeypatch.setattr(api, "get_job", lambda jid: job)
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, answers: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: None)
+    monkeypatch.setattr(api.threading, "Thread", _SyncThread)
+    monkeypatch.setattr(api, "GitHubClient", _FakeClient)
+    monkeypatch.setattr(
+        api,
+        "_run_with_github_hooks",
+        lambda job_id, request, plan, issue, token: hook_calls.update({"token": token}),
+    )
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200
+    assert hook_calls["token"] == "persisted-pat"
+
+
 def test_resume_github_job_400_without_token(monkeypatch):
     ctx = {"owner": "acme", "repo": "widgets", "issue_number": 42}
-    job = _job(status="waiting_for_user", github_context=ctx)
+    job = _job(status="waiting_for_user", github_context=ctx)  # no github_token persisted
     monkeypatch.setattr(api, "get_job", lambda jid: job)
     monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     r = client.post("/run/j1/resume")
     assert r.status_code == 400
     assert "GITHUB_TOKEN" in r.json()["detail"]
+
+
+def test_persisted_github_token_never_leaks_into_responses(monkeypatch):
+    """The token persisted for resume must never be serialized into /status or /jobs."""
+    ctx = {"owner": "acme", "repo": "widgets", "issue_number": 42}
+    job = _job(github_context=ctx, github_token="super-secret-pat")
+    monkeypatch.setattr(api, "get_job", lambda jid: job)
+    monkeypatch.setattr(api, "list_jobs", lambda **kw: [job])
+
+    status_body = client.get("/status/j1").text
+    assert "super-secret-pat" not in status_body
+
+    jobs_body = client.get("/jobs").text
+    assert "super-secret-pat" not in jobs_body
 
 
 def test_auto_resume_refuses_terminal_job():

--- a/backend/agents/coding_team/tests/test_api_hitl.py
+++ b/backend/agents/coding_team/tests/test_api_hitl.py
@@ -502,9 +502,43 @@ def test_persisted_github_token_never_leaks_into_responses(monkeypatch):
     assert "super-secret-pat" not in jobs_body
 
 
+def test_resume_400_when_running_and_not_locally_alive(monkeypatch):
+    """Multi-worker safety: a genuinely running job whose thread lives in another worker has no
+    fresh heartbeat (heartbeats only happen during a pause). Resume must refuse rather than start
+    a second orchestrator on the same checkout."""
+
+    def _no_spawn(*a, **k):
+        raise AssertionError("must not spawn a second orchestrator for a running job")
+
+    job = _job(status="running", waiting_for_answers=False)  # no answer_wait_heartbeat_at → stale
+    monkeypatch.setattr(api, "get_job", lambda jid: job)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api.threading, "Thread", _no_spawn)
+    r = client.post("/run/j1/resume")
+    assert r.status_code == 400
+    assert "only a paused" in r.json()["detail"].lower()
+
+
+def test_resume_running_job_alive_locally_is_noop(monkeypatch):
+    """A running job whose thread IS alive in this worker is a no-op, not a 400 — the status guard
+    sits after the liveness no-op so a self-targeted resume still reports 'already running'."""
+    job = _job(status="running", waiting_for_answers=False)
+    monkeypatch.setattr(api, "get_job", lambda jid: job)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: True)
+    r = client.post("/run/j1/resume")
+    assert r.status_code == 200
+    assert "already running" in r.json()["message"]
+
+
 def test_auto_resume_refuses_terminal_job():
     assert api._try_auto_resume("j1", _job(status="completed")) is False
     assert api._try_auto_resume("j1", _job(status="cancelled")) is False
+
+
+def test_auto_resume_refuses_non_paused_job():
+    """Defensive invariant: _try_auto_resume only restarts a paused (waiting_for_user) job."""
+    assert api._try_auto_resume("j1", _job(status="running", waiting_for_answers=False)) is False
+    assert api._try_auto_resume("j1", _job(status="pending", waiting_for_answers=False)) is False
 
 
 class _ImmediateTimer:

--- a/backend/agents/coding_team/tests/test_api_hitl.py
+++ b/backend/agents/coding_team/tests/test_api_hitl.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
+import pytest
 from cryptography.fernet import Fernet
 from fastapi.testclient import TestClient
 
@@ -14,9 +15,19 @@ from coding_team.api import main as api
 client = TestClient(api.app)
 
 
+@pytest.fixture(autouse=True)
+def _default_resume_claim(monkeypatch):
+    """By default let the cross-worker resume claim succeed: these tests use monkeypatched job
+    records that don't exist in the in-process job service, so the real claim would always lose.
+    Tests that exercise the claim itself override these."""
+    monkeypatch.setattr(api, "claim_resume", lambda jid: True)
+    monkeypatch.setattr(api, "release_resume_claim", lambda jid: None)
+
+
 def _set_encryption_key(monkeypatch) -> None:
     """Configure a Fernet key so token_crypto encrypt/decrypt round-trips in-test."""
     monkeypatch.setenv("INTEGRATION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
 
 _PENDING = [
     {
@@ -466,7 +477,9 @@ def test_auto_resume_github_job_uses_persisted_token_without_env(monkeypatch):
 
     _set_encryption_key(monkeypatch)
     ctx = {"owner": "acme", "repo": "widgets", "issue_number": 42}
-    job = _job(github_context=ctx, github_token_encrypted=token_crypto.encrypt_token("persisted-pat"))
+    job = _job(
+        github_context=ctx, github_token_encrypted=token_crypto.encrypt_token("persisted-pat")
+    )
     monkeypatch.setattr(api, "get_job", lambda jid: job)
     monkeypatch.setattr(api, "store_submit_answers", lambda jid, answers: None)
     monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
@@ -553,6 +566,51 @@ def test_auto_resume_refuses_non_paused_job():
     """Defensive invariant: _try_auto_resume only restarts a paused (waiting_for_user) job."""
     assert api._try_auto_resume("j1", _job(status="running", waiting_for_answers=False)) is False
     assert api._try_auto_resume("j1", _job(status="pending", waiting_for_answers=False)) is False
+
+
+def test_auto_resume_skips_spawn_when_another_worker_holds_claim(monkeypatch):
+    """Cross-worker safety: if the shared-store claim is already held (another worker is resuming),
+    this worker must NOT spawn a second orchestrator on the same checkout."""
+
+    def _no_spawn(*a, **k):
+        raise AssertionError("must not spawn while another worker holds the resume claim")
+
+    monkeypatch.setattr(api, "claim_resume", lambda jid: False)  # another worker won
+    monkeypatch.setattr(api.threading, "Thread", _no_spawn)
+    result = api._try_auto_resume("j1", _job(plan_input={"requirements_title": "T"}))
+    assert result is True  # someone is resuming; not a failure
+
+
+def test_resume_409ish_noop_when_another_worker_holds_claim(monkeypatch):
+    """/resume on a paused job whose cross-worker claim another worker already holds is a no-op."""
+
+    def _no_spawn(*a, **k):
+        raise AssertionError("must not spawn while another worker holds the resume claim")
+
+    job = _job(status="waiting_for_user", plan_input={"requirements_title": "T"})
+    monkeypatch.setattr(api, "get_job", lambda jid: job)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "claim_resume", lambda jid: False)
+    monkeypatch.setattr(api.threading, "Thread", _no_spawn)
+    r = client.post("/run/j1/resume")
+    assert r.status_code == 200
+    assert "already running" in r.json()["message"]
+
+
+def test_auto_resume_releases_claim_on_spawn_failure(monkeypatch):
+    """A failed spawn after winning the shared claim must release it so a retry can win."""
+    released = {}
+    monkeypatch.setattr(api, "claim_resume", lambda jid: True)
+    monkeypatch.setattr(api, "release_resume_claim", lambda jid: released.setdefault("yes", True))
+    monkeypatch.setattr(api, "_claim_run_thread", lambda jid: True)
+
+    def _boom(*a, **k):
+        raise RuntimeError("no threads")
+
+    monkeypatch.setattr(api.threading, "Thread", _boom)
+    result = api._try_auto_resume("j1", _job(plan_input={"requirements_title": "T"}))
+    assert result is False
+    assert released.get("yes") is True
 
 
 class _ImmediateTimer:

--- a/backend/agents/coding_team/tests/test_api_hitl.py
+++ b/backend/agents/coding_team/tests/test_api_hitl.py
@@ -117,6 +117,25 @@ def test_answers_400_unknown_id(monkeypatch):
     assert "Unknown question" in r.json()["detail"]
 
 
+def test_answers_400_duplicate_question_id(monkeypatch):
+    # Two answers for the same question must be rejected: otherwise the dedup set hides the conflict
+    # at validation time and both entries get persisted, letting the orchestrator act on
+    # contradictory decisions for one required question.
+    monkeypatch.setattr(api, "get_job", lambda jid: _job())
+    r = client.post(
+        "/run/j1/answers",
+        json={
+            "answers": [
+                {"question_id": "q1", "selected_option_id": "strict"},
+                {"question_id": "q1", "selected_option_id": "other", "other_text": "lenient"},
+            ]
+        },
+    )
+    assert r.status_code == 400
+    assert "Duplicate answers" in r.json()["detail"]
+    assert "q1" in r.json()["detail"]
+
+
 def test_answers_400_other_without_text(monkeypatch):
     monkeypatch.setattr(api, "get_job", lambda jid: _job())
     r = client.post(

--- a/backend/agents/coding_team/tests/test_api_hitl.py
+++ b/backend/agents/coding_team/tests/test_api_hitl.py
@@ -181,11 +181,44 @@ def test_answers_success_stores_and_returns_status(monkeypatch):
     )
     assert r.status_code == 200
     assert stored["answers"][0]["question_id"] == "q1"
+    # The stored answer must carry the question text so a resume after thread death can match it
+    # against re-asked questions (the HITL coverage check matches strictly by text).
+    assert stored["answers"][0]["question_text"] == "Allergen strictness default?"
 
 
-def test_answers_dead_thread_adds_resume_hint(monkeypatch):
+class _SyncThread:
+    """Stand-in for threading.Thread that runs the target inline, so spawned work is observable."""
+
+    def __init__(self, target, daemon=None):
+        self._target = target
+
+    def start(self):
+        self._target()
+
+
+def test_answers_dead_thread_auto_resumes(monkeypatch):
     calls = {}
+    started = {}
     monkeypatch.setattr(api, "get_job", lambda jid: _job())
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, answers: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: calls.update(kw))
+    monkeypatch.setattr(api.threading, "Thread", _SyncThread)
+    monkeypatch.setattr(
+        api, "run_coding_team_orchestrator", lambda *a, **k: started.update({"ran": True})
+    )
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200
+    assert started.get("ran") is True
+    assert "resuming" in calls["status_text"].lower()
+
+
+def test_answers_dead_thread_adds_resume_hint_when_unresumable(monkeypatch):
+    """No repo_path/plan_input → auto-resume is impossible; fall back to the manual hint."""
+    calls = {}
+    monkeypatch.setattr(api, "get_job", lambda jid: _job(repo_path=None))
     monkeypatch.setattr(api, "store_submit_answers", lambda jid, answers: None)
     monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
     monkeypatch.setattr(api, "update_job", lambda jid, **kw: calls.update(kw))
@@ -194,6 +227,261 @@ def test_answers_dead_thread_adds_resume_hint(monkeypatch):
     )
     assert r.status_code == 200
     assert "Resume" in calls["status_text"]
+
+
+def test_answers_dead_thread_claim_lost_counts_as_resuming(monkeypatch):
+    """A lost thread claim means someone else is starting the orchestrator — not a failure."""
+    calls = {}
+    monkeypatch.setattr(api, "get_job", lambda jid: _job())
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, answers: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: calls.update(kw))
+    monkeypatch.setattr(api, "_claim_run_thread", lambda jid: False)
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200
+    assert "resuming" in calls["status_text"].lower()
+
+
+def test_answers_dead_thread_fresh_heartbeat_skips_spawn(monkeypatch):
+    """A fresh answer-wait heartbeat means a live wait loop exists in another worker process —
+    spawning here would double-drive the job, so auto-resume must not start a thread."""
+    from datetime import datetime, timezone
+
+    calls = {}
+    job = _job(answer_wait_heartbeat_at=datetime.now(timezone.utc).isoformat())
+    monkeypatch.setattr(api, "get_job", lambda jid: job)
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, answers: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: calls.update(kw))
+
+    def _no_spawn(*a, **k):
+        raise AssertionError("must not spawn a thread while a wait loop heartbeats")
+
+    monkeypatch.setattr(api.threading, "Thread", _no_spawn)
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200
+    assert "resuming" in calls["status_text"].lower()
+
+
+def test_answers_dead_thread_stale_heartbeat_resumes(monkeypatch):
+    calls = {}
+    started = {}
+    job = _job(answer_wait_heartbeat_at="2020-01-01T00:00:00+00:00")
+    monkeypatch.setattr(api, "get_job", lambda jid: job)
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, answers: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: calls.update(kw))
+    monkeypatch.setattr(api.threading, "Thread", _SyncThread)
+    monkeypatch.setattr(
+        api, "run_coding_team_orchestrator", lambda *a, **k: started.update({"ran": True})
+    )
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200
+    assert started.get("ran") is True
+
+
+def test_answers_dead_thread_github_job_resumes_through_hook_path(monkeypatch):
+    """GitHub-issue jobs must resume through the hook path so publication (PR, comments) survives."""
+    calls = {}
+    hook_calls = {}
+
+    class _FakeClient:
+        def __init__(self, token=None):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def get_issue(self, owner, repo, number):
+            return {"number": number}
+
+    ctx = {"owner": "acme", "repo": "widgets", "issue_number": 42, "remote": "origin"}
+    monkeypatch.setattr(api, "get_job", lambda jid: _job(github_context=ctx))
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, answers: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: calls.update(kw))
+    monkeypatch.setattr(api.threading, "Thread", _SyncThread)
+    monkeypatch.setattr(api, "GitHubClient", _FakeClient)
+    monkeypatch.setattr(
+        api,
+        "_run_with_github_hooks",
+        lambda job_id, request, plan, issue, token: hook_calls.update(
+            {"job_id": job_id, "owner": request.owner, "issue": issue, "token": token}
+        ),
+    )
+    monkeypatch.setenv("GITHUB_TOKEN", "tok-123")
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200
+    assert hook_calls["job_id"] == "j1"
+    assert hook_calls["owner"] == "acme"
+    assert hook_calls["token"] == "tok-123"
+    assert "resuming" in calls["status_text"].lower()
+
+
+def test_answers_dead_thread_github_job_without_token_falls_back_to_hint(monkeypatch):
+    calls = {}
+    ctx = {"owner": "acme", "repo": "widgets", "issue_number": 42}
+    monkeypatch.setattr(api, "get_job", lambda jid: _job(github_context=ctx))
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, answers: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: calls.update(kw))
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    def _no_spawn(*a, **k):
+        raise AssertionError("must not resume a GitHub job hook-less")
+
+    monkeypatch.setattr(api.threading, "Thread", _no_spawn)
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200
+    assert "Resume" in calls["status_text"]
+
+
+def test_resume_refuses_when_heartbeat_fresh(monkeypatch):
+    from datetime import datetime, timezone
+
+    job = _job(
+        status="waiting_for_user",
+        answer_wait_heartbeat_at=datetime.now(timezone.utc).isoformat(),
+    )
+    monkeypatch.setattr(api, "get_job", lambda jid: job)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    r = client.post("/run/j1/resume")
+    assert r.status_code == 200
+    assert "already running" in r.json()["message"]
+
+
+def test_answer_wait_heartbeat_fresh_handles_garbage():
+    assert api._answer_wait_heartbeat_fresh({}) is False
+    assert api._answer_wait_heartbeat_fresh({"answer_wait_heartbeat_at": "not-a-date"}) is False
+    assert api._answer_wait_heartbeat_fresh({"answer_wait_heartbeat_at": ""}) is False
+    # Naive timestamps are treated as UTC rather than rejected.
+    from datetime import datetime, timezone
+
+    naive_now = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
+    assert api._answer_wait_heartbeat_fresh({"answer_wait_heartbeat_at": naive_now}) is True
+
+
+def test_answers_dead_thread_invalid_plan_falls_back_to_hint(monkeypatch):
+    calls = {}
+    monkeypatch.setattr(
+        api, "get_job", lambda jid: _job(plan_input={"requirements_title": {"not": "a string"}})
+    )
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, answers: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: calls.update(kw))
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200
+    assert "Resume" in calls["status_text"]
+
+
+def test_resumed_orchestrator_failure_marks_job_failed(monkeypatch):
+    calls = {}
+    monkeypatch.setattr(api, "get_job", lambda jid: _job())
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, answers: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: calls.update(kw))
+    monkeypatch.setattr(api.threading, "Thread", _SyncThread)
+
+    def _boom(*a, **k):
+        raise RuntimeError("orchestrator crashed")
+
+    monkeypatch.setattr(api, "run_coding_team_orchestrator", _boom)
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200
+    assert calls["status"] == "failed"
+    assert "orchestrator crashed" in calls["error"]
+    # The crashed thread must release its registration so a manual /resume stays possible.
+    assert api._is_run_thread_alive("j1") is False
+
+
+def test_github_resume_issue_fetch_failure_marks_job_failed(monkeypatch):
+    calls = {}
+
+    class _FailingClient:
+        def __init__(self, token=None):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def get_issue(self, owner, repo, number):
+            raise RuntimeError("github down")
+
+    ctx = {"owner": "acme", "repo": "widgets", "issue_number": 42}
+    monkeypatch.setattr(api, "get_job", lambda jid: _job(github_context=ctx))
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, answers: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: calls.update(kw))
+    monkeypatch.setattr(api.threading, "Thread", _SyncThread)
+    monkeypatch.setattr(api, "GitHubClient", _FailingClient)
+    monkeypatch.setenv("GITHUB_TOKEN", "tok-123")
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200
+    assert calls["status"] == "failed"
+    assert "github down" in calls["error"]
+
+
+def test_github_resume_spawn_failure_falls_back_to_hint(monkeypatch):
+    calls = {}
+    ctx = {"owner": "acme", "repo": "widgets", "issue_number": 42}
+    monkeypatch.setattr(api, "get_job", lambda jid: _job(github_context=ctx))
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, answers: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: calls.update(kw))
+    monkeypatch.setenv("GITHUB_TOKEN", "tok-123")
+
+    def _boom(*a, **k):
+        raise RuntimeError("no threads")
+
+    monkeypatch.setattr(api.threading, "Thread", _boom)
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200
+    assert "Resume" in calls["status_text"]
+    assert "j1" not in api._starting_run_jobs
+
+
+def test_answers_dead_thread_spawn_failure_falls_back_to_hint(monkeypatch):
+    calls = {}
+    monkeypatch.setattr(api, "get_job", lambda jid: _job())
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, answers: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: calls.update(kw))
+
+    def _boom(*a, **k):
+        raise RuntimeError("no threads")
+
+    monkeypatch.setattr(api.threading, "Thread", _boom)
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200
+    assert "Resume" in calls["status_text"]
+    # The failed spawn must release the claim so a later manual /resume can succeed.
+    assert "j1" not in api._starting_run_jobs
 
 
 # --------------------------------------------------------------------------- /run/{id}/resume

--- a/backend/agents/coding_team/tests/test_api_hitl.py
+++ b/backend/agents/coding_team/tests/test_api_hitl.py
@@ -761,6 +761,18 @@ def test_answer_wait_heartbeat_fresh_handles_garbage():
     assert api._answer_wait_heartbeat_fresh({"answer_wait_heartbeat_at": naive_now}) is True
 
 
+def test_answer_wait_heartbeat_future_is_not_fresh():
+    """A future-dated heartbeat (clock skew / corruption) must not block resume until that time —
+    it is treated as stale, not fresh."""
+    from datetime import datetime, timedelta, timezone
+
+    future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+    assert api._answer_wait_heartbeat_fresh({"answer_wait_heartbeat_at": future}) is False
+    # And a normal recent stamp is still fresh.
+    recent = (datetime.now(timezone.utc) - timedelta(seconds=2)).isoformat()
+    assert api._answer_wait_heartbeat_fresh({"answer_wait_heartbeat_at": recent}) is True
+
+
 def test_answers_dead_thread_invalid_plan_falls_back_to_hint(monkeypatch):
     calls = {}
     monkeypatch.setattr(

--- a/backend/agents/coding_team/tests/test_api_hitl.py
+++ b/backend/agents/coding_team/tests/test_api_hitl.py
@@ -5,11 +5,18 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
+from cryptography.fernet import Fernet
 from fastapi.testclient import TestClient
 
+from coding_team import token_crypto
 from coding_team.api import main as api
 
 client = TestClient(api.app)
+
+
+def _set_encryption_key(monkeypatch) -> None:
+    """Configure a Fernet key so token_crypto encrypt/decrypt round-trips in-test."""
+    monkeypatch.setenv("INTEGRATION_ENCRYPTION_KEY", Fernet.generate_key().decode())
 
 _PENDING = [
     {
@@ -417,12 +424,13 @@ def test_resume_github_job_uses_persisted_token_without_env(monkeypatch):
         def get_issue(self, owner, repo, number):
             return {"number": number}
 
+    _set_encryption_key(monkeypatch)
     ctx = {"owner": "acme", "repo": "widgets", "issue_number": 42}
     job = _job(
         status="waiting_for_user",
         plan_input={"requirements_title": "T"},
         github_context=ctx,
-        github_token="persisted-pat",
+        github_token_encrypted=token_crypto.encrypt_token("persisted-pat"),
     )
     monkeypatch.setattr(api, "get_job", lambda jid: job)
     monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
@@ -456,8 +464,9 @@ def test_auto_resume_github_job_uses_persisted_token_without_env(monkeypatch):
         def get_issue(self, owner, repo, number):
             return {"number": number}
 
+    _set_encryption_key(monkeypatch)
     ctx = {"owner": "acme", "repo": "widgets", "issue_number": 42}
-    job = _job(github_context=ctx, github_token="persisted-pat")
+    job = _job(github_context=ctx, github_token_encrypted=token_crypto.encrypt_token("persisted-pat"))
     monkeypatch.setattr(api, "get_job", lambda jid: job)
     monkeypatch.setattr(api, "store_submit_answers", lambda jid, answers: None)
     monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
@@ -488,18 +497,23 @@ def test_resume_github_job_400_without_token(monkeypatch):
     assert "GITHUB_TOKEN" in r.json()["detail"]
 
 
-def test_persisted_github_token_never_leaks_into_responses(monkeypatch):
-    """The token persisted for resume must never be serialized into /status or /jobs."""
+def test_persisted_token_is_encrypted_not_plaintext(monkeypatch):
+    """Only opaque ciphertext is persisted — a usable PAT is never written to the job record (which
+    the generic GET /api/jobs/{team} route echoes verbatim)."""
+    _set_encryption_key(monkeypatch)
+    enc = token_crypto.encrypt_token("super-secret-pat")
+    assert enc and enc != "super-secret-pat"
+    assert token_crypto.decrypt_token(enc) == "super-secret-pat"
+
+    # And the ciphertext field is not surfaced by the coding-team response models either.
     ctx = {"owner": "acme", "repo": "widgets", "issue_number": 42}
-    job = _job(github_context=ctx, github_token="super-secret-pat")
+    job = _job(github_context=ctx, github_token_encrypted=enc)
     monkeypatch.setattr(api, "get_job", lambda jid: job)
     monkeypatch.setattr(api, "list_jobs", lambda **kw: [job])
-
-    status_body = client.get("/status/j1").text
-    assert "super-secret-pat" not in status_body
-
-    jobs_body = client.get("/jobs").text
-    assert "super-secret-pat" not in jobs_body
+    assert "super-secret-pat" not in client.get("/status/j1").text
+    assert enc not in client.get("/status/j1").text
+    assert "super-secret-pat" not in client.get("/jobs").text
+    assert enc not in client.get("/jobs").text
 
 
 def test_resume_400_when_running_and_not_locally_alive(monkeypatch):

--- a/backend/agents/coding_team/tests/test_api_hitl.py
+++ b/backend/agents/coding_team/tests/test_api_hitl.py
@@ -322,6 +322,63 @@ def test_answers_dead_thread_claim_store_error_falls_back_to_hint(monkeypatch):
     assert "Resume" in calls["status_text"]
 
 
+def test_answers_does_not_resume_job_cancelled_after_get(monkeypatch):
+    """TOCTOU: if the job is cancelled between the initial get_job and storing answers, the resume
+    decision must use the re-read (terminal) record — not the stale pre-cancellation one — and must
+    not spawn a new orchestrator that would overwrite the terminal status."""
+    waiting = _job()  # initial read: waiting_for_user
+    cancelled = _job(status="cancelled")
+    reads = iter([waiting, cancelled])  # 1st read waiting (endpoint), 2nd read cancelled (re-read)
+    monkeypatch.setattr(api, "get_job", lambda jid: next(reads, cancelled))
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, a: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: None)
+
+    def _no_spawn(*a, **k):
+        raise AssertionError("must not spawn an orchestrator for a cancelled job")
+
+    monkeypatch.setattr(api, "_start_orchestrator_thread", _no_spawn)
+    monkeypatch.setattr(api, "_start_github_resume_thread", _no_spawn)
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200  # answers stored; no spawn
+
+
+def test_answers_deferred_claim_schedules_post_ttl_recheck(monkeypatch):
+    """Deferring to another worker's resume claim must schedule a recheck past the claim TTL, so a
+    winner that dies before advancing the job still gets reclaimed instead of stranding it."""
+    scheduled = {}
+    monkeypatch.setattr(api, "get_job", lambda jid: _job())
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, a: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: None)
+    monkeypatch.setattr(api, "_answer_wait_heartbeat_fresh", lambda d: False)
+    monkeypatch.setattr(api, "claim_resume", lambda jid: False)  # another worker holds the claim
+
+    def _record(jid, delay=None):
+        scheduled.update({"jid": jid, "delay": delay})
+
+    monkeypatch.setattr(api, "_schedule_resume_recheck", _record)
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200
+    assert scheduled["jid"] == "j1"
+    assert scheduled["delay"] == api.RESUME_CLAIM_TTL_S + 5.0
+
+
+def test_resume_400_when_plan_input_corrupted(monkeypatch):
+    """A non-dict plan_input is a corrupted record: resume must reject it with a controlled 400, not
+    raise AttributeError off plan_raw.get()."""
+    job = _job(status="waiting_for_user", plan_input="not-a-dict")
+    monkeypatch.setattr(api, "get_job", lambda jid: job)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    r = client.post("/run/j1/resume")
+    assert r.status_code == 400
+    assert "corrupted plan_input" in r.json()["detail"]
+
+
 def test_resume_500_when_claim_store_errors(monkeypatch):
     """A job-store transport error during the resume claim surfaces as a controlled 500 — not a bare
     propagation, and not a misleading 'already running' (no claim was actually taken)."""
@@ -624,6 +681,14 @@ def test_persisted_token_is_encrypted_not_plaintext(monkeypatch):
     assert enc not in client.get("/status/j1").text
     assert "super-secret-pat" not in client.get("/jobs").text
     assert enc not in client.get("/jobs").text
+    # Belt-and-braces beyond the substring scan: the token fields must be structurally absent from
+    # the parsed JSON, so a differently-encoded value can't slip through either.
+    status_body = client.get("/status/j1").json()
+    assert "github_token_encrypted" not in status_body
+    assert "github_token" not in status_body
+    for row in client.get("/jobs").json():
+        assert "github_token_encrypted" not in row
+        assert "github_token" not in row
 
 
 def test_resume_400_when_running_and_not_locally_alive(monkeypatch):

--- a/backend/agents/coding_team/tests/test_api_hitl.py
+++ b/backend/agents/coding_team/tests/test_api_hitl.py
@@ -349,6 +349,195 @@ def test_answers_dead_thread_github_job_without_token_falls_back_to_hint(monkeyp
     assert "Resume" in calls["status_text"]
 
 
+def test_resume_400_when_terminal(monkeypatch):
+    """A finished run must never be silently re-executed."""
+    for status in ("completed", "completed_with_failures", "failed", "cancelled"):
+        monkeypatch.setattr(api, "get_job", lambda jid, s=status: _job(status=s))
+        r = client.post("/run/j1/resume")
+        assert r.status_code == 400
+        assert "cannot be resumed" in r.json()["detail"]
+
+
+def test_resume_github_job_uses_hook_path(monkeypatch):
+    """GitHub-issue jobs resume through the hook path so publication survives."""
+    hook_calls = {}
+
+    class _FakeClient:
+        def __init__(self, token=None):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def get_issue(self, owner, repo, number):
+            return {"number": number}
+
+    ctx = {"owner": "acme", "repo": "widgets", "issue_number": 42}
+    job = _job(
+        status="waiting_for_user",
+        plan_input={"requirements_title": "T"},
+        github_context=ctx,
+    )
+    monkeypatch.setattr(api, "get_job", lambda jid: job)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api.threading, "Thread", _SyncThread)
+    monkeypatch.setattr(api, "GitHubClient", _FakeClient)
+    monkeypatch.setattr(
+        api,
+        "_run_with_github_hooks",
+        lambda job_id, request, plan, issue, token: hook_calls.update(
+            {"job_id": job_id, "owner": request.owner, "token": token}
+        ),
+    )
+    monkeypatch.setenv("GITHUB_TOKEN", "tok-123")
+    r = client.post("/run/j1/resume")
+    assert r.status_code == 200
+    assert r.json()["message"] == "Job resumed."
+    assert hook_calls == {"job_id": "j1", "owner": "acme", "token": "tok-123"}
+
+
+def test_resume_github_job_400_without_token(monkeypatch):
+    ctx = {"owner": "acme", "repo": "widgets", "issue_number": 42}
+    job = _job(status="waiting_for_user", github_context=ctx)
+    monkeypatch.setattr(api, "get_job", lambda jid: job)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    r = client.post("/run/j1/resume")
+    assert r.status_code == 400
+    assert "GITHUB_TOKEN" in r.json()["detail"]
+
+
+def test_auto_resume_refuses_terminal_job():
+    assert api._try_auto_resume("j1", _job(status="completed")) is False
+    assert api._try_auto_resume("j1", _job(status="cancelled")) is False
+
+
+class _ImmediateTimer:
+    """Stand-in for threading.Timer that fires the callback synchronously on start()."""
+
+    def __init__(self, interval, fn):
+        self._fn = fn
+        self.daemon = False
+
+    def start(self):
+        self._fn()
+
+
+def test_fresh_heartbeat_schedules_recheck_that_resumes_a_dead_loop(monkeypatch):
+    """The orphaned-heartbeat window: a worker that died right after its last beat must still
+    get its run resumed once the staleness window passes."""
+    from datetime import datetime, timezone
+
+    started = {}
+    fresh = _job(answer_wait_heartbeat_at=datetime.now(timezone.utc).isoformat())
+    # After the (simulated) delay, the heartbeat is stale and the job still paused.
+    stale = _job(
+        waiting_for_answers=False,
+        answer_wait_heartbeat_at="2020-01-01T00:00:00+00:00",
+    )
+    calls = {"n": 0}
+
+    def get_job(jid):
+        calls["n"] += 1
+        return fresh if calls["n"] == 1 else stale
+
+    monkeypatch.setattr(api, "get_job", get_job)
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, answers: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: None)
+    monkeypatch.setattr(api.threading, "Timer", _ImmediateTimer)
+    monkeypatch.setattr(api.threading, "Thread", _SyncThread)
+    monkeypatch.setattr(
+        api, "run_coding_team_orchestrator", lambda *a, **k: started.update({"ran": True})
+    )
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200
+    assert started.get("ran") is True
+
+
+def test_recheck_writes_hint_when_resume_impossible(monkeypatch):
+    """If the dead loop's job can't be auto-resumed at recheck time, the manual hint is restored."""
+    from datetime import datetime, timezone
+
+    writes = {}
+    fresh = _job(answer_wait_heartbeat_at=datetime.now(timezone.utc).isoformat())
+    # Stale at recheck time, and unresumable: no repo_path/plan to restart from.
+    stale = _job(
+        repo_path=None,
+        waiting_for_answers=False,
+        answer_wait_heartbeat_at="2020-01-01T00:00:00+00:00",
+    )
+    calls = {"n": 0}
+
+    def get_job(jid):
+        calls["n"] += 1
+        return fresh if calls["n"] == 1 else stale
+
+    monkeypatch.setattr(api, "get_job", get_job)
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, answers: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: writes.update(kw))
+    monkeypatch.setattr(api.threading, "Timer", _ImmediateTimer)
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200
+    assert "Resume" in writes["status_text"]
+
+
+def test_recheck_noop_when_job_moved_on(monkeypatch):
+    """No spawn when the deferred-to wait loop really did consume the answers."""
+    from datetime import datetime, timezone
+
+    fresh = _job(answer_wait_heartbeat_at=datetime.now(timezone.utc).isoformat())
+    resumed = _job(status="running", waiting_for_answers=False)
+    calls = {"n": 0}
+
+    def get_job(jid):
+        calls["n"] += 1
+        return fresh if calls["n"] == 1 else resumed
+
+    def _no_spawn(*a, **k):
+        raise AssertionError("recheck must not spawn once the job moved on")
+
+    monkeypatch.setattr(api, "get_job", get_job)
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, answers: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: None)
+    monkeypatch.setattr(api.threading, "Timer", _ImmediateTimer)
+    monkeypatch.setattr(api.threading, "Thread", _no_spawn)
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200
+
+
+def test_recheck_noop_when_heartbeat_fresh_again(monkeypatch):
+    """A still-fresh heartbeat at recheck time means the loop is genuinely alive elsewhere."""
+    from datetime import datetime, timezone
+
+    fresh = _job(answer_wait_heartbeat_at=datetime.now(timezone.utc).isoformat())
+
+    def _no_spawn(*a, **k):
+        raise AssertionError("recheck must not spawn while the heartbeat stays fresh")
+
+    monkeypatch.setattr(api, "get_job", lambda jid: fresh)
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, answers: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: None)
+    monkeypatch.setattr(api.threading, "Timer", _ImmediateTimer)
+    monkeypatch.setattr(api.threading, "Thread", _no_spawn)
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200
+
+
 def test_resume_refuses_when_heartbeat_fresh(monkeypatch):
     from datetime import datetime, timezone
 

--- a/backend/agents/coding_team/tests/test_api_hitl.py
+++ b/backend/agents/coding_team/tests/test_api_hitl.py
@@ -117,6 +117,18 @@ def test_answers_400_unknown_id(monkeypatch):
     assert "Unknown question" in r.json()["detail"]
 
 
+def test_answers_500_when_pending_question_missing_id(monkeypatch):
+    # A pending question without an "id" is a corrupted job record, not bad client input: the
+    # endpoint must surface a controlled 500 with a clear message instead of a bare KeyError.
+    bad = [{"question_text": "no id here", "required": True, "options": []}]
+    monkeypatch.setattr(api, "get_job", lambda jid: _job(pending_questions=bad))
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "x"}]}
+    )
+    assert r.status_code == 500
+    assert "Corrupted job record" in r.json()["detail"]
+
+
 def test_answers_400_duplicate_question_id(monkeypatch):
     # Two answers for the same question must be rejected: otherwise the dedup set hides the conflict
     # at validation time and both entries get persisted, letting the orchestrator act on
@@ -418,7 +430,9 @@ def test_resume_github_job_uses_hook_path(monkeypatch):
         plan_input={"requirements_title": "T"},
         github_context=ctx,
     )
+    updates: List[Dict[str, Any]] = []
     monkeypatch.setattr(api, "get_job", lambda jid: job)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: updates.append(kw))
     monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
     monkeypatch.setattr(api.threading, "Thread", _SyncThread)
     monkeypatch.setattr(api, "GitHubClient", _FakeClient)
@@ -434,6 +448,9 @@ def test_resume_github_job_uses_hook_path(monkeypatch):
     assert r.status_code == 200
     assert r.json()["message"] == "Job resumed."
     assert hook_calls == {"job_id": "j1", "owner": "acme", "token": "tok-123"}
+    # The resume must wipe any stale current_activity left by the dead attempt so the UI does not
+    # render a frozen sub-bar through the resumed run's early phases.
+    assert {"current_activity": None} in updates
 
 
 def test_resume_github_job_uses_persisted_token_without_env(monkeypatch):
@@ -463,6 +480,7 @@ def test_resume_github_job_uses_persisted_token_without_env(monkeypatch):
         github_token_encrypted=token_crypto.encrypt_token("persisted-pat"),
     )
     monkeypatch.setattr(api, "get_job", lambda jid: job)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: None)
     monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
     monkeypatch.setattr(api.threading, "Thread", _SyncThread)
     monkeypatch.setattr(api, "GitHubClient", _FakeClient)

--- a/backend/agents/coding_team/tests/test_api_hitl.py
+++ b/backend/agents/coding_team/tests/test_api_hitl.py
@@ -245,6 +245,29 @@ class _SyncThread:
         self._target()
 
 
+def test_start_orchestrator_thread_clears_claim_if_registration_fails(monkeypatch):
+    """_register_run_thread sits inside the run() try: if it raises, the finally must still release
+    the run-thread claim and the job must be marked failed — otherwise the claim wedges in
+    _starting_run_jobs and no future resume in this worker can proceed."""
+    cleared: list[str] = []
+    updates: list[dict] = []
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: updates.append(kw))
+    monkeypatch.setattr(api, "_clear_run_thread", lambda jid: cleared.append(jid))
+
+    def boom(jid):
+        raise RuntimeError("registry broken")
+
+    monkeypatch.setattr(api, "_register_run_thread", boom)
+    monkeypatch.setattr(api.threading, "Thread", _SyncThread)
+    plan = api.CodingTeamPlanInput.model_validate({"repo_path": "/tmp/repo"})
+
+    # Must not raise out of the spawn helper.
+    api._start_orchestrator_thread("j1", "/tmp/repo", plan)
+
+    assert cleared == ["j1"]  # finally ran despite the registration failure
+    assert any(u.get("status") == "failed" for u in updates)
+
+
 def test_answers_dead_thread_auto_resumes(monkeypatch):
     calls = {}
     started = {}

--- a/backend/agents/coding_team/tests/test_api_hitl.py
+++ b/backend/agents/coding_team/tests/test_api_hitl.py
@@ -278,6 +278,43 @@ def test_answers_dead_thread_adds_resume_hint_when_unresumable(monkeypatch):
     assert "Resume" in calls["status_text"]
 
 
+def test_answers_dead_thread_claim_store_error_falls_back_to_hint(monkeypatch):
+    """A job-store transport error while claiming the resume must not 500 after answers were stored:
+    _try_auto_resume honours its 'never raises' contract by swallowing the store error and returning
+    False, so the endpoint completes 200 with the manual-resume hint."""
+    calls = {}
+    monkeypatch.setattr(api, "get_job", lambda jid: _job())
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, answers: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: calls.update(kw))
+
+    def boom(jid):
+        raise RuntimeError("store down")
+
+    monkeypatch.setattr(api, "claim_resume", boom)
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200
+    assert "Resume" in calls["status_text"]
+
+
+def test_resume_500_when_claim_store_errors(monkeypatch):
+    """A job-store transport error during the resume claim surfaces as a controlled 500 — not a bare
+    propagation, and not a misleading 'already running' (no claim was actually taken)."""
+    monkeypatch.setattr(api, "get_job", lambda jid: _job(status="waiting_for_user"))
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+
+    def boom(jid):
+        raise RuntimeError("store down")
+
+    monkeypatch.setattr(api, "claim_resume", boom)
+    r = client.post("/run/j1/resume")
+    assert r.status_code == 500
+    assert "job-store error" in r.json()["detail"]
+
+
 def test_answers_dead_thread_claim_lost_counts_as_resuming(monkeypatch):
     """A lost thread claim means someone else is starting the orchestrator — not a failure."""
     calls = {}

--- a/backend/agents/coding_team/tests/test_api_hitl.py
+++ b/backend/agents/coding_team/tests/test_api_hitl.py
@@ -1255,3 +1255,123 @@ def test_resume_releases_claim_when_activity_clear_fails(monkeypatch):
     assert second.status_code == 200
     assert second.json()["message"] == "Job resumed."
     assert started["n"] == 1, "claim must have been released so the retry can spawn"
+
+
+# --------------------------------------------------------------------------- clock-skew tolerance
+
+
+def test_heartbeat_fresh_tolerates_small_forward_clock_skew():
+    """A heartbeat stamped slightly in the future (NTP drift on a faster-clocked worker) must
+    still be treated as fresh, so a live wait loop in that worker doesn't appear dead to the
+    checking worker and prompt a spurious second orchestrator spawn."""
+    from datetime import datetime, timedelta, timezone
+
+    skewed = (datetime.now(timezone.utc) + timedelta(seconds=5)).isoformat()
+    assert api._answer_wait_heartbeat_fresh({"answer_wait_heartbeat_at": skewed}) is True
+
+
+def test_heartbeat_implausibly_future_stamp_is_not_fresh():
+    """A stamp far in the future (more than _HEARTBEAT_CLOCK_SKEW_TOLERANCE_S ahead) is
+    corruption or severe misconfiguration — it must NOT block resume indefinitely."""
+    from datetime import datetime, timedelta, timezone
+
+    far_future = (
+        datetime.now(timezone.utc)
+        + timedelta(seconds=api._HEARTBEAT_CLOCK_SKEW_TOLERANCE_S + 30)
+    ).isoformat()
+    assert api._answer_wait_heartbeat_fresh({"answer_wait_heartbeat_at": far_future}) is False
+
+
+# --------------------------------------------------------------------------- post-claim terminal check
+
+
+def test_auto_resume_aborts_post_claim_if_job_becomes_terminal(monkeypatch):
+    """TOCTOU: cancellation that occurs after the resume claim is acquired but before the
+    orchestrator is spawned must abort the spawn. The post-claim get_job re-read detects the
+    terminal state and the claim is released so a later attempt can succeed."""
+    waiting = _job()
+    cancelled = _job(status="cancelled")
+    read_count = {"n": 0}
+
+    def _get_job(jid):
+        read_count["n"] += 1
+        # Reads 1 (endpoint) and 2 (TOCTOU reread after store) → waiting.
+        # Read 3 (post-claim re-read inside _try_auto_resume) → cancelled.
+        return waiting if read_count["n"] < 3 else cancelled
+
+    monkeypatch.setattr(api, "get_job", _get_job)
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, a: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: None)
+    release_calls: List[str] = []
+    monkeypatch.setattr(api, "release_resume_claim", lambda jid: release_calls.append(jid))
+
+    def _no_spawn(*a, **k):
+        raise AssertionError("must not spawn for a job that became terminal after claiming")
+
+    monkeypatch.setattr(api, "_start_orchestrator_thread", _no_spawn)
+    monkeypatch.setattr(api, "_start_github_resume_thread", _no_spawn)
+
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200
+    assert release_calls, "claim must be released when the post-claim terminal check fires"
+
+
+# --------------------------------------------------------------------------- GitHub resume status advance
+
+
+def test_github_resume_thread_advances_status_before_io(monkeypatch):
+    """The GitHub-resume thread must update the job to status='running' BEFORE the GitHub issue
+    fetch. The cross-worker claim TTL is 60s; a slow issue fetch or branch prep could outlast it
+    and let another worker steal the claim. Advancing the status out of waiting_for_user first
+    closes that window: _try_auto_resume and resume_job only proceed for waiting_for_user jobs."""
+    events: List[Any] = []
+    ctx = {"owner": "acme", "repo": "widgets", "issue_number": 42, "remote": "origin"}
+
+    monkeypatch.setattr(api, "get_job", lambda jid: _job(github_context=ctx))
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, a: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: events.append(("update", dict(kw))))
+
+    class _FakeClient:
+        def __init__(self, token=None):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def get_issue(self, owner, repo, number):
+            events.append(("get_issue",))
+            return {"number": number}
+
+    monkeypatch.setattr(api, "GitHubClient", _FakeClient)
+    monkeypatch.setattr(api, "_run_with_github_hooks", lambda *a, **k: None)
+
+    class _SyncThread:
+        def __init__(self, target, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    monkeypatch.setattr(api.threading, "Thread", _SyncThread)
+    monkeypatch.setenv("GITHUB_TOKEN", "tok-123")
+
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200
+
+    running_update_idx = next(
+        (i for i, e in enumerate(events) if e[0] == "update" and e[1].get("status") == "running"),
+        None,
+    )
+    io_idx = next((i for i, e in enumerate(events) if e[0] == "get_issue"), None)
+    assert running_update_idx is not None, "thread must update status to 'running'"
+    assert io_idx is not None, "thread must call get_issue"
+    assert running_update_idx < io_idx, "status must advance to 'running' before GitHub I/O"

--- a/backend/agents/coding_team/tests/test_api_hitl.py
+++ b/backend/agents/coding_team/tests/test_api_hitl.py
@@ -1276,8 +1276,7 @@ def test_heartbeat_implausibly_future_stamp_is_not_fresh():
     from datetime import datetime, timedelta, timezone
 
     far_future = (
-        datetime.now(timezone.utc)
-        + timedelta(seconds=api._HEARTBEAT_CLOCK_SKEW_TOLERANCE_S + 30)
+        datetime.now(timezone.utc) + timedelta(seconds=api._HEARTBEAT_CLOCK_SKEW_TOLERANCE_S + 30)
     ).isoformat()
     assert api._answer_wait_heartbeat_fresh({"answer_wait_heartbeat_at": far_future}) is False
 
@@ -1317,6 +1316,109 @@ def test_auto_resume_aborts_post_claim_if_job_becomes_terminal(monkeypatch):
     )
     assert r.status_code == 200
     assert release_calls, "claim must be released when the post-claim terminal check fires"
+
+
+def test_auto_resume_aborts_post_claim_if_job_becomes_running(monkeypatch):
+    """TOCTOU: if a concurrent worker advances the job from waiting_for_user to running between
+    claim and post-claim re-read, the spawn must be aborted and the claim released. 'running' is
+    non-terminal but non-waiting, so the post-claim status check must cover it — not just terminal
+    states (which the earlier is_terminal check already handled)."""
+    waiting = _job()
+    running = _job(status="running", waiting_for_answers=False)
+    read_count = {"n": 0}
+
+    def _get_job(jid):
+        read_count["n"] += 1
+        # Reads 1 (endpoint) and 2 (TOCTOU reread after store) → waiting.
+        # Read 3 (post-claim re-read inside _try_auto_resume) → running.
+        return waiting if read_count["n"] < 3 else running
+
+    monkeypatch.setattr(api, "get_job", _get_job)
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, a: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: None)
+    release_calls: List[str] = []
+    monkeypatch.setattr(api, "release_resume_claim", lambda jid: release_calls.append(jid))
+
+    def _no_spawn(*a, **k):
+        raise AssertionError("must not spawn for a job that became 'running' after claiming")
+
+    monkeypatch.setattr(api, "_start_orchestrator_thread", _no_spawn)
+    monkeypatch.setattr(api, "_start_github_resume_thread", _no_spawn)
+
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200
+    assert release_calls, "claim must be released when post-claim check finds job is 'running'"
+
+
+def test_auto_resume_post_claim_store_error_releases_claim_and_falls_back_to_hint(monkeypatch):
+    """A job-store transport error during the post-claim re-read in _try_auto_resume must release
+    the claim immediately (so the TTL window is recovered) and return False so the endpoint falls
+    back to the manual-resume hint — never leaves the claim wedged, never raises, never spawns."""
+    waiting = _job()
+    read_count = {"n": 0}
+
+    def _get_job(jid):
+        read_count["n"] += 1
+        # Reads 1 (endpoint initial) and 2 (TOCTOU re-read after store) → waiting.
+        # Read 3 (post-claim re-read inside _try_auto_resume) → store error.
+        # Read 4+ (get_status at end of submit_pending_answers) → waiting (not part of test).
+        if read_count["n"] == 3:
+            raise RuntimeError("store error during post-claim read")
+        return waiting
+
+    monkeypatch.setattr(api, "get_job", _get_job)
+    monkeypatch.setattr(api, "store_submit_answers", lambda jid, a: None)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    calls: dict = {}
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: calls.update(kw))
+    release_calls: List[str] = []
+    monkeypatch.setattr(api, "release_resume_claim", lambda jid: release_calls.append(jid))
+
+    def _no_spawn(*a, **k):
+        raise AssertionError("must not spawn when post-claim store read fails")
+
+    monkeypatch.setattr(api, "_start_orchestrator_thread", _no_spawn)
+    monkeypatch.setattr(api, "_start_github_resume_thread", _no_spawn)
+
+    r = client.post(
+        "/run/j1/answers", json={"answers": [{"question_id": "q1", "selected_option_id": "strict"}]}
+    )
+    assert r.status_code == 200
+    assert release_calls, "claim must be released on post-claim store error"
+    assert "Resume" in calls.get("status_text", ""), "must fall back to the manual-resume hint"
+
+
+def test_resume_post_claim_abort_when_job_advances_to_running(monkeypatch):
+    """TOCTOU on /resume: if the job status advances from waiting_for_user to running between
+    claim_resume and the post-claim re-read, the endpoint must release the claim and return
+    'already running' rather than spawning a second orchestrator for a job already in flight."""
+    waiting = _job(status="waiting_for_user", plan_input={"requirements_title": "T"})
+    running = _job(status="running", waiting_for_answers=False)
+    read_count = {"n": 0}
+
+    def _get_job(jid):
+        read_count["n"] += 1
+        # Read 1 (initial endpoint check): waiting. Read 2 (post-claim re-read): running.
+        return waiting if read_count["n"] == 1 else running
+
+    monkeypatch.setattr(api, "get_job", _get_job)
+    monkeypatch.setattr(api, "_is_run_thread_alive", lambda jid: False)
+    monkeypatch.setattr(api, "update_job", lambda jid, **kw: None)
+    release_calls: List[str] = []
+    monkeypatch.setattr(api, "release_resume_claim", lambda jid: release_calls.append(jid))
+
+    def _no_spawn(*a, **k):
+        raise AssertionError("must not spawn when post-claim re-read finds job is 'running'")
+
+    monkeypatch.setattr(api.threading, "Thread", _no_spawn)
+
+    r = client.post("/run/j1/resume")
+    assert r.status_code == 200
+    assert "already running" in r.json()["message"]
+    assert release_calls, "claim must be released when job is no longer waiting after claiming"
 
 
 # --------------------------------------------------------------------------- GitHub resume status advance

--- a/backend/agents/coding_team/tests/test_api_jobs.py
+++ b/backend/agents/coding_team/tests/test_api_jobs.py
@@ -80,7 +80,7 @@ def test_jobs_empty_list(monkeypatch):
 
 
 def test_jobs_active_filter_pushed_to_store(monkeypatch):
-    """?active=true must filter at the job service (running_only) rather than client-side, so
+    """?active=true must filter at the job service (active_only) rather than client-side, so
     terminal jobs' full records never cross the wire."""
     seen = {}
 
@@ -90,6 +90,6 @@ def test_jobs_active_filter_pushed_to_store(monkeypatch):
 
     monkeypatch.setattr(api, "list_jobs", fake_list_jobs)
     assert client.get("/jobs?active=true").status_code == 200
-    assert seen == {"running_only": True}
+    assert seen == {"active_only": True}
     assert client.get("/jobs").status_code == 200
-    assert seen == {"running_only": False}
+    assert seen == {"active_only": False}

--- a/backend/agents/coding_team/tests/test_api_jobs.py
+++ b/backend/agents/coding_team/tests/test_api_jobs.py
@@ -1,0 +1,95 @@
+"""Tests for GET /jobs: list serialization including the pause flag and GitHub context."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from fastapi.testclient import TestClient
+
+from coding_team.api import main as api
+
+client = TestClient(api.app)
+
+
+def _job(**over: Any) -> Dict[str, Any]:
+    base = {
+        "job_id": "j1",
+        "status": "running",
+        "phase": "coding",
+        "repo_path": "/tmp/repo",
+    }
+    base.update(over)
+    return base
+
+
+def test_jobs_serializes_github_context_and_pause_flag(monkeypatch):
+    ctx = {
+        "owner": "acme",
+        "repo": "widgets",
+        "issue_number": 42,
+        "issue_url": "https://github.com/acme/widgets/issues/42",
+    }
+    monkeypatch.setattr(
+        api,
+        "list_jobs",
+        lambda **kw: [
+            _job(
+                status="waiting_for_user",
+                phase="paused",
+                status_text="Paused for a decision",
+                updated_at="2026-06-09T12:00:00Z",
+                waiting_for_answers=True,
+                github_context=ctx,
+            )
+        ],
+    )
+    r = client.get("/jobs")
+    assert r.status_code == 200
+    (item,) = r.json()
+    assert item["job_id"] == "j1"
+    assert item["status"] == "waiting_for_user"
+    assert item["phase"] == "paused"
+    assert item["status_text"] == "Paused for a decision"
+    assert item["updated_at"] == "2026-06-09T12:00:00Z"
+    assert item["waiting_for_answers"] is True
+    assert item["github_context"] == ctx
+
+
+def test_jobs_defaults_when_fields_absent(monkeypatch):
+    monkeypatch.setattr(api, "list_jobs", lambda **kw: [_job()])
+    r = client.get("/jobs")
+    assert r.status_code == 200
+    (item,) = r.json()
+    assert item["status_text"] is None
+    assert item["updated_at"] is None
+    assert item["waiting_for_answers"] is False
+    assert item["github_context"] is None
+
+
+def test_jobs_coerces_truthy_pause_flag(monkeypatch):
+    monkeypatch.setattr(api, "list_jobs", lambda **kw: [_job(waiting_for_answers=1)])
+    (item,) = client.get("/jobs").json()
+    assert item["waiting_for_answers"] is True
+
+
+def test_jobs_empty_list(monkeypatch):
+    monkeypatch.setattr(api, "list_jobs", lambda **kw: [])
+    r = client.get("/jobs")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_jobs_active_filter_pushed_to_store(monkeypatch):
+    """?active=true must filter at the job service (running_only) rather than client-side, so
+    terminal jobs' full records never cross the wire."""
+    seen = {}
+
+    def fake_list_jobs(**kw):
+        seen.update(kw)
+        return []
+
+    monkeypatch.setattr(api, "list_jobs", fake_list_jobs)
+    assert client.get("/jobs?active=true").status_code == 200
+    assert seen == {"running_only": True}
+    assert client.get("/jobs").status_code == 200
+    assert seen == {"running_only": False}

--- a/backend/agents/coding_team/tests/test_github_source.py
+++ b/backend/agents/coding_team/tests/test_github_source.py
@@ -699,6 +699,26 @@ class TestEndpointHappyPath:
         assert job["github_pr_url"] == "https://example/pr/42"
         assert job["integration_branch"] == "khala/issue-11"
 
+    def test_persists_request_token_for_resume(self, patched_app) -> None:
+        """The per-request PAT is persisted on the job record so a later resume (after the
+        orchestrator thread dies) can re-drive the GitHub publish flow without a GITHUB_TOKEN env."""
+        gh = _FakeClient(issues=[_issue(11, title="Add feature")], sub_map={11: []})
+        patched_app["set_github"](gh)
+        resp = patched_app["client"].post(
+            "/run-from-github",
+            json={
+                "owner": "o",
+                "repo": "r",
+                "repo_path": patched_app["repo_path"],
+                "github_token": "request-pat",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        job = patched_app["jobs"].get_job(resp.json()["job_id"])
+        assert job["github_token"] == "request-pat"
+        # The token is internal to the record, never inside the client-facing github_context.
+        assert "github_token" not in (job.get("github_context") or {})
+
     def test_specific_issue_number(self, patched_app) -> None:
         gh = _FakeClient(issues=[_issue(7)], sub_map={7: []})
         patched_app["set_github"](gh)

--- a/backend/agents/coding_team/tests/test_github_source.py
+++ b/backend/agents/coding_team/tests/test_github_source.py
@@ -699,9 +699,15 @@ class TestEndpointHappyPath:
         assert job["github_pr_url"] == "https://example/pr/42"
         assert job["integration_branch"] == "khala/issue-11"
 
-    def test_persists_request_token_for_resume(self, patched_app) -> None:
-        """The per-request PAT is persisted on the job record so a later resume (after the
-        orchestrator thread dies) can re-drive the GitHub publish flow without a GITHUB_TOKEN env."""
+    def test_persists_request_token_encrypted_for_resume(self, patched_app, monkeypatch) -> None:
+        """The per-request PAT is persisted ENCRYPTED on the job record so a later resume (after the
+        orchestrator thread dies) can re-drive the GitHub publish flow without a GITHUB_TOKEN env —
+        and the raw record (echoed by the generic GET /api/jobs/{team}) never holds a usable PAT."""
+        from cryptography.fernet import Fernet
+
+        from coding_team import token_crypto
+
+        monkeypatch.setenv("INTEGRATION_ENCRYPTION_KEY", Fernet.generate_key().decode())
         gh = _FakeClient(issues=[_issue(11, title="Add feature")], sub_map={11: []})
         patched_app["set_github"](gh)
         resp = patched_app["client"].post(
@@ -715,9 +721,28 @@ class TestEndpointHappyPath:
         )
         assert resp.status_code == 200, resp.text
         job = patched_app["jobs"].get_job(resp.json()["job_id"])
-        assert job["github_token"] == "request-pat"
-        # The token is internal to the record, never inside the client-facing github_context.
-        assert "github_token" not in (job.get("github_context") or {})
+        # Only opaque ciphertext is stored; the plaintext PAT appears nowhere in the record.
+        assert "github_token" not in job
+        assert job["github_token_encrypted"] != "request-pat"
+        assert token_crypto.decrypt_token(job["github_token_encrypted"]) == "request-pat"
+        assert "request-pat" not in json.dumps(job)
+
+    def test_no_encryption_key_skips_token_persistence(self, patched_app, monkeypatch) -> None:
+        """With no key configured, the token is simply not persisted (resume falls back to env)."""
+        from coding_team import token_crypto
+
+        monkeypatch.delenv("INTEGRATION_ENCRYPTION_KEY", raising=False)
+        monkeypatch.setattr(token_crypto, "_load_key", lambda: None)
+        gh = _FakeClient(issues=[_issue(11, title="Add feature")], sub_map={11: []})
+        patched_app["set_github"](gh)
+        resp = patched_app["client"].post(
+            "/run-from-github",
+            json={"owner": "o", "repo": "r", "repo_path": patched_app["repo_path"]},
+        )
+        assert resp.status_code == 200, resp.text
+        job = patched_app["jobs"].get_job(resp.json()["job_id"])
+        assert "github_token_encrypted" not in job
+        assert "github_token" not in job
 
     def test_specific_issue_number(self, patched_app) -> None:
         gh = _FakeClient(issues=[_issue(7)], sub_map={7: []})

--- a/backend/agents/coding_team/tests/test_hitl.py
+++ b/backend/agents/coding_team/tests/test_hitl.py
@@ -433,6 +433,33 @@ def test_wait_for_answers_resumes_after_polls():
     assert state["polls"] >= 3
 
 
+def test_wait_for_answers_heartbeats_each_poll():
+    state = {"polls": 0}
+    beats: list = []
+
+    def get_job(jid):
+        state["polls"] += 1
+        return {"waiting_for_answers": state["polls"] < 3}
+
+    assert hitl.wait_for_answers("j", get_job, sleep=lambda s: None, heartbeat_fn=beats.append)
+    assert len(beats) == 2  # one per waiting poll; none once the flag clears
+    for ts in beats:
+        assert "T" in ts  # ISO-8601 timestamps
+
+
+def test_wait_for_answers_heartbeat_failure_does_not_break_wait():
+    state = {"polls": 0}
+
+    def get_job(jid):
+        state["polls"] += 1
+        return {"waiting_for_answers": state["polls"] < 3}
+
+    def boom(ts):
+        raise RuntimeError("job service down")
+
+    assert hitl.wait_for_answers("j", get_job, sleep=lambda s: None, heartbeat_fn=boom) is True
+
+
 def test_wait_for_answers_times_out():
     clock = {"t": 0.0}
 

--- a/backend/agents/coding_team/tests/test_job_store_filters.py
+++ b/backend/agents/coding_team/tests/test_job_store_filters.py
@@ -16,11 +16,11 @@ class _FakeClient:
         return []
 
 
-def test_running_only_includes_waiting_for_user(monkeypatch):
+def test_active_only_includes_waiting_for_user(monkeypatch):
     fake = _FakeClient()
     monkeypatch.setattr(job_store, "_client", lambda cache_dir=None: fake)
 
-    job_store.list_jobs(running_only=True)
+    job_store.list_jobs(active_only=True)
     assert fake.calls[-1] == list(job_store.NON_TERMINAL_STATUSES)
     assert "waiting_for_user" in fake.calls[-1]
 
@@ -159,11 +159,8 @@ def test_claim_implausibly_future_stamp_is_not_fresh(monkeypatch):
     from datetime import datetime, timedelta, timezone
 
     far_future = (
-        datetime.now(timezone.utc)
-        + timedelta(seconds=job_store._CLAIM_CLOCK_SKEW_TOLERANCE_S + 30)
+        datetime.now(timezone.utc) + timedelta(seconds=job_store._CLAIM_CLOCK_SKEW_TOLERANCE_S + 30)
     ).isoformat()
-    fake = _AtomicFakeClient(
-        {"job_id": "j1", "resume_claim_seq": 1, "resume_claim_at": far_future}
-    )
+    fake = _AtomicFakeClient({"job_id": "j1", "resume_claim_seq": 1, "resume_claim_at": far_future})
     monkeypatch.setattr(job_store, "_client", lambda cache_dir=None: fake)
     assert job_store.claim_resume("j1") is True  # far-future stamp re-claimable

--- a/backend/agents/coding_team/tests/test_job_store_filters.py
+++ b/backend/agents/coding_team/tests/test_job_store_filters.py
@@ -1,8 +1,8 @@
-"""Tests for job_store list filters: running_only must include paused (waiting_for_user) jobs."""
+"""Tests for job_store list filters and the cross-worker resume claim."""
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from coding_team import job_store
 
@@ -26,3 +26,46 @@ def test_running_only_includes_waiting_for_user(monkeypatch):
 
     job_store.list_jobs()
     assert fake.calls[-1] is None
+
+
+class _AtomicFakeClient:
+    """Minimal in-memory client modeling the job service's atomic, row-locked increment."""
+
+    def __init__(self, job: Dict[str, Any]):
+        self.job = job
+
+    def apply_and_get(self, job_id, *, increment=None, **_kw):
+        if increment:
+            for field, delta in increment.items():
+                self.job[field] = self.job.get(field, 0) + delta
+        return dict(self.job)
+
+    def update_job(self, job_id, *, heartbeat=True, **fields):
+        self.job.update(fields)
+
+
+def test_claim_resume_first_caller_wins_others_lose(monkeypatch):
+    fake = _AtomicFakeClient({"job_id": "j1"})  # no resume_claim yet → starts at 0
+    monkeypatch.setattr(job_store, "_client", lambda cache_dir=None: fake)
+
+    assert job_store.claim_resume("j1") is True  # 0 -> 1 wins
+    assert job_store.claim_resume("j1") is False  # 1 -> 2 loses
+    assert job_store.claim_resume("j1") is False  # 2 -> 3 loses
+
+
+def test_release_resets_claim_so_a_later_caller_can_win(monkeypatch):
+    fake = _AtomicFakeClient({"job_id": "j1", "resume_claim": 3})
+    monkeypatch.setattr(job_store, "_client", lambda cache_dir=None: fake)
+
+    job_store.release_resume_claim("j1")
+    assert fake.job["resume_claim"] == 0
+    assert job_store.claim_resume("j1") is True  # 0 -> 1 wins again
+
+
+def test_claim_resume_returns_false_for_missing_job(monkeypatch):
+    class _NoneClient:
+        def apply_and_get(self, *a, **k):
+            return None
+
+    monkeypatch.setattr(job_store, "_client", lambda cache_dir=None: _NoneClient())
+    assert job_store.claim_resume("ghost") is False

--- a/backend/agents/coding_team/tests/test_job_store_filters.py
+++ b/backend/agents/coding_team/tests/test_job_store_filters.py
@@ -136,3 +136,34 @@ def test_claim_resume_returns_false_for_missing_job(monkeypatch):
 
     monkeypatch.setattr(job_store, "_client", lambda cache_dir=None: _NoneClient())
     assert job_store.claim_resume("ghost") is False
+
+
+def test_claim_tolerates_small_forward_clock_skew(monkeypatch):
+    """A claim stamp a few seconds in the future (NTP drift on the stamping host) must still
+    be treated as fresh so the checking worker doesn't immediately re-claim an active lease
+    and allow two orchestrators to run against the same checkout."""
+    from datetime import datetime, timedelta, timezone
+
+    future_stamp = (datetime.now(timezone.utc) + timedelta(seconds=5)).isoformat()
+    fake = _AtomicFakeClient(
+        {"job_id": "j1", "resume_claim_seq": 1, "resume_claim_at": future_stamp}
+    )
+    monkeypatch.setattr(job_store, "_client", lambda cache_dir=None: fake)
+    assert job_store.claim_resume("j1") is False  # 5s ahead is within tolerance → still fresh
+
+
+def test_claim_implausibly_future_stamp_is_not_fresh(monkeypatch):
+    """A stamp far in the future (beyond _CLAIM_CLOCK_SKEW_TOLERANCE_S) is corruption or
+    severe misconfiguration — treat it as expired so the lease can be re-claimed rather
+    than wedged indefinitely."""
+    from datetime import datetime, timedelta, timezone
+
+    far_future = (
+        datetime.now(timezone.utc)
+        + timedelta(seconds=job_store._CLAIM_CLOCK_SKEW_TOLERANCE_S + 30)
+    ).isoformat()
+    fake = _AtomicFakeClient(
+        {"job_id": "j1", "resume_claim_seq": 1, "resume_claim_at": far_future}
+    )
+    monkeypatch.setattr(job_store, "_client", lambda cache_dir=None: fake)
+    assert job_store.claim_resume("j1") is True  # far-future stamp re-claimable

--- a/backend/agents/coding_team/tests/test_job_store_filters.py
+++ b/backend/agents/coding_team/tests/test_job_store_filters.py
@@ -102,6 +102,20 @@ def test_release_clears_stamp_so_a_later_caller_can_win(monkeypatch):
     assert job_store.claim_resume("j1") is True  # now re-claimable
 
 
+def test_release_swallows_store_transport_error(monkeypatch):
+    """Release is best-effort cleanup: a job-store transport error must be swallowed, not raised —
+    callers promise 'never raises' or call it from an except block re-raising a prior error, and the
+    lease self-heals via its TTL anyway."""
+
+    class _BoomClient:
+        def update_job(self, *a, **k):
+            raise RuntimeError("store down")
+
+    monkeypatch.setattr(job_store, "_client", lambda cache_dir=None: _BoomClient())
+    # Must not raise.
+    assert job_store.release_resume_claim("j1") is None
+
+
 def test_concurrent_claim_only_one_wins(monkeypatch):
     """Two callers that both read the same prior seq before either writes: only the one whose
     increment yields prior+1 wins (optimistic compare-and-set)."""

--- a/backend/agents/coding_team/tests/test_job_store_filters.py
+++ b/backend/agents/coding_team/tests/test_job_store_filters.py
@@ -1,0 +1,28 @@
+"""Tests for job_store list filters: running_only must include paused (waiting_for_user) jobs."""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+from coding_team import job_store
+
+
+class _FakeClient:
+    def __init__(self):
+        self.calls: List[Any] = []
+
+    def list_jobs(self, statuses: Optional[List[str]] = None):
+        self.calls.append(statuses)
+        return []
+
+
+def test_running_only_includes_waiting_for_user(monkeypatch):
+    fake = _FakeClient()
+    monkeypatch.setattr(job_store, "_client", lambda cache_dir=None: fake)
+
+    job_store.list_jobs(running_only=True)
+    assert fake.calls[-1] == list(job_store.NON_TERMINAL_STATUSES)
+    assert "waiting_for_user" in fake.calls[-1]
+
+    job_store.list_jobs()
+    assert fake.calls[-1] is None

--- a/backend/agents/coding_team/tests/test_job_store_filters.py
+++ b/backend/agents/coding_team/tests/test_job_store_filters.py
@@ -29,42 +29,95 @@ def test_running_only_includes_waiting_for_user(monkeypatch):
 
 
 class _AtomicFakeClient:
-    """Minimal in-memory client modeling the job service's atomic, row-locked increment."""
+    """Minimal in-memory client modeling the job service's atomic, row-locked apply + get_job."""
 
     def __init__(self, job: Dict[str, Any]):
         self.job = job
 
-    def apply_and_get(self, job_id, *, increment=None, **_kw):
+    def get_job(self, job_id):
+        return dict(self.job)
+
+    def apply_and_get(self, job_id, *, increment=None, merge_fields=None, **_kw):
         if increment:
             for field, delta in increment.items():
-                self.job[field] = self.job.get(field, 0) + delta
+                self.job[field] = (self.job.get(field) or 0) + delta
+        if merge_fields:
+            self.job.update(merge_fields)
         return dict(self.job)
 
     def update_job(self, job_id, *, heartbeat=True, **fields):
         self.job.update(fields)
 
 
-def test_claim_resume_first_caller_wins_others_lose(monkeypatch):
-    fake = _AtomicFakeClient({"job_id": "j1"})  # no resume_claim yet → starts at 0
+def _stamp(seconds_ago: float) -> str:
+    from datetime import datetime, timedelta, timezone
+
+    return (datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)).isoformat()
+
+
+def test_claim_resume_first_caller_wins_when_lease_free(monkeypatch):
+    fake = _AtomicFakeClient({"job_id": "j1"})  # no lease yet
     monkeypatch.setattr(job_store, "_client", lambda cache_dir=None: fake)
+    assert job_store.claim_resume("j1") is True  # acquires the free lease
+    # Now a fresh lease is held → a subsequent claim declines.
+    assert job_store.claim_resume("j1") is False
 
-    assert job_store.claim_resume("j1") is True  # 0 -> 1 wins
-    assert job_store.claim_resume("j1") is False  # 1 -> 2 loses
-    assert job_store.claim_resume("j1") is False  # 2 -> 3 loses
 
-
-def test_release_resets_claim_so_a_later_caller_can_win(monkeypatch):
-    fake = _AtomicFakeClient({"job_id": "j1", "resume_claim": 3})
+def test_claim_resume_declines_while_lease_fresh(monkeypatch):
+    fake = _AtomicFakeClient({"job_id": "j1", "resume_claim_seq": 5, "resume_claim_at": _stamp(1)})
     monkeypatch.setattr(job_store, "_client", lambda cache_dir=None: fake)
+    assert job_store.claim_resume("j1") is False  # a live worker holds it
 
+
+def test_claim_resume_reclaims_expired_lease_after_worker_death(monkeypatch):
+    # Winner died: the lease stamp is older than the TTL and the seq stayed nonzero.
+    fake = _AtomicFakeClient(
+        {
+            "job_id": "j1",
+            "resume_claim_seq": 1,
+            "resume_claim_at": _stamp(job_store.RESUME_CLAIM_TTL_S + 10),
+        }
+    )
+    monkeypatch.setattr(job_store, "_client", lambda cache_dir=None: fake)
+    assert job_store.claim_resume("j1") is True  # recoverable — not wedged
+    assert fake.job["resume_claim_seq"] == 2
+
+
+def test_claim_resume_future_stamp_is_not_fresh(monkeypatch):
+    # A future-dated stamp (skew/corruption) must not block the claim forever.
+    fake = _AtomicFakeClient(
+        {"job_id": "j1", "resume_claim_seq": 1, "resume_claim_at": _stamp(-3600)}
+    )
+    monkeypatch.setattr(job_store, "_client", lambda cache_dir=None: fake)
+    assert job_store.claim_resume("j1") is True
+
+
+def test_release_clears_stamp_so_a_later_caller_can_win(monkeypatch):
+    fake = _AtomicFakeClient({"job_id": "j1", "resume_claim_seq": 3, "resume_claim_at": _stamp(1)})
+    monkeypatch.setattr(job_store, "_client", lambda cache_dir=None: fake)
+    assert job_store.claim_resume("j1") is False  # fresh lease blocks
     job_store.release_resume_claim("j1")
-    assert fake.job["resume_claim"] == 0
-    assert job_store.claim_resume("j1") is True  # 0 -> 1 wins again
+    assert fake.job["resume_claim_at"] is None
+    assert fake.job["resume_claim_seq"] == 3  # seq untouched (monotonic)
+    assert job_store.claim_resume("j1") is True  # now re-claimable
+
+
+def test_concurrent_claim_only_one_wins(monkeypatch):
+    """Two callers that both read the same prior seq before either writes: only the one whose
+    increment yields prior+1 wins (optimistic compare-and-set)."""
+    fake = _AtomicFakeClient({"job_id": "j1", "resume_claim_seq": 5})
+    monkeypatch.setattr(job_store, "_client", lambda cache_dir=None: fake)
+    # Simulate both reading seq=5 before either increments by snapshotting get_job.
+    snapshot = dict(fake.job)
+    fake.get_job = lambda job_id: dict(snapshot)  # both callers see seq=5, no fresh stamp
+    results = [job_store.claim_resume("j1"), job_store.claim_resume("j1")]
+    assert results.count(True) == 1  # exactly one winner
+    assert fake.job["resume_claim_seq"] == 7  # both incremented (5→6→7), one matched 6
 
 
 def test_claim_resume_returns_false_for_missing_job(monkeypatch):
     class _NoneClient:
-        def apply_and_get(self, *a, **k):
+        def get_job(self, *a, **k):
             return None
 
     monkeypatch.setattr(job_store, "_client", lambda cache_dir=None: _NoneClient())

--- a/backend/agents/coding_team/tests/test_orchestrator_hitl.py
+++ b/backend/agents/coding_team/tests/test_orchestrator_hitl.py
@@ -149,6 +149,43 @@ def test_pause_publish_writes_heartbeat_atomically_with_flag(monkeypatch):
     assert "T" in pause_update["answer_wait_heartbeat_at"]  # ISO-8601
 
 
+def test_pause_renews_lease_during_slow_on_pause(monkeypatch):
+    """A slow on_pause (e.g. a GitHub comment with retries exceeding the 30s staleness window) must
+    not let the lease go stale: a background renewer heartbeats while the callback runs."""
+    import threading as _threading
+
+    # Shrink the renewal cadence so the test is fast and deterministic.
+    monkeypatch.setattr(orch_mod.hitl, "ANSWER_WAIT_POLL_INTERVAL_S", 0.01)
+    heartbeats: List[str] = []
+    job: Dict[str, Any] = {}
+    monkeypatch.setattr(orch_mod.hitl, "wait_for_answers", _answer_all(job))
+
+    def update_fn(**kw):
+        job.update(kw)
+        if "answer_wait_heartbeat_at" in kw and kw.get("waiting_for_answers") is None:
+            heartbeats.append(kw["answer_wait_heartbeat_at"])
+
+    started = _threading.Event()
+
+    def slow_on_pause(_qs):
+        started.set()
+        # Hold the callback long enough for several renewal ticks (cadence 0.01s).
+        _threading.Event().wait(0.08)
+
+    _run_pause_cycle(
+        "j",
+        ["Q?"],
+        "src",
+        get_job_fn=lambda j: job,
+        update_fn=update_fn,
+        on_pause=slow_on_pause,
+    )
+    assert started.is_set()
+    # The lease was renewed at least once *during* the slow callback (separate from the atomic
+    # initial heartbeat that rides the pause-publish update).
+    assert len(heartbeats) >= 1
+
+
 def test_pause_cycle_on_pause_error_is_swallowed(monkeypatch):
     job: Dict[str, Any] = {}
     monkeypatch.setattr(orch_mod.hitl, "wait_for_answers", _answer_all(job))

--- a/backend/agents/coding_team/tests/test_orchestrator_hitl.py
+++ b/backend/agents/coding_team/tests/test_orchestrator_hitl.py
@@ -272,6 +272,149 @@ def test_pause_cycle_terminal_leaves_status(monkeypatch):
     assert job["status"] == "cancelled"  # not overwritten to failed
 
 
+# --------------------------------------------------------------------------- _run_pause_cycle resilience (orchestrator threads 10/11/12/14)
+
+
+def test_pause_cycle_pinned_activity_falls_back_on_store_error(monkeypatch):
+    """Thread 10+12: if get_job_fn raises during the post-pause pin read, _run_pause_cycle must
+    continue with pinned_activity_at=None rather than crashing. Thread 12: with None pin, heartbeats
+    must NOT write last_activity_at=None (which would clobber the real field with null)."""
+    import threading as _threading
+
+    monkeypatch.setattr(orch_mod.hitl, "ANSWER_WAIT_POLL_INTERVAL_S", 0.01)
+    job: Dict[str, Any] = {}
+    monkeypatch.setattr(orch_mod.hitl, "wait_for_answers", _answer_all(job))
+
+    call_count = {"n": 0}
+
+    def get_job_fn(jid):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("store error during pin read")
+        return dict(job)
+
+    hb_calls: List[Dict[str, Any]] = []
+    first_beat = _threading.Event()
+
+    def update_fn(**kw):
+        job.update(kw)
+        if "answer_wait_heartbeat_at" in kw and kw.get("waiting_for_answers") is None:
+            hb_calls.append(dict(kw))
+            first_beat.set()
+
+    def slow_on_pause(_qs):
+        assert first_beat.wait(5.0), "renewer did not heartbeat during on_pause"
+
+    _, ok = _run_pause_cycle(
+        "j", ["Q?"], "src", get_job_fn=get_job_fn, update_fn=update_fn, on_pause=slow_on_pause
+    )
+    assert ok is True
+    assert hb_calls, "expected heartbeats even when the pin read failed"
+    # Thread 12: when pinned_activity_at is unknown (None), heartbeats must not forward
+    # last_activity_at=None — that would overwrite real activity data with a null sentinel.
+    assert not any("last_activity_at" in c for c in hb_calls), (
+        "heartbeats must not write last_activity_at=None when the pin read failed"
+    )
+
+
+def test_pause_cycle_terminal_check_store_error_marks_failed(monkeypatch):
+    """Thread 11 (timeout path): if get_job_fn raises during the terminal check after wait_for_answers
+    times out, the cycle must default to 'mark failed' rather than crashing — it cannot distinguish a
+    cancelled job from a timeout when the store is down, so failing closed is the safe default."""
+    job: Dict[str, Any] = {}
+    call_count = {"n": 0}
+
+    def get_job_fn(jid):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("store error during pin read")  # Thread 10: falls back to None
+        raise RuntimeError("store error during terminal check")  # Thread 11: defaults to failed
+
+    updates: List[Dict[str, Any]] = []
+    monkeypatch.setattr(orch_mod.hitl, "wait_for_answers", lambda *a, **k: False)
+
+    _, ok = _run_pause_cycle(
+        "j",
+        ["Q?"],
+        "src",
+        get_job_fn=get_job_fn,
+        update_fn=lambda **kw: (job.update(kw), updates.append(dict(kw))),
+    )
+    assert ok is False
+    assert any(u.get("status") == "failed" for u in updates)
+
+
+def test_pause_cycle_submitted_answers_store_error_continues_with_empty(monkeypatch):
+    """Thread 11 (answers path): if get_job_fn raises when reading submitted_answers after answers
+    are received, the cycle must proceed with an empty list and return ok=True rather than crashing
+    with waiting_for_answers still True (which would strand the run in the paused state)."""
+    job: Dict[str, Any] = {}
+    answered = {"did": False}
+
+    def fake_wait(job_id, gj, **kw):
+        job["waiting_for_answers"] = False
+        answered["did"] = True
+        return True
+
+    monkeypatch.setattr(orch_mod.hitl, "wait_for_answers", fake_wait)
+
+    call_count = {"n": 0}
+
+    def get_job_fn(jid):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return dict(job)  # pin read: succeeds, no last_activity_at → pinned=None
+        raise RuntimeError("store error reading submitted_answers")
+
+    resolved, ok = _run_pause_cycle(
+        "j",
+        ["Q?"],
+        "src",
+        get_job_fn=get_job_fn,
+        update_fn=lambda **kw: job.update(kw),
+    )
+    assert ok is True
+    assert answered["did"]
+    assert resolved == [], "must continue with empty answers rather than raising"
+
+
+def test_pause_renewer_thread_start_failure_is_swallowed(monkeypatch):
+    """Thread 14: if threading.Thread.start raises RuntimeError (resource exhaustion), the pause
+    cycle must still invoke on_pause and wait for answers — the run continues without background
+    heartbeat renewal rather than aborting due to the OS failure."""
+    job: Dict[str, Any] = {}
+    monkeypatch.setattr(orch_mod.hitl, "wait_for_answers", _answer_all(job))
+    pause_called: List[bool] = []
+
+    class _FailStartThread:
+        """Thread stand-in whose start() raises RuntimeError to simulate resource exhaustion."""
+
+        def __init__(self, target=None, daemon=None, name=None):
+            self._target = target
+
+        def start(self):
+            raise RuntimeError("max threads exceeded")
+
+        def join(self, timeout=None):
+            pass
+
+    monkeypatch.setattr(orch_mod.threading, "Thread", _FailStartThread)
+
+    def on_pause(_qs):
+        pause_called.append(True)
+
+    _, ok = _run_pause_cycle(
+        "j",
+        ["Q?"],
+        "src",
+        get_job_fn=lambda j: job,
+        update_fn=lambda **kw: job.update(kw),
+        on_pause=on_pause,
+    )
+    assert ok is True
+    assert pause_called, "on_pause must be called even when the renewer thread fails to start"
+
+
 # --------------------------------------------------------------------------- _plan_with_hitl
 
 

--- a/backend/agents/coding_team/tests/test_orchestrator_hitl.py
+++ b/backend/agents/coding_team/tests/test_orchestrator_hitl.py
@@ -143,12 +143,13 @@ def test_pause_publish_writes_heartbeat_atomically_with_flag(monkeypatch):
         update_fn=lambda **kw: (job.update(kw), updates.append(dict(kw))),
         on_pause=lambda qs: None,
     )
-    # The update that publishes the pause flag also carries the heartbeat timestamp and resets the
-    # cross-worker resume claim so this pause is independently claimable.
+    # The update that publishes the pause flag also carries the heartbeat timestamp and clears the
+    # cross-worker resume-claim lease so this pause is immediately claimable.
     pause_update = next(u for u in updates if u.get("waiting_for_answers") is True)
     assert pause_update.get("answer_wait_heartbeat_at")
     assert "T" in pause_update["answer_wait_heartbeat_at"]  # ISO-8601
-    assert pause_update.get("resume_claim") == 0
+    assert "resume_claim_at" in pause_update
+    assert pause_update["resume_claim_at"] is None
 
 
 def test_pause_renews_lease_during_slow_on_pause(monkeypatch):

--- a/backend/agents/coding_team/tests/test_orchestrator_hitl.py
+++ b/backend/agents/coding_team/tests/test_orchestrator_hitl.py
@@ -54,7 +54,7 @@ def _patch_git(monkeypatch, diff: str = "", merge=(True, "ok")):
 def _answer_all(job: Dict[str, Any], option: str = "yes"):
     """Fake hitl.wait_for_answers: answer every surfaced question and clear the wait flag."""
 
-    def fake_wait(job_id, get_job_fn):
+    def fake_wait(job_id, get_job_fn, **kw):
         pend = job.get("pending_questions") or []
         job["submitted_answers"] = list(job.get("submitted_answers") or []) + [
             {"question_id": q["id"], "selected_option_id": option} for q in pend
@@ -160,7 +160,7 @@ def test_pause_cycle_timeout_sets_failed(monkeypatch):
 def test_pause_cycle_terminal_leaves_status(monkeypatch):
     job: Dict[str, Any] = {}
 
-    def fake_wait(job_id, gj):
+    def fake_wait(job_id, gj, **kw):
         job["status"] = "cancelled"  # job goes terminal while waiting
         return False
 

--- a/backend/agents/coding_team/tests/test_orchestrator_hitl.py
+++ b/backend/agents/coding_team/tests/test_orchestrator_hitl.py
@@ -129,6 +129,26 @@ def test_pause_cycle_success_calls_on_pause(monkeypatch):
     assert job["waiting_for_answers"] is False
 
 
+def test_pause_publish_writes_heartbeat_atomically_with_flag(monkeypatch):
+    """The pause flag and the first heartbeat must be set in the SAME update, so a concurrent
+    answer on another worker can never see waiting_for_answers without a live heartbeat."""
+    updates: List[Dict[str, Any]] = []
+    job: Dict[str, Any] = {}
+    monkeypatch.setattr(orch_mod.hitl, "wait_for_answers", _answer_all(job))
+    _run_pause_cycle(
+        "j",
+        ["Q?"],
+        "src",
+        get_job_fn=lambda j: job,
+        update_fn=lambda **kw: (job.update(kw), updates.append(dict(kw))),
+        on_pause=lambda qs: None,
+    )
+    # The update that publishes the pause flag also carries the heartbeat timestamp.
+    pause_update = next(u for u in updates if u.get("waiting_for_answers") is True)
+    assert pause_update.get("answer_wait_heartbeat_at")
+    assert "T" in pause_update["answer_wait_heartbeat_at"]  # ISO-8601
+
+
 def test_pause_cycle_on_pause_error_is_swallowed(monkeypatch):
     job: Dict[str, Any] = {}
     monkeypatch.setattr(orch_mod.hitl, "wait_for_answers", _answer_all(job))

--- a/backend/agents/coding_team/tests/test_orchestrator_hitl.py
+++ b/backend/agents/coding_team/tests/test_orchestrator_hitl.py
@@ -195,6 +195,40 @@ def test_pause_renews_lease_during_slow_on_pause(monkeypatch):
     assert len(heartbeats) >= 1
 
 
+def test_pause_heartbeats_preserve_last_activity_at(monkeypatch):
+    """Answer-wait heartbeats are liveness pings, not real activity: they must pin last_activity_at
+    to its pre-pause value so a job waiting hours on the user does not look continuously active
+    (the API contract excludes heartbeats from last_activity_at)."""
+    import threading as _threading
+
+    monkeypatch.setattr(orch_mod.hitl, "ANSWER_WAIT_POLL_INTERVAL_S", 0.01)
+    pinned = "2020-01-01T00:00:00+00:00"
+    job: Dict[str, Any] = {"last_activity_at": pinned}
+    monkeypatch.setattr(orch_mod.hitl, "wait_for_answers", _answer_all(job))
+
+    hb_calls: List[Dict[str, Any]] = []
+    first_beat = _threading.Event()
+
+    def update_fn(**kw):
+        job.update(kw)
+        # Capture the renewal/wait-loop heartbeats (which carry answer_wait_heartbeat_at but not the
+        # waiting_for_answers flag that rides the one-shot pause-publish update).
+        if "answer_wait_heartbeat_at" in kw and kw.get("waiting_for_answers") is None:
+            hb_calls.append(kw)
+            first_beat.set()
+
+    def slow_on_pause(_qs):
+        assert first_beat.wait(5.0), "renewer did not heartbeat during on_pause"
+
+    _run_pause_cycle(
+        "j", ["Q?"], "src", get_job_fn=lambda j: job, update_fn=update_fn, on_pause=slow_on_pause
+    )
+
+    assert hb_calls, "expected at least one answer-wait heartbeat"
+    # Every heartbeat pins last_activity_at to the pre-pause value rather than advancing it.
+    assert all(c.get("last_activity_at") == pinned for c in hb_calls)
+
+
 def test_pause_cycle_on_pause_error_is_swallowed(monkeypatch):
     job: Dict[str, Any] = {}
     monkeypatch.setattr(orch_mod.hitl, "wait_for_answers", _answer_all(job))

--- a/backend/agents/coding_team/tests/test_orchestrator_hitl.py
+++ b/backend/agents/coding_team/tests/test_orchestrator_hitl.py
@@ -163,17 +163,23 @@ def test_pause_renews_lease_during_slow_on_pause(monkeypatch):
     job: Dict[str, Any] = {}
     monkeypatch.setattr(orch_mod.hitl, "wait_for_answers", _answer_all(job))
 
+    first_beat = _threading.Event()
+
     def update_fn(**kw):
         job.update(kw)
         if "answer_wait_heartbeat_at" in kw and kw.get("waiting_for_answers") is None:
             heartbeats.append(kw["answer_wait_heartbeat_at"])
+            first_beat.set()
 
     started = _threading.Event()
 
     def slow_on_pause(_qs):
         started.set()
-        # Hold the callback long enough for several renewal ticks (cadence 0.01s).
-        _threading.Event().wait(0.08)
+        # Block on the actual renewal signal instead of a wall-clock sleep: the callback returns the
+        # moment the background renewer heartbeats once (which is exactly what this test asserts), so
+        # it is deterministic rather than racing real time. The generous timeout is only a safety cap
+        # that trips on a genuinely broken renewer, not on a slow/loaded CI host.
+        assert first_beat.wait(5.0), "renewer did not heartbeat during the slow on_pause callback"
 
     _run_pause_cycle(
         "j",

--- a/backend/agents/coding_team/tests/test_orchestrator_hitl.py
+++ b/backend/agents/coding_team/tests/test_orchestrator_hitl.py
@@ -143,10 +143,12 @@ def test_pause_publish_writes_heartbeat_atomically_with_flag(monkeypatch):
         update_fn=lambda **kw: (job.update(kw), updates.append(dict(kw))),
         on_pause=lambda qs: None,
     )
-    # The update that publishes the pause flag also carries the heartbeat timestamp.
+    # The update that publishes the pause flag also carries the heartbeat timestamp and resets the
+    # cross-worker resume claim so this pause is independently claimable.
     pause_update = next(u for u in updates if u.get("waiting_for_answers") is True)
     assert pause_update.get("answer_wait_heartbeat_at")
     assert "T" in pause_update["answer_wait_heartbeat_at"]  # ISO-8601
+    assert pause_update.get("resume_claim") == 0
 
 
 def test_pause_renews_lease_during_slow_on_pause(monkeypatch):

--- a/backend/agents/coding_team/tests/test_pr_review_mapping.py
+++ b/backend/agents/coding_team/tests/test_pr_review_mapping.py
@@ -170,7 +170,9 @@ def test_map_unknown_file_goes_to_body() -> None:
 
 
 def test_format_comment_body_includes_severity_and_fix() -> None:
-    body = format_comment_body(_Issue(severity="high", category="logic", description="X", suggestion="Y"))
+    body = format_comment_body(
+        _Issue(severity="high", category="logic", description="X", suggestion="Y")
+    )
     assert "**[HIGH] logic** — X" in body
     assert "**Suggested fix:** Y" in body
 

--- a/backend/agents/coding_team/tests/test_resume_claim_integration.py
+++ b/backend/agents/coding_team/tests/test_resume_claim_integration.py
@@ -1,0 +1,43 @@
+"""Integration tests for the cross-worker resume claim against the REAL job service.
+
+These exercise the atomic read-after-write the unit tests can only model with the fake client:
+``/jobs/{team}/{job_id}/apply`` must return the value written inside its own row-locked transaction,
+so a counter increment reports the caller's OWN result, not a value a concurrent patch committed
+afterward. Skipped unless run with ``-m integration`` and a real Postgres + job service.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from coding_team import job_store
+from job_service_client import JobServiceClient
+
+
+@pytest.mark.integration
+def test_apply_returns_callers_own_incremented_value(
+    integration_job_service: str, truncate_jobs_table: None
+) -> None:
+    client = JobServiceClient(team="coding_team")
+    client.create_job("j-atomic", status="waiting_for_user")
+
+    r1 = client.apply_and_get("j-atomic", increment={"resume_claim_seq": 1})
+    assert r1 is not None and r1["resume_claim_seq"] == 1  # this call's own result
+
+    r2 = client.apply_and_get("j-atomic", increment={"resume_claim_seq": 1})
+    assert r2 is not None and r2["resume_claim_seq"] == 2
+
+
+@pytest.mark.integration
+def test_claim_resume_single_winner_against_real_service(
+    integration_job_service: str, truncate_jobs_table: None
+) -> None:
+    client = JobServiceClient(team="coding_team")
+    client.create_job("j-claim", status="waiting_for_user")
+
+    assert job_store.claim_resume("j-claim") is True  # acquires the free lease
+    assert job_store.claim_resume("j-claim") is False  # the fresh lease now blocks
+
+    # Releasing the stamp makes it immediately re-claimable (seq stays monotonic).
+    job_store.release_resume_claim("j-claim")
+    assert job_store.claim_resume("j-claim") is True

--- a/backend/agents/coding_team/tests/test_token_crypto.py
+++ b/backend/agents/coding_team/tests/test_token_crypto.py
@@ -1,0 +1,58 @@
+"""Tests for the resume-token encryption helper: round-trip, no-key fallback, bad input."""
+
+from __future__ import annotations
+
+from cryptography.fernet import Fernet
+
+from coding_team import token_crypto
+
+
+def _set_key(monkeypatch) -> str:
+    key = Fernet.generate_key().decode()
+    monkeypatch.setenv("INTEGRATION_ENCRYPTION_KEY", key)
+    return key
+
+
+def test_round_trip(monkeypatch):
+    _set_key(monkeypatch)
+    ct = token_crypto.encrypt_token("ghp_secret")
+    assert ct is not None
+    assert ct != "ghp_secret"  # opaque ciphertext, not the plaintext
+    assert token_crypto.decrypt_token(ct) == "ghp_secret"
+
+
+def test_no_key_means_no_persistence(monkeypatch, tmp_path):
+    monkeypatch.delenv("INTEGRATION_ENCRYPTION_KEY", raising=False)
+    # Point AGENT_CACHE at an empty dir so no key file is found, and we never generate one.
+    monkeypatch.setenv("AGENT_CACHE", str(tmp_path))
+    assert token_crypto.encrypt_token("ghp_secret") is None
+    assert token_crypto.decrypt_token("anything") is None
+
+
+def test_reads_key_file_when_env_unset(monkeypatch, tmp_path):
+    monkeypatch.delenv("INTEGRATION_ENCRYPTION_KEY", raising=False)
+    monkeypatch.setenv("AGENT_CACHE", str(tmp_path))
+    (tmp_path / "integration.key").write_bytes(Fernet.generate_key())
+    ct = token_crypto.encrypt_token("ghp_secret")
+    assert ct is not None
+    assert token_crypto.decrypt_token(ct) == "ghp_secret"
+
+
+def test_empty_and_none_inputs(monkeypatch):
+    _set_key(monkeypatch)
+    assert token_crypto.encrypt_token("") is None
+    assert token_crypto.decrypt_token(None) is None
+    assert token_crypto.decrypt_token("") is None
+
+
+def test_decrypt_bad_ciphertext_returns_none(monkeypatch):
+    _set_key(monkeypatch)
+    assert token_crypto.decrypt_token("not-valid-fernet") is None
+
+
+def test_decrypt_with_wrong_key_returns_none(monkeypatch):
+    _set_key(monkeypatch)
+    ct = token_crypto.encrypt_token("ghp_secret")
+    # Rotate the key: the old ciphertext is no longer decryptable, but we fail closed, not raise.
+    monkeypatch.setenv("INTEGRATION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    assert token_crypto.decrypt_token(ct) is None

--- a/backend/agents/coding_team/token_crypto.py
+++ b/backend/agents/coding_team/token_crypto.py
@@ -1,0 +1,88 @@
+"""Encrypt the GitHub token the coding team persists for resume.
+
+A GitHub-issue job must be resumable after its orchestrator thread dies (server restart, a
+different worker process), and the standard deployment has no ``GITHUB_TOKEN`` env — the PAT
+arrives per-request from the unified API credential store. So the token is persisted on the job
+record. To keep a *usable* PAT out of the raw job record (which the generic
+``GET /api/jobs/{team}`` route echoes verbatim), only **opaque Fernet ciphertext** is ever stored.
+
+Key sourcing reuses the unified API's integration-credential key so no new secret is introduced:
+``INTEGRATION_ENCRYPTION_KEY`` env first, else the ``integration.key`` file under the shared
+``AGENT_CACHE`` volume (every team container mounts it). We never *generate* a key here — an
+ephemeral key would make a token encrypted before a restart undecryptable afterwards, defeating the
+whole point. When no key is available the token is simply not persisted and resume falls back to
+``GITHUB_TOKEN`` env (or refuses), so we never store plaintext.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+from cryptography.fernet import Fernet
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_CACHE_DIR = ".agent_cache"
+_KEY_FILENAME = "integration.key"
+
+
+def _load_key() -> Optional[bytes]:
+    """Return the Fernet key (env or shared key file), or None when none is available.
+
+    Postconditions:
+        - Never generates or persists a key; a missing key yields None so callers fall back to
+          not persisting the token rather than minting an ephemeral, restart-unstable key.
+    """
+    env_key = os.getenv("INTEGRATION_ENCRYPTION_KEY", "").strip()
+    if env_key:
+        return env_key.encode()
+    cache_dir = os.getenv("AGENT_CACHE", _DEFAULT_CACHE_DIR)
+    key_path = Path(cache_dir) / _KEY_FILENAME
+    try:
+        if key_path.exists():
+            return key_path.read_bytes().strip()
+    except OSError:
+        logger.warning("Could not read encryption key at %s", key_path, exc_info=True)
+    return None
+
+
+def encrypt_token(token: str) -> Optional[str]:
+    """Return Fernet ciphertext for ``token``.
+
+    Postconditions:
+        - Returns an opaque ciphertext string on success; returns None when ``token`` is empty,
+          no key is available, or encryption fails — in which case the caller must not persist the
+          token. Never raises.
+    """
+    if not token:
+        return None
+    key = _load_key()
+    if not key:
+        return None
+    try:
+        return Fernet(key).encrypt(token.encode()).decode()
+    except Exception:
+        logger.warning("GitHub token encryption failed; token will not be persisted.", exc_info=True)
+        return None
+
+
+def decrypt_token(ciphertext: Optional[str]) -> Optional[str]:
+    """Return the plaintext token from ``ciphertext``.
+
+    Postconditions:
+        - Returns the decrypted token on success; returns None when ``ciphertext`` is falsy, no key
+          is available, or decryption fails (wrong/rotated key, corruption). Never raises.
+    """
+    if not ciphertext:
+        return None
+    key = _load_key()
+    if not key:
+        return None
+    try:
+        return Fernet(key).decrypt(ciphertext.encode()).decode()
+    except Exception:
+        logger.warning("GitHub token decryption failed.", exc_info=True)
+        return None

--- a/backend/agents/coding_team/token_crypto.py
+++ b/backend/agents/coding_team/token_crypto.py
@@ -65,7 +65,9 @@ def encrypt_token(token: str) -> Optional[str]:
     try:
         return Fernet(key).encrypt(token.encode()).decode()
     except Exception:
-        logger.warning("GitHub token encryption failed; token will not be persisted.", exc_info=True)
+        logger.warning(
+            "GitHub token encryption failed; token will not be persisted.", exc_info=True
+        )
         return None
 
 

--- a/backend/agents/job_service_client.py
+++ b/backend/agents/job_service_client.py
@@ -264,6 +264,36 @@ class JobServiceClient:
             },
         )
 
+    def apply_and_get(
+        self,
+        job_id: str,
+        *,
+        merge_fields: Optional[Dict[str, Any]] = None,
+        merge_nested: Optional[Dict[str, Any]] = None,
+        append_to: Optional[Dict[str, List[Any]]] = None,
+        increment: Optional[Dict[str, int]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Like :meth:`atomic_update`, but return the updated job record.
+
+        The job service applies the patch under a row lock (``SELECT ... FOR UPDATE``) and returns
+        the post-update record, so a caller can read back an atomically-incremented counter — a
+        cross-worker fencing token — and learn whether its own increment produced a given value.
+
+        Postconditions:
+            - Returns the updated job dict, or None when the job does not exist.
+        """
+        resp = self._request(
+            "POST",
+            self._url(f"/jobs/{self.team}/{job_id}/apply"),
+            json={
+                "merge_fields": merge_fields,
+                "merge_nested": merge_nested,
+                "append_to": append_to,
+                "increment": increment,
+            },
+        )
+        return resp.json().get("job")
+
     def increment_field(self, job_id: str, field: str, delta: int = 1) -> None:
         """Atomically increment an integer field by *delta*."""
         self.atomic_update(job_id, increment={field: delta})

--- a/backend/agents/job_service_client_fake.py
+++ b/backend/agents/job_service_client_fake.py
@@ -252,6 +252,25 @@ class FakeJobServiceClient:
             job["last_activity_at"] = _now_iso()
         self._stamp(job)
 
+    def apply_and_get(
+        self,
+        job_id: str,
+        *,
+        merge_fields: dict[str, Any] | None = None,
+        merge_nested: dict[str, Any] | None = None,
+        append_to: dict[str, list[Any]] | None = None,
+        increment: dict[str, int] | None = None,
+    ) -> dict[str, Any] | None:
+        """Like ``atomic_update`` but returns the updated job (mirrors production fencing-token use)."""
+        self.atomic_update(
+            job_id,
+            merge_fields=merge_fields,
+            merge_nested=merge_nested,
+            append_to=append_to,
+            increment=increment,
+        )
+        return self.get_job(job_id)
+
 
 @pytest.fixture
 def fake_job_client() -> FakeJobServiceClient:

--- a/backend/agents/job_service_client_fake.py
+++ b/backend/agents/job_service_client_fake.py
@@ -261,7 +261,14 @@ class FakeJobServiceClient:
         append_to: dict[str, list[Any]] | None = None,
         increment: dict[str, int] | None = None,
     ) -> dict[str, Any] | None:
-        """Like ``atomic_update`` but returns the updated job (mirrors production fencing-token use)."""
+        """Like ``atomic_update`` but returns the updated job (mirrors production fencing-token use).
+
+        Invariant: this fake is single-threaded and in-memory — tests drive it sequentially from the
+        test thread. ``atomic_update`` mutates the live job dict in place and ``get_job`` returns a
+        fresh copy of that same dict, so the returned snapshot always reflects this call's own
+        increment with no read-after-write gap. The production service guarantees the same via a
+        row-locked transaction; behaviour under genuine concurrency can only be exercised against it.
+        """
         self.atomic_update(
             job_id,
             merge_fields=merge_fields,

--- a/backend/job_service/db.py
+++ b/backend/job_service/db.py
@@ -282,12 +282,17 @@ def apply_patch(
     merge_nested: dict[str, Any] | None = None,
     append_to: dict[str, list[Any]] | None = None,
     increment: dict[str, int] | None = None,
-) -> None:
+) -> dict[str, Any] | None:
     """Atomic read-modify-write: merge fields, merge into nested dicts, append to lists, increment counters.
 
-    Postconditions: ``data.last_activity_at`` is stamped with the server's UTC now
-    unless ``merge_fields`` supplied it explicitly (a patch is a real update — see
-    :func:`update_job`).
+    Postconditions:
+        - ``data.last_activity_at`` is stamped with the server's UTC now unless ``merge_fields``
+          supplied it explicitly (a patch is a real update — see :func:`update_job`).
+        - Returns the updated job record, read back WITHIN the same row-locked transaction as the
+          write — so a caller that increments a counter observes its OWN result, never a value a
+          concurrent patch committed afterward (the readback must not be a separate transaction, or
+          two racing increments could each read the final value and both mis-conclude they lost).
+          Returns None when the job does not exist.
     """
     with get_conn() as conn, conn.cursor() as cur:
         cur.execute(
@@ -296,7 +301,7 @@ def apply_patch(
         )
         row = cur.fetchone()
         if row is None:
-            return
+            return None
         data = row[0] if isinstance(row[0], dict) else json.loads(row[0])
         current_status = row[1]
         new_status = current_status
@@ -352,6 +357,11 @@ def apply_patch(
                 """,
             (json.dumps(data), new_status, now, now, team, job_id),
         )
+        # Read back inside the same row-locked transaction so the returned record reflects THIS
+        # patch's write (the FOR UPDATE lock is held until commit, so a concurrent patch can't
+        # interleave between this write and read).
+        cur.execute("SELECT * FROM jobs WHERE team = %s AND job_id = %s", (team, job_id))
+        return _row_to_dict(cur.fetchone(), cur)
 
 
 def append_event(

--- a/backend/job_service/main.py
+++ b/backend/job_service/main.py
@@ -156,7 +156,11 @@ def update_job(team: str, job_id: str, req: UpdateJobRequest):
 
 @app.post("/jobs/{team}/{job_id}/apply", response_model=JobResponse)
 def apply_patch(team: str, job_id: str, req: ApplyPatchRequest):
-    db_apply_patch(
+    # Return the record read back inside apply_patch's own row-locked transaction — NOT a separate
+    # db_get_job, which could observe a concurrent patch's write and break atomic read-after-write
+    # for counter increments (two racing claims could each read the other's final value and both
+    # mis-conclude they lost).
+    updated = db_apply_patch(
         team,
         job_id,
         merge_fields=req.merge_fields,
@@ -164,7 +168,7 @@ def apply_patch(team: str, job_id: str, req: ApplyPatchRequest):
         append_to=req.append_to,
         increment=req.increment,
     )
-    return JobResponse(job=db_get_job(team, job_id))
+    return JobResponse(job=updated)
 
 
 @app.post("/jobs/{team}/{job_id}/event", response_model=JobResponse)

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.html
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.html
@@ -66,7 +66,7 @@
           <h3>
             Working on issue
             @if (activeJob.issue_url) {
-              <a [href]="activeJob.issue_url" target="_blank" rel="noopener">#{{ activeJob.issue_number }}</a>
+              <a [href]="activeJob.issue_url" target="_blank" rel="noopener noreferrer">#{{ activeJob.issue_number }}</a>
             } @else {
               #{{ activeJob.issue_number }}
             }
@@ -79,7 +79,8 @@
           <button
             mat-button
             (click)="dismissJob()"
-            [matTooltip]="isJobTerminal() ? 'Dismiss this finished job' : 'Hide this panel — the run keeps going in the background'"
+            [disabled]="hasPendingQuestions()"
+            [matTooltip]="hasPendingQuestions() ? 'Answer the pending questions to continue — this run can\'t be dismissed while waiting' : isJobTerminal() ? 'Dismiss this finished job' : 'Hide this panel — the run keeps going in the background'"
           >
             <mat-icon>close</mat-icon>
             Dismiss

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.html
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.html
@@ -136,6 +136,27 @@
                 (answersSubmitted)="onAnswersSubmitted($event)"
               />
             }
+            @if (jobStatus.status === 'waiting_for_user' && !jobStatus.waiting_for_answers) {
+              <div class="github-banner github-banner--waiting" role="status">
+                <mat-icon>play_circle_outline</mat-icon>
+                <span>Answers were received but the run could not restart automatically.</span>
+                <button
+                  mat-flat-button
+                  color="accent"
+                  (click)="resumeJob()"
+                  [disabled]="resumingJob"
+                  aria-label="Resume the coding-team run"
+                >
+                  @if (resumingJob) {
+                    <mat-spinner diameter="18"></mat-spinner>
+                    Resuming…
+                  } @else {
+                    <mat-icon>play_arrow</mat-icon>
+                    Resume Run
+                  }
+                </button>
+              </div>
+            }
             @if (jobStatus.thinking) {
               <mat-expansion-panel class="thinking-panel" [expanded]="true">
                 <mat-expansion-panel-header>

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.html
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.html
@@ -63,13 +63,27 @@
       <div class="github-job-panel">
         <div class="github-job-panel__header">
           <mat-icon>engineering</mat-icon>
-          <h3>Working on issue #{{ activeJob.issue_number }}</h3>
-          @if (isJobTerminal()) {
-            <button mat-button (click)="dismissJob()">
-              <mat-icon>close</mat-icon>
-              Dismiss
-            </button>
+          <h3>
+            Working on issue
+            @if (activeJob.issue_url) {
+              <a [href]="activeJob.issue_url" target="_blank" rel="noopener">#{{ activeJob.issue_number }}</a>
+            } @else {
+              #{{ activeJob.issue_number }}
+            }
+          </h3>
+          @if (jobStatus?.waiting_for_answers) {
+            <span class="github-job-status github-job-status--waiting_for_user">
+              waiting for your answers
+            </span>
           }
+          <button
+            mat-button
+            (click)="dismissJob()"
+            [matTooltip]="isJobTerminal() ? 'Dismiss this finished job' : 'Hide this panel — the run keeps going in the background'"
+          >
+            <mat-icon>close</mat-icon>
+            Dismiss
+          </button>
         </div>
 
         <div class="github-job-panel__body">
@@ -108,6 +122,18 @@
                   }
                 </div>
               </div>
+            }
+            @if (hasPendingQuestions()) {
+              <div class="github-banner github-banner--waiting" role="status">
+                <mat-icon>help_outline</mat-icon>
+                <span>The coding team is paused and needs your decisions before it can continue.</span>
+              </div>
+              <app-pending-questions
+                [jobId]="activeJob.job_id"
+                [questions]="jobStatus.pending_questions!"
+                submitEndpoint="coding-team"
+                (answersSubmitted)="onAnswersSubmitted($any($event))"
+              />
             }
             @if (jobStatus.thinking) {
               <mat-expansion-panel class="thinking-panel" [expanded]="true">
@@ -210,6 +236,15 @@
             >
               <span class="github-issue-row__number">#{{ issue.number }}</span>
               <span class="github-issue-row__title">{{ issue.title }}</span>
+              @if (isIssueInProgress(issue)) {
+                <span
+                  class="github-label-chip github-label-chip--active"
+                  matTooltip="The coding team is already working on this issue"
+                >
+                  <mat-icon>engineering</mat-icon>
+                  In progress
+                </span>
+              }
               <span class="github-issue-row__labels">
                 @for (label of issue.labels; track label) {
                   <span class="github-label-chip">{{ label }}</span>

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.html
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.html
@@ -132,7 +132,7 @@
                 [jobId]="activeJob.job_id"
                 [questions]="jobStatus.pending_questions!"
                 submitEndpoint="coding-team"
-                (answersSubmitted)="onAnswersSubmitted($any($event))"
+                (answersSubmitted)="onAnswersSubmitted($event)"
               />
             }
             @if (jobStatus.thinking) {

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.scss
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.scss
@@ -81,6 +81,11 @@
     background: #fce8e6;
     color: #c5221f;
   }
+
+  &--waiting {
+    background: #fef7e0;
+    color: #b06000;
+  }
 }
 
 // Issue list
@@ -178,6 +183,22 @@
   font-size: 0.75rem;
   background: var(--mat-sys-secondary-container, #e8f0fe);
   color: var(--mat-sys-on-secondary-container, #1a73e8);
+
+  &--active {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    flex-shrink: 0;
+    background: #fef7e0;
+    color: #b06000;
+    font-weight: 600;
+
+    mat-icon {
+      font-size: 1rem;
+      width: 1rem;
+      height: 1rem;
+    }
+  }
 }
 
 // Confirmation panel
@@ -342,6 +363,10 @@
   &--cancelled {
     background: #f5f5f5;
     color: #80868b;
+  }
+  &--waiting_for_user {
+    background: #fef7e0;
+    color: #b06000;
   }
 }
 

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.spec.ts
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.spec.ts
@@ -435,6 +435,8 @@ describe('CodingTeamPageComponent', () => {
     it('re-attaches to a non-terminal GitHub-issue job on init', async () => {
       apiSpy.listJobs.mockReturnValue(of([GH_JOB]));
       await setup();
+      // Must request active-only so terminal jobs' full records never cross the wire.
+      expect(apiSpy.listJobs).toHaveBeenCalledWith(true);
       expect(component.activeJob?.job_id).toBe('j-restore');
       expect(component.activeJob?.issue_number).toBe(2);
       expect(component.activeJob?.issue_url).toBe('https://example.com/2');

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.spec.ts
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { of, throwError } from 'rxjs';
+import { Subject, of, throwError } from 'rxjs';
+import type { CodingTeamJobListItem } from '../../models/coding-team.model';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
@@ -51,6 +52,8 @@ describe('CodingTeamPageComponent', () => {
   let apiSpy: {
     health: ReturnType<typeof vi.fn>;
     getJobStatus: ReturnType<typeof vi.fn>;
+    submitAnswers: ReturnType<typeof vi.fn>;
+    listJobs: ReturnType<typeof vi.fn>;
   };
   let integrationsSpy: {
     getGitHubConfig: ReturnType<typeof vi.fn>;
@@ -79,6 +82,8 @@ describe('CodingTeamPageComponent', () => {
     apiSpy = {
       health: vi.fn().mockReturnValue(of({ status: 'ok' })),
       getJobStatus: vi.fn().mockReturnValue(of({ job_id: 'j1', status: 'running' })),
+      submitAnswers: vi.fn(),
+      listJobs: vi.fn().mockReturnValue(of([])),
     };
     integrationsSpy = {
       getGitHubConfig: vi.fn().mockReturnValue(of(CONFIGURED)),
@@ -342,5 +347,295 @@ describe('CodingTeamPageComponent', () => {
     fixture.detectChanges();
     const el: HTMLElement = fixture.nativeElement;
     expect(el.querySelector('.thinking-stream')).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Pending questions (human-in-the-loop)
+  // -------------------------------------------------------------------------
+
+  describe('pending questions panel', () => {
+    const QUESTION = {
+      id: 'q1',
+      question_text: 'Which auth flow?',
+      options: [{ id: 'oauth', label: 'OAuth' }],
+      required: true,
+      source: 'tech_lead',
+    };
+
+    function showActiveJob(jobStatusOverrides: Record<string, unknown>): void {
+      component.activeJob = { job_id: 'j1', issue_number: 5, issue_url: 'u', status: 'queued', message: '' };
+      component.jobStatus = { job_id: 'j1', status: 'waiting_for_user', ...jobStatusOverrides } as any;
+      fixture.detectChanges();
+    }
+
+    it('renders the questions panel and waiting banner when the job is paused', async () => {
+      await setup();
+      showActiveJob({ waiting_for_answers: true, pending_questions: [QUESTION] });
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.querySelector('.github-banner--waiting')).not.toBeNull();
+      expect(el.querySelector('app-pending-questions')).not.toBeNull();
+      expect(el.textContent).toContain('Which auth flow?');
+    });
+
+    it('hides the panel when the job is not waiting for answers', async () => {
+      await setup();
+      showActiveJob({ waiting_for_answers: false, pending_questions: [QUESTION] });
+      expect(fixture.nativeElement.querySelector('app-pending-questions')).toBeNull();
+    });
+
+    it('hides the panel when there are no pending questions', async () => {
+      await setup();
+      showActiveJob({ waiting_for_answers: true, pending_questions: [] });
+      expect(fixture.nativeElement.querySelector('app-pending-questions')).toBeNull();
+      expect(component.hasPendingQuestions()).toBe(false);
+    });
+
+    it('shows the waiting badge in the job panel header while paused', async () => {
+      await setup();
+      showActiveJob({ waiting_for_answers: true, pending_questions: [QUESTION] });
+      const badge = fixture.nativeElement.querySelector('.github-job-status--waiting_for_user');
+      expect(badge?.textContent).toContain('waiting for your answers');
+    });
+
+    it('onAnswersSubmitted folds the post-submit status in and restarts polling', async () => {
+      await setup();
+      component.activeJob = { job_id: 'j1', issue_number: 5, issue_url: 'u', status: 'queued', message: '' };
+      component['startPolling']('j1');
+      const staleSub = component['pollSub'];
+      component.issueError = 'Lost connection to the coding team — status polling failed.';
+
+      const resumed = { job_id: 'j1', status: 'running', waiting_for_answers: false };
+      component.onAnswersSubmitted(resumed as any);
+
+      expect(component.jobStatus).toEqual(resumed);
+      // Polling restarted from scratch: stale in-flight fetches are discarded.
+      expect(staleSub?.closed).toBe(true);
+      expect(component['pollSub']).not.toBeNull();
+      expect(component['pollSub']).not.toBe(staleSub);
+      // A stale "lost connection" banner is cleared — answering proves the link is back.
+      expect(component.issueError).toBeNull();
+      component['stopPolling']();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Active-job restore across reloads
+  // -------------------------------------------------------------------------
+
+  describe('active job restore', () => {
+    const GH_JOB = {
+      job_id: 'j-restore',
+      status: 'waiting_for_user',
+      phase: 'paused',
+      updated_at: '2026-06-09T10:00:00Z',
+      waiting_for_answers: true,
+      github_context: { owner: 'acme', repo: 'widgets', issue_number: 2, issue_url: 'https://example.com/2' },
+    };
+
+    it('re-attaches to a non-terminal GitHub-issue job on init', async () => {
+      apiSpy.listJobs.mockReturnValue(of([GH_JOB]));
+      await setup();
+      expect(component.activeJob?.job_id).toBe('j-restore');
+      expect(component.activeJob?.issue_number).toBe(2);
+      expect(component.activeJob?.issue_url).toBe('https://example.com/2');
+      // The poller's first fetch is immediate (timer(0)), so the restored
+      // panel is hydrated without waiting a full poll interval.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(apiSpy.getJobStatus).toHaveBeenCalledWith('j-restore');
+      expect(component.activeIssueNumbers.has(2)).toBe(true);
+      component['stopPolling']();
+    });
+
+    it('ignores jobs belonging to a different repository', async () => {
+      apiSpy.listJobs.mockReturnValue(
+        of([
+          { ...GH_JOB, github_context: { ...GH_JOB.github_context, repo: 'other-repo' } },
+          { ...GH_JOB, job_id: 'other-owner', github_context: { ...GH_JOB.github_context, owner: 'someone-else' } },
+        ]),
+      );
+      await setup();
+      expect(component.activeJob).toBeNull();
+      expect(component.activeIssueNumbers.size).toBe(0);
+    });
+
+    it('does not restore at all when GitHub is not configured', async () => {
+      integrationsSpy.getGitHubConfig.mockReturnValue(of({ ...CONFIGURED, token_configured: false }));
+      apiSpy.listJobs.mockReturnValue(of([GH_JOB]));
+      await setup();
+      expect(apiSpy.listJobs).not.toHaveBeenCalled();
+      expect(component.activeJob).toBeNull();
+    });
+
+    it('does not adopt a job when the list resolves after destroy', async () => {
+      const jobs$ = new Subject<CodingTeamJobListItem[]>();
+      apiSpy.listJobs.mockReturnValue(jobs$.asObservable());
+      await setup();
+      fixture.destroy();
+      jobs$.next([GH_JOB]);
+      expect(component.activeJob).toBeNull();
+      expect(component['pollSub']).toBeNull();
+    });
+
+    it('ignores terminal jobs and jobs without a GitHub issue', async () => {
+      apiSpy.listJobs.mockReturnValue(
+        of([
+          { ...GH_JOB, job_id: 'done', status: 'completed' },
+          { job_id: 'local-run', status: 'running', repo_path: '/tmp/x' },
+        ]),
+      );
+      await setup();
+      expect(component.activeJob).toBeNull();
+      expect(component.activeIssueNumbers.size).toBe(0);
+    });
+
+    it('picks the most recently updated job when several are active', async () => {
+      apiSpy.listJobs.mockReturnValue(
+        of([
+          { ...GH_JOB, job_id: 'older', updated_at: '2026-06-08T10:00:00Z' },
+          {
+            ...GH_JOB,
+            job_id: 'newer',
+            updated_at: '2026-06-09T11:00:00Z',
+            github_context: { ...GH_JOB.github_context, issue_number: 3 },
+          },
+        ]),
+      );
+      await setup();
+      expect(component.activeJob?.job_id).toBe('newer');
+      // Both issues are still flagged as in progress.
+      expect(component.activeIssueNumbers).toEqual(new Set([2, 3]));
+      component['stopPolling']();
+    });
+
+    it('does not replace a job the user just started', async () => {
+      await setup();
+      component.activeJob = { job_id: 'mine', issue_number: 9, issue_url: '', status: 'queued', message: '' };
+      apiSpy.listJobs.mockReturnValue(of([GH_JOB]));
+      component['restoreActiveJob']();
+      expect(component.activeJob.job_id).toBe('mine');
+      expect(component.activeIssueNumbers.has(2)).toBe(true);
+    });
+
+    it('stays usable when the job list cannot be fetched', async () => {
+      apiSpy.listJobs.mockReturnValue(throwError(() => new Error('down')));
+      await setup();
+      expect(component.activeJob).toBeNull();
+      expect(component.githubConfigured).toBe(true);
+    });
+
+    it('renders an "In progress" chip on issues with an active job', async () => {
+      apiSpy.listJobs.mockReturnValue(
+        of([{ ...GH_JOB, github_context: { ...GH_JOB.github_context, issue_number: 2 } }]),
+      );
+      await setup();
+      // Dismiss the restored job so the issue list is visible again.
+      component.dismissJob();
+      fixture.detectChanges();
+      const chips = fixture.nativeElement.querySelectorAll('.github-label-chip--active');
+      expect(chips.length).toBe(1);
+      expect(chips[0].textContent).toContain('In progress');
+      component['stopPolling']();
+    });
+
+    it('marks a just-started issue as in progress', async () => {
+      await setup();
+      const issue = component.issues[0];
+      integrationsSpy.runGitHubIssue.mockReturnValue(
+        of({ job_id: 'j1', issue_number: issue.number, issue_url: 'u', status: 'queued', message: '' }),
+      );
+      component.selectIssue(issue);
+      component.confirmAndRun();
+      expect(component.isIssueInProgress(issue)).toBe(true);
+      component['stopPolling']();
+    });
+
+    it('removes the in-progress chip when the poller observes a terminal status', async () => {
+      await setup();
+      component.activeJob = { job_id: 'j1', issue_number: 7, issue_url: 'u', status: 'queued', message: '' };
+      component.activeIssueNumbers.add(7);
+      apiSpy.getJobStatus.mockReturnValue(of({ job_id: 'j1', status: 'completed' }));
+      component['startPolling']('j1');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(component.activeIssueNumbers.has(7)).toBe(false);
+    });
+
+    it('dismissing a finished job removes its chip; dismissing a running one keeps it', async () => {
+      await setup();
+      // Running case: the server still lists the job after dismiss, so the chip survives
+      // — but the dismissed job itself is never re-adopted into the panel.
+      apiSpy.listJobs.mockReturnValue(
+        of([
+          {
+            job_id: 'j1',
+            status: 'running',
+            github_context: { owner: 'acme', repo: 'widgets', issue_number: 7 },
+          },
+        ]),
+      );
+      component.activeJob = { job_id: 'j1', issue_number: 7, issue_url: 'u', status: 'queued', message: '' };
+      component.activeIssueNumbers.add(7);
+      component.jobStatus = { job_id: 'j1', status: 'running' };
+      component.dismissJob();
+      expect(component.activeIssueNumbers.has(7)).toBe(true);
+      expect(component.activeJob).toBeNull();
+
+      // Finished case: the active-jobs list no longer contains it → chip removed.
+      apiSpy.listJobs.mockReturnValue(of([]));
+      component.activeJob = { job_id: 'j2', issue_number: 7, issue_url: 'u', status: 'queued', message: '' };
+      component.jobStatus = { job_id: 'j2', status: 'completed' };
+      component.dismissJob();
+      expect(component.activeIssueNumbers.has(7)).toBe(false);
+      expect(component.activeJob).toBeNull();
+    });
+
+    it('dismissing one job adopts another active, non-dismissed job', async () => {
+      apiSpy.listJobs.mockReturnValue(
+        of([
+          { ...GH_JOB, job_id: 'j-a', updated_at: '2026-06-09T12:00:00Z' },
+          {
+            ...GH_JOB,
+            job_id: 'j-b',
+            updated_at: '2026-06-09T11:00:00Z',
+            github_context: { ...GH_JOB.github_context, issue_number: 3 },
+          },
+        ]),
+      );
+      await setup();
+      expect(component.activeJob?.job_id).toBe('j-a');
+
+      component.jobStatus = { job_id: 'j-a', status: 'running' };
+      component.dismissJob();
+      // The dismissed job is excluded; the other in-flight job takes the panel.
+      expect(component.activeJob?.job_id).toBe('j-b');
+      expect(component.activeJob?.issue_number).toBe(3);
+      component['stopPolling']();
+    });
+
+    it('matches the configured repository case-insensitively', async () => {
+      apiSpy.listJobs.mockReturnValue(
+        of([{ ...GH_JOB, github_context: { ...GH_JOB.github_context, owner: 'Acme', repo: 'Widgets' } }]),
+      );
+      await setup();
+      expect(component.activeJob?.job_id).toBe('j-restore');
+      expect(component.activeIssueNumbers.has(2)).toBe(true);
+      component['stopPolling']();
+    });
+
+    it('a stale jobs snapshot cannot wipe the chip of a just-started run', async () => {
+      await setup();
+      component.activeJob = { job_id: 'mine', issue_number: 9, issue_url: '', status: 'queued', message: '' };
+      apiSpy.listJobs.mockReturnValue(of([]));
+      component['restoreActiveJob']();
+      expect(component.activeIssueNumbers.has(9)).toBe(true);
+    });
+
+    it('renders the Dismiss button even while the job is non-terminal', async () => {
+      await setup();
+      component.activeJob = { job_id: 'j1', issue_number: 7, issue_url: 'u', status: 'queued', message: '' };
+      component.jobStatus = { job_id: 'j1', status: 'waiting_for_user' };
+      fixture.detectChanges();
+      const header = fixture.nativeElement.querySelector('.github-job-panel__header');
+      expect(header?.textContent).toContain('Dismiss');
+    });
   });
 });

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.spec.ts
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.spec.ts
@@ -624,9 +624,20 @@ describe('CodingTeamPageComponent', () => {
     it('a stale jobs snapshot cannot wipe the chip of a just-started run', async () => {
       await setup();
       component.activeJob = { job_id: 'mine', issue_number: 9, issue_url: '', status: 'queued', message: '' };
+      component.jobStatus = { job_id: 'mine', status: 'running' };
       apiSpy.listJobs.mockReturnValue(of([]));
       component['restoreActiveJob']();
       expect(component.activeIssueNumbers.has(9)).toBe(true);
+    });
+
+    it('does not re-add the chip for a displayed job that has finished', async () => {
+      await setup();
+      // The poller dropped #9 when the job went terminal; a refresh must not resurrect it.
+      component.activeJob = { job_id: 'mine', issue_number: 9, issue_url: '', status: 'queued', message: '' };
+      component.jobStatus = { job_id: 'mine', status: 'completed' };
+      apiSpy.listJobs.mockReturnValue(of([]));
+      component['restoreActiveJob']();
+      expect(component.activeIssueNumbers.has(9)).toBe(false);
     });
 
     it('renders the Dismiss button even while the job is non-terminal', async () => {

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
@@ -278,7 +278,9 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
         };
         this.startPolling(mostRecent.job_id);
       },
-      error: () => undefined,
+      // Best-effort restore: the page stays usable if /jobs fails, but log it so a persistent
+      // failure is diagnosable rather than silently swallowed.
+      error: (err) => console.error('Failed to restore active coding-team job', err),
     });
   }
 
@@ -318,9 +320,12 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
       jobId,
       (status) => {
         this.jobStatus = status;
-        // The watched job finished: its issue is no longer being worked on.
+        // The watched job finished: re-sync the whole active-job snapshot from the server rather
+        // than only dropping this job's chip, so any background jobs that also finished lose their
+        // "In progress" chips too. restoreActiveJob won't re-adopt here because activeJob is still
+        // set (the finished panel stays until the user dismisses it).
         if (this.activeJob && isCodingTeamTerminalStatus(status.status)) {
-          this.activeIssueNumbers.delete(this.activeJob.issue_number);
+          this.restoreActiveJob();
         }
       },
       () => {
@@ -348,6 +353,12 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
    * job for this repo via `restoreActiveJob`.
    */
   dismissJob(): void {
+    // A job paused on questions the user must answer cannot be dismissed: restore excludes
+    // dismissed ids and re-running the issue is rejected as a duplicate active run, so dismissing
+    // would strand the run with no way to reopen it and answer. Keep the panel until it's answered.
+    if (this.hasPendingQuestions()) {
+      return;
+    }
     if (this.activeJob) {
       // Never auto-re-adopt a job the user explicitly dismissed.
       this.dismissedJobIds.add(this.activeJob.job_id);

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
@@ -15,7 +15,10 @@ import { IntegrationsApiService } from '../../services/integrations-api.service'
 import { pollJobStatus } from '../../services/job-status-poller';
 import { HealthIndicatorComponent } from '../health-indicator/health-indicator.component';
 import { TeamAssistantChatComponent } from '../team-assistant-chat/team-assistant-chat.component';
-import { PendingQuestionsComponent } from '../pending-questions/pending-questions.component';
+import {
+  PendingQuestionsComponent,
+  type AnswersSubmittedStatus,
+} from '../pending-questions/pending-questions.component';
 import type { GitHubIssueItem, RunGitHubIssueResponse } from '../../models/integrations.model';
 import type { CodingTeamJobStatus } from '../../models/coding-team.model';
 import { isCodingTeamTerminalStatus } from '../../models/job-status.model';
@@ -272,8 +275,10 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
    * revives polling after a connection loss (answering proves the connection
    * is back), so the stale "lost connection" error is cleared too.
    */
-  onAnswersSubmitted(status: CodingTeamJobStatus): void {
-    this.jobStatus = status;
+  onAnswersSubmitted(status: AnswersSubmittedStatus): void {
+    // This page always configures the panel with submitEndpoint="coding-team",
+    // so the emitted union member is always the coding-team status shape.
+    this.jobStatus = status as CodingTeamJobStatus;
     this.issueError = null;
     if (this.activeJob) {
       this.startPolling(this.activeJob.job_id);

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
@@ -15,8 +15,9 @@ import { IntegrationsApiService } from '../../services/integrations-api.service'
 import { pollJobStatus } from '../../services/job-status-poller';
 import { HealthIndicatorComponent } from '../health-indicator/health-indicator.component';
 import { TeamAssistantChatComponent } from '../team-assistant-chat/team-assistant-chat.component';
+import { PendingQuestionsComponent } from '../pending-questions/pending-questions.component';
 import type { GitHubIssueItem, RunGitHubIssueResponse } from '../../models/integrations.model';
-import type { CodingTeamJobStatus } from '../../models/coding-team.model';
+import type { CodingTeamJobListItem, CodingTeamJobStatus } from '../../models/coding-team.model';
 import { isCodingTeamTerminalStatus } from '../../models/job-status.model';
 
 @Component({
@@ -35,6 +36,7 @@ import { isCodingTeamTerminalStatus } from '../../models/job-status.model';
     RouterLink,
     HealthIndicatorComponent,
     TeamAssistantChatComponent,
+    PendingQuestionsComponent,
   ],
   templateUrl: './coding-team-page.component.html',
   styleUrl: './coding-team-page.component.scss',
@@ -72,6 +74,13 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
   activeJob: RunGitHubIssueResponse | null = null;
   jobStatus: CodingTeamJobStatus | null = null;
   private pollSub: Subscription | null = null;
+  private restoreSub: Subscription | null = null;
+
+  /** Issue numbers with a non-terminal coding-team job, for "In progress" chips. */
+  activeIssueNumbers = new Set<number>();
+
+  /** Jobs the user dismissed this session — never re-adopted into the panel automatically. */
+  private dismissedJobIds = new Set<string>();
 
   ngOnInit(): void {
     this.checkGitHubConfig();
@@ -79,6 +88,8 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.stopPolling();
+    this.restoreSub?.unsubscribe();
+    this.restoreSub = null;
   }
 
   checkGitHubConfig(): void {
@@ -90,6 +101,9 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
         this.githubRepo = cfg.repo;
         this.loadingConfig = false;
         if (this.githubConfigured) {
+          // loadIssues also refreshes the active-jobs snapshot; restore happens only
+          // once the configured owner/repo is known, so jobs from other repositories
+          // are never matched against this page's issues.
           this.loadIssues();
         }
       },
@@ -104,6 +118,9 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
     this.loadingIssues = true;
     this.issueError = null;
     this.selectedIssue = null;
+    // Refreshing the issue list also refreshes the "In progress" chips (and adopts an
+    // in-flight job if none is shown), so the list and the jobs snapshot never drift.
+    this.restoreActiveJob();
     this.integrationsApi.getGitHubIssues().subscribe({
       next: (issues) => {
         this.issues = issues;
@@ -169,6 +186,7 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
     this.integrationsApi.runGitHubIssue({ issue_number: this.selectedIssue.number }).subscribe({
       next: (resp: RunGitHubIssueResponse) => {
         this.activeJob = resp;
+        this.activeIssueNumbers.add(resp.issue_number);
         this.selectedIssue = null;
         this.runningIssue = false;
         this.startPolling(resp.job_id);
@@ -180,6 +198,89 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
     });
   }
 
+  /**
+   * Re-attach the page to a coding-team run already in flight (e.g. after a
+   * page reload), so the "working on issue #N" indicator and any pending
+   * questions survive navigation. Also the single source for the issue list's
+   * "In progress" chips — called on every issue refresh and on dismiss so the
+   * chips track the server's view instead of local bookkeeping.
+   *
+   * Preconditions: the GitHub integration is configured (`githubOwner`/`githubRepo`
+   * are set) — only jobs for this repository (owner/repo compared
+   * case-insensitively, as GitHub does) are considered.
+   * Postconditions: `activeIssueNumbers` holds every non-terminal job for this
+   * repo plus the currently displayed job (a snapshot taken before a just-started
+   * run must not wipe its chip); when no job is displayed, the most recently
+   * updated non-dismissed one is adopted as `activeJob` and polling started
+   * (the poller's first fetch is immediate). List fetch failures leave the page
+   * usable (silent no-op).
+   */
+  private restoreActiveJob(): void {
+    const owner = this.githubOwner.toLowerCase();
+    const repo = this.githubRepo.toLowerCase();
+    this.restoreSub?.unsubscribe();
+    this.restoreSub = this.api.listJobs().subscribe({
+      next: (jobs) => {
+        const candidates = jobs.filter(
+          (j) =>
+            !isCodingTeamTerminalStatus(j.status) &&
+            j.github_context?.issue_number != null &&
+            j.github_context.owner.toLowerCase() === owner &&
+            j.github_context.repo.toLowerCase() === repo,
+        );
+        const issueNumbers = new Set(candidates.map((j) => j.github_context!.issue_number!));
+        if (this.activeJob) {
+          issueNumbers.add(this.activeJob.issue_number);
+        }
+        this.activeIssueNumbers = issueNumbers;
+
+        const adoptable = candidates.filter((j) => !this.dismissedJobIds.has(j.job_id));
+        if (this.activeJob || adoptable.length === 0) return;
+
+        const mostRecent = adoptable.reduce((best, j) =>
+          (j.updated_at ?? '').localeCompare(best.updated_at ?? '') > 0 ? j : best,
+        );
+        const ctx = mostRecent.github_context!;
+        this.activeJob = {
+          job_id: mostRecent.job_id,
+          issue_number: ctx.issue_number!,
+          issue_url: ctx.issue_url ?? '',
+          status: mostRecent.status,
+          message: '',
+        };
+        this.startPolling(mostRecent.job_id);
+      },
+      error: () => undefined,
+    });
+  }
+
+  /** True when the job is paused on questions the user must answer. */
+  hasPendingQuestions(): boolean {
+    return !!this.jobStatus?.waiting_for_answers && (this.jobStatus?.pending_questions?.length ?? 0) > 0;
+  }
+
+  /**
+   * Fold the post-submit status into the panel and restart polling from scratch.
+   *
+   * Restarting (rather than letting the old poller run on) discards any status
+   * fetch that was already in flight before the answers were stored — a stale
+   * response would otherwise re-render the just-answered questions — and also
+   * revives polling after a connection loss (answering proves the connection
+   * is back), so the stale "lost connection" error is cleared too.
+   */
+  onAnswersSubmitted(status: CodingTeamJobStatus): void {
+    this.jobStatus = status;
+    this.issueError = null;
+    if (this.activeJob) {
+      this.startPolling(this.activeJob.job_id);
+    }
+  }
+
+  /** True when a non-terminal coding-team job is already working this issue. */
+  isIssueInProgress(issue: GitHubIssueItem): boolean {
+    return this.activeIssueNumbers.has(issue.number);
+  }
+
   private startPolling(jobId: string): void {
     this.stopPolling();
     this.pollSub = pollJobStatus(
@@ -187,6 +288,10 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
       jobId,
       (status) => {
         this.jobStatus = status;
+        // The watched job finished: its issue is no longer being worked on.
+        if (this.activeJob && isCodingTeamTerminalStatus(status.status)) {
+          this.activeIssueNumbers.delete(this.activeJob.issue_number);
+        }
       },
       () => {
         this.issueError = 'Lost connection to the coding team — status polling failed.';
@@ -207,9 +312,22 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
   }
 
   dismissJob(): void {
+    if (this.activeJob) {
+      // Never auto-re-adopt a job the user explicitly dismissed.
+      this.dismissedJobIds.add(this.activeJob.job_id);
+      // A finished job's issue is no longer in progress; a still-running job the
+      // user merely hides keeps its chip so the issue list stays truthful (the
+      // refresh below confirms either way against the server).
+      if (this.isJobTerminal()) {
+        this.activeIssueNumbers.delete(this.activeJob.issue_number);
+      }
+    }
     this.stopPolling();
     this.activeJob = null;
     this.jobStatus = null;
+    // Re-sync chips with the server and surface any other in-flight job for this
+    // repo (e.g. one started in another tab) now that the panel is free.
+    this.restoreActiveJob();
   }
 
   onWorkflowLaunched(event: { job_id: string | null; conversation_id: string }): void {

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
@@ -17,7 +17,7 @@ import { HealthIndicatorComponent } from '../health-indicator/health-indicator.c
 import { TeamAssistantChatComponent } from '../team-assistant-chat/team-assistant-chat.component';
 import { PendingQuestionsComponent } from '../pending-questions/pending-questions.component';
 import type { GitHubIssueItem, RunGitHubIssueResponse } from '../../models/integrations.model';
-import type { CodingTeamJobListItem, CodingTeamJobStatus } from '../../models/coding-team.model';
+import type { CodingTeamJobStatus } from '../../models/coding-team.model';
 import { isCodingTeamTerminalStatus } from '../../models/job-status.model';
 
 @Component({
@@ -221,6 +221,10 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
     this.restoreSub?.unsubscribe();
     this.restoreSub = this.api.listJobs().subscribe({
       next: (jobs) => {
+        // listJobs() already filters to active jobs server-side; the terminal check is
+        // a defensive belt — the backend's non-terminal status set and this client's
+        // terminal list are maintained independently, and adopting a finished job would
+        // pin a dead panel on screen if they ever drift.
         const candidates = jobs.filter(
           (j) =>
             !isCodingTeamTerminalStatus(j.status) &&

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
@@ -313,6 +313,31 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
     return this.activeIssueNumbers.has(issue.number);
   }
 
+  /** True while a manual resume POST is in flight (drives a spinner on the Resume button). */
+  resumingJob = false;
+
+  /**
+   * Restart the active job's orchestrator after answers were stored but auto-resume failed. No-op
+   * when no active job is displayed. On success, restarts polling from scratch; on error, surfaces
+   * `issueError`.
+   */
+  resumeJob(): void {
+    if (!this.activeJob) return;
+    const jobId = this.activeJob.job_id;
+    this.resumingJob = true;
+    this.issueError = null;
+    this.api.resumeJob(jobId).subscribe({
+      next: () => {
+        this.resumingJob = false;
+        this.startPolling(jobId);
+      },
+      error: (err: { error?: { detail?: string }; message?: string }) => {
+        this.resumingJob = false;
+        this.issueError = err?.error?.detail ?? err?.message ?? 'Failed to resume job.';
+      },
+    });
+  }
+
   private startPolling(jobId: string): void {
     this.stopPolling();
     this.pollSub = pollJobStatus(

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
@@ -95,6 +95,12 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
     this.restoreSub = null;
   }
 
+  /**
+   * Load the configured GitHub integration (enabled flag, token, owner/repo) and gate the page on
+   * it. On success, marks the page configured only when all of enabled/token/owner/repo are present
+   * and — once the owner/repo is known — kicks off the first issue load; on error, leaves the page
+   * in the unconfigured state. Sets `loadingConfig` for the duration.
+   */
   checkGitHubConfig(): void {
     this.loadingConfig = true;
     this.integrationsApi.getGitHubConfig().subscribe({
@@ -117,6 +123,11 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
     });
   }
 
+  /**
+   * Refresh the open-issue list and the active-jobs snapshot together so they never drift. Resets
+   * the selection/pagination, re-syncs the "In progress" chips (adopting an in-flight job if none
+   * is shown) via `restoreActiveJob`, then fetches issues. Sets `issueError` on failure.
+   */
   loadIssues(): void {
     this.loadingIssues = true;
     this.issueError = null;
@@ -149,6 +160,7 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
     this.pageSize = event.pageSize;
   }
 
+  /** Select an issue, surfacing the run-confirmation affordance for it. */
   selectIssue(issue: GitHubIssueItem): void {
     this.selectedIssue = issue;
   }
@@ -182,6 +194,11 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
       : `Depends on ${this.allDepRefs(issue)} (all complete)`;
   }
 
+  /**
+   * Start a coding-team run for the selected issue. No-op when nothing is selected. On success,
+   * adopts the returned job as the active panel, marks its issue in progress, clears the selection,
+   * and begins polling its status; on error, surfaces `issueError`. Toggles `runningIssue`.
+   */
   confirmAndRun(): void {
     if (!this.selectedIssue) return;
     this.runningIssue = true;
@@ -222,12 +239,12 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
     const owner = this.githubOwner.toLowerCase();
     const repo = this.githubRepo.toLowerCase();
     this.restoreSub?.unsubscribe();
-    this.restoreSub = this.api.listJobs().subscribe({
+    this.restoreSub = this.api.listJobs(true).subscribe({
       next: (jobs) => {
-        // listJobs() already filters to active jobs server-side; the terminal check is
-        // a defensive belt — the backend's non-terminal status set and this client's
-        // terminal list are maintained independently, and adopting a finished job would
-        // pin a dead panel on screen if they ever drift.
+        // listJobs(true) requests ?active=true so terminal jobs' full records never cross the
+        // wire; the terminal check below is a defensive belt — the backend's non-terminal status
+        // set and this client's terminal list are maintained independently, and adopting a
+        // finished job would pin a dead panel on screen if they ever drift.
         const candidates = jobs.filter(
           (j) =>
             !isCodingTeamTerminalStatus(j.status) &&
@@ -324,6 +341,12 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
     return isCodingTeamTerminalStatus(this.jobStatus?.status);
   }
 
+  /**
+   * Dismiss the displayed job panel. Records the job id so it is never auto-re-adopted; drops its
+   * issue chip only when the job is terminal (a still-running job the user merely hides keeps its
+   * chip). Stops polling, clears the panel, then re-syncs chips and surfaces any other in-flight
+   * job for this repo via `restoreActiveJob`.
+   */
   dismissJob(): void {
     if (this.activeJob) {
       // Never auto-re-adopt a job the user explicitly dismissed.

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
@@ -236,7 +236,11 @@ export class CodingTeamPageComponent implements OnInit, OnDestroy {
             j.github_context.repo.toLowerCase() === repo,
         );
         const issueNumbers = new Set(candidates.map((j) => j.github_context!.issue_number!));
-        if (this.activeJob) {
+        // Merge the displayed job's issue so a stale snapshot can't wipe a just-started run's
+        // chip — but ONLY while that job is still non-terminal. Once it finishes, the poller has
+        // already dropped its chip, and /jobs?active=true no longer lists it, so re-adding here
+        // would wrongly re-label a completed issue "In progress" until the panel is dismissed.
+        if (this.activeJob && !this.isJobTerminal()) {
           issueNumbers.add(this.activeJob.issue_number);
         }
         this.activeIssueNumbers = issueNumbers;

--- a/user-interface/src/app/components/pending-questions/pending-questions.component.html
+++ b/user-interface/src/app/components/pending-questions/pending-questions.component.html
@@ -28,6 +28,7 @@
             [autoAnswerResult]="getAutoAnswerResult(question.id)"
             [isAutoAnswering]="isAutoAnswering(question.id)"
             [isAnswered]="isQuestionAnswered(question)"
+            [autoAnswerEnabled]="autoAnswerEnabled"
             (optionToggled)="onQuestionOptionToggled(question.id, $event)"
             (otherTextChanged)="onQuestionOtherTextChanged(question.id, $event)"
             (autoAnswerRequested)="autoAnswerQuestion(question)"
@@ -49,7 +50,7 @@
       <button
         mat-raised-button
         color="primary"
-        [disabled]="!allRequiredAnswered || submitting"
+        [disabled]="!allAnswersSubmittable || submitting"
         (click)="submitAnswers()"
       >
         @if (submitting) {

--- a/user-interface/src/app/components/pending-questions/pending-questions.component.spec.ts
+++ b/user-interface/src/app/components/pending-questions/pending-questions.component.spec.ts
@@ -4,6 +4,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { vi } from 'vitest';
 import { SoftwareEngineeringApiService } from '../../services/software-engineering-api.service';
 import { PlanningV3ApiService } from '../../services/planning-v3-api.service';
+import { CodingTeamApiService } from '../../services/coding-team-api.service';
 import { PendingQuestionsComponent } from './pending-questions.component';
 
 describe('PendingQuestionsComponent', () => {
@@ -15,6 +16,7 @@ describe('PendingQuestionsComponent', () => {
     submitProductAnalysisAnswers: ReturnType<typeof vi.fn>;
   };
   let planningV3ApiSpy: { submitAnswers: ReturnType<typeof vi.fn> };
+  let codingTeamApiSpy: { submitAnswers: ReturnType<typeof vi.fn> };
 
   const mockQuestion = {
     id: 'q1',
@@ -30,12 +32,14 @@ describe('PendingQuestionsComponent', () => {
       submitProductAnalysisAnswers: vi.fn(),
     };
     planningV3ApiSpy = { submitAnswers: vi.fn() };
+    codingTeamApiSpy = { submitAnswers: vi.fn() };
 
     await TestBed.configureTestingModule({
       imports: [PendingQuestionsComponent, NoopAnimationsModule],
       providers: [
         { provide: SoftwareEngineeringApiService, useValue: apiSpy },
         { provide: PlanningV3ApiService, useValue: planningV3ApiSpy },
+        { provide: CodingTeamApiService, useValue: codingTeamApiSpy },
       ],
     }).compileComponents();
 
@@ -287,5 +291,139 @@ describe('PendingQuestionsComponent', () => {
   it('getAutoAnswerResult returns set value', () => {
     component.autoAnswerResults.set('q1', { selected_option_id: 'a1' } as any);
     expect(component.getAutoAnswerResult('q1')).toBeDefined();
+  });
+
+  it('should call CodingTeamApiService.submitAnswers when submitEndpoint is coding-team', () => {
+    component.submitEndpoint = 'coding-team';
+    component.questions = [{ ...mockQuestion, required: false } as any];
+    component.initializeAnswers();
+    component.getAnswer('q1')!.selectedOptionIds.add('a1');
+    component.answers = new Map(component.answers);
+
+    const mockStatus = { job_id: 'job-1', status: 'running', waiting_for_answers: false };
+    codingTeamApiSpy.submitAnswers.mockReturnValue(of(mockStatus));
+
+    let emitted: any;
+    component.answersSubmitted.subscribe((r) => (emitted = r));
+    component.submitAnswers();
+
+    expect(codingTeamApiSpy.submitAnswers).toHaveBeenCalledWith('job-1', {
+      answers: [{ question_id: 'q1', selected_option_id: 'a1', other_text: null }],
+    });
+    // The coding-team backend contract is single-select: no multi-select field.
+    const body = codingTeamApiSpy.submitAnswers.mock.calls[0][1];
+    expect('selected_option_ids' in body.answers[0]).toBe(false);
+    expect(emitted).toEqual(mockStatus);
+  });
+
+  it('coding-team submit error path sets error', () => {
+    component.submitEndpoint = 'coding-team';
+    component.questions = [{ ...mockQuestion, required: false } as any];
+    component.initializeAnswers();
+    component.getAnswer('q1')!.selectedOptionIds.add('a1');
+    component.answers = new Map(component.answers);
+
+    codingTeamApiSpy.submitAnswers.mockReturnValue(
+      throwError(() => ({ error: { detail: 'Job is not waiting for answers.' } })),
+    );
+    component.submitAnswers();
+
+    expect(component.error).toContain('not waiting');
+    expect(component.submitting).toBe(false);
+  });
+
+  it('autoAnswerEnabled is false for coding-team and planning-v3, true otherwise', () => {
+    component.submitEndpoint = 'coding-team';
+    expect(component.autoAnswerEnabled).toBe(false);
+    component.submitEndpoint = 'planning-v3';
+    expect(component.autoAnswerEnabled).toBe(false);
+    component.submitEndpoint = 'run-team';
+    expect(component.autoAnswerEnabled).toBe(true);
+    component.submitEndpoint = 'product-analysis';
+    expect(component.autoAnswerEnabled).toBe(true);
+  });
+
+  it('an out-of-union endpoint surfaces an error instead of stranding the submit spinner', () => {
+    component.submitEndpoint = 'bogus-endpoint' as any;
+    component.questions = [{ ...mockQuestion, required: false } as any];
+    component.initializeAnswers();
+    component.getAnswer('q1')!.selectedOptionIds.add('a1');
+    component.answers = new Map(component.answers);
+
+    component.submitAnswers();
+
+    expect(component.submitting).toBe(false);
+    expect(component.error).toContain('Unsupported submit endpoint');
+  });
+
+  it('autoAnswerQuestion no-op for coding-team (user-only decisions)', () => {
+    component.submitEndpoint = 'coding-team';
+    component.autoAnswerQuestion(mockQuestion as any);
+    expect(component.hasAutoAnswerResult('q1')).toBe(false);
+    expect(component.isAutoAnswering('q1')).toBe(false);
+  });
+
+  it('single-select toggle replaces the previous selection', () => {
+    component.onQuestionOptionToggled('q1', { optionId: 'a1', checked: true });
+    component.onQuestionOptionToggled('q1', { optionId: 'other', checked: true });
+    const ids = component.getAnswer('q1')!.selectedOptionIds;
+    expect(ids.has('a1')).toBe(false);
+    expect(ids.has('other')).toBe(true);
+    expect(ids.size).toBe(1);
+  });
+
+  it('single-select toggle away from "other" clears otherText', () => {
+    component.onQuestionOptionToggled('q1', { optionId: 'other', checked: true });
+    component.onQuestionOtherTextChanged('q1', 'custom answer');
+    component.onQuestionOptionToggled('q1', { optionId: 'a1', checked: true });
+    expect(component.getAnswer('q1')!.otherText).toBe('');
+    expect(component.getAnswer('q1')!.selectedOptionIds.has('other')).toBe(false);
+  });
+
+  it('blocks submission while an optional question is half-answered (blank "other")', () => {
+    const required = { ...mockQuestion, id: 'q1', required: true };
+    const optional = { ...mockQuestion, id: 'q2', required: false };
+    fixture.componentRef.setInput('questions', [required as any, optional as any]);
+    fixture.detectChanges();
+
+    component.onQuestionOptionToggled('q1', { optionId: 'a1', checked: true });
+    component.onQuestionOptionToggled('q2', { optionId: 'other', checked: true });
+
+    // Required answered, but the optional 'other' has no text — the backend
+    // would 400 the whole batch, so the gate must hold.
+    expect(component.allRequiredAnswered).toBe(true);
+    expect(component.allAnswersSubmittable).toBe(false);
+    component.submitAnswers();
+    expect(apiSpy.submitAnswers).not.toHaveBeenCalled();
+
+    component.onQuestionOtherTextChanged('q2', 'now valid');
+    expect(component.allAnswersSubmittable).toBe(true);
+  });
+
+  it('allows submission when an optional question is left untouched', () => {
+    const required = { ...mockQuestion, id: 'q1', required: true };
+    const optional = { ...mockQuestion, id: 'q2', required: false };
+    fixture.componentRef.setInput('questions', [required as any, optional as any]);
+    fixture.detectChanges();
+
+    component.onQuestionOptionToggled('q1', { optionId: 'a1', checked: true });
+    expect(component.allAnswersSubmittable).toBe(true);
+
+    apiSpy.submitAnswers.mockReturnValue(of({ job_id: 'job-1', status: 'running' }));
+    component.submitAnswers();
+    // The untouched optional question is omitted from the submission entirely.
+    const body = apiSpy.submitAnswers.mock.calls[0][1];
+    expect(body.answers.map((a: { question_id: string }) => a.question_id)).toEqual(['q1']);
+  });
+
+  it('multi-select questions still accumulate selections', () => {
+    const multiQuestion = { ...mockQuestion, allow_multiple: true };
+    fixture.componentRef.setInput('questions', [multiQuestion as any]);
+    fixture.detectChanges();
+    component.onQuestionOptionToggled('q1', { optionId: 'a1', checked: true });
+    component.onQuestionOptionToggled('q1', { optionId: 'other', checked: true });
+    const ids = component.getAnswer('q1')!.selectedOptionIds;
+    expect(ids.has('a1')).toBe(true);
+    expect(ids.has('other')).toBe(true);
   });
 });

--- a/user-interface/src/app/components/pending-questions/pending-questions.component.ts
+++ b/user-interface/src/app/components/pending-questions/pending-questions.component.ts
@@ -290,6 +290,7 @@ export class PendingQuestionsComponent implements OnChanges {
   applyAutoAnswer(questionId: string): void {
     const result = this.autoAnswerResults.get(questionId);
     if (!result || !this.jobId) return;
+    const jobId = this.jobId;
 
     // Mark as submitting (reuse autoAnsweringQuestions set for spinner)
     this.autoAnsweringQuestions.add(questionId);
@@ -303,7 +304,7 @@ export class PendingQuestionsComponent implements OnChanges {
     };
     const request = { answers: [submission] };
 
-    this.getSubmitObservable(request).subscribe({
+    this.getSubmitObservable(jobId, request).subscribe({
       next: (statusResponse) => {
         this.autoAnsweringQuestions.delete(questionId);
         this.autoAnswerResults.delete(questionId);
@@ -319,6 +320,7 @@ export class PendingQuestionsComponent implements OnChanges {
   }
 
   private getSubmitObservable(
+    jobId: string,
     request: { answers: AnswerSubmission[] }
   ): Observable<
     | JobStatusResponse
@@ -335,12 +337,12 @@ export class PendingQuestionsComponent implements OnChanges {
           selected_option_ids: a.selected_option_ids,
           other_text: a.other_text ?? undefined,
         }));
-        return this.planningV3Api.submitAnswers(this.jobId!, body);
+        return this.planningV3Api.submitAnswers(jobId, body);
       }
       case 'planning-v2':
-        return this.api.submitPlanningV2Answers(this.jobId!, request);
+        return this.api.submitPlanningV2Answers(jobId, request);
       case 'product-analysis':
-        return this.api.submitProductAnalysisAnswers(this.jobId!, request) as Observable<ProductAnalysisStatusResponse>;
+        return this.api.submitProductAnalysisAnswers(jobId, request) as Observable<ProductAnalysisStatusResponse>;
       case 'coding-team': {
         // Coding-team answers are single-select: strip the multi-select field to
         // match the backend contract exactly.
@@ -351,10 +353,10 @@ export class PendingQuestionsComponent implements OnChanges {
             other_text: a.other_text,
           })),
         };
-        return this.codingTeamApi.submitAnswers(this.jobId!, body);
+        return this.codingTeamApi.submitAnswers(jobId, body);
       }
       case 'run-team':
-        return this.api.submitAnswers(this.jobId!, request);
+        return this.api.submitAnswers(jobId, request);
       default: {
         // Compile-time exhaustiveness: a new SubmitEndpointType member fails to
         // build until it gets an explicit submit route (no silent fallthrough
@@ -374,6 +376,7 @@ export class PendingQuestionsComponent implements OnChanges {
 
   submitAnswers(): void {
     if (!this.jobId || !this.allAnswersSubmittable) return;
+    const jobId = this.jobId;
 
     const submissions: AnswerSubmission[] = [];
     for (const q of this.questions) {
@@ -397,7 +400,7 @@ export class PendingQuestionsComponent implements OnChanges {
 
     const request = { answers: submissions };
 
-    this.getSubmitObservable(request).subscribe({
+    this.getSubmitObservable(jobId, request).subscribe({
       next: (response) => {
         this.submitting = false;
         this.answersSubmitted.emit(response);

--- a/user-interface/src/app/components/pending-questions/pending-questions.component.ts
+++ b/user-interface/src/app/components/pending-questions/pending-questions.component.ts
@@ -31,6 +31,18 @@ import { QuestionCardComponent } from './question-card/question-card.component';
 export type SubmitEndpointType = 'run-team' | 'planning-v2' | 'planning-v3' | 'product-analysis' | 'coding-team';
 
 /**
+ * Everything `answersSubmitted` can emit — the post-submit status of whichever
+ * endpoint the component was configured with. Consumers narrow to the shape
+ * their own `submitEndpoint` produces.
+ */
+export type AnswersSubmittedStatus =
+  | JobStatusResponse
+  | PlanningV2StatusResponse
+  | PlanningV3StatusResponse
+  | ProductAnalysisStatusResponse
+  | CodingTeamJobStatus;
+
+/**
  * Per-endpoint capabilities. `Record` over the full union makes adding a new
  * endpoint a compile error until its capabilities are declared here — the
  * single source of truth for whether AI auto-answer is offered (default-deny:
@@ -86,13 +98,7 @@ export class PendingQuestionsComponent implements OnChanges {
   @Input() questions: PendingQuestion[] = [];
   /** Which endpoint to call: 'run-team' (default), 'planning-v3', 'product-analysis', or 'coding-team'. */
   @Input() submitEndpoint: SubmitEndpointType = 'run-team';
-  @Output() answersSubmitted = new EventEmitter<
-    | JobStatusResponse
-    | PlanningV2StatusResponse
-    | PlanningV3StatusResponse
-    | ProductAnalysisStatusResponse
-    | CodingTeamJobStatus
-  >();
+  @Output() answersSubmitted = new EventEmitter<AnswersSubmittedStatus>();
 
   answers = new Map<string, QuestionAnswer>();
   submitting = false;

--- a/user-interface/src/app/components/pending-questions/pending-questions.component.ts
+++ b/user-interface/src/app/components/pending-questions/pending-questions.component.ts
@@ -11,9 +11,10 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatChipsModule } from '@angular/material/chips';
-import { Observable } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 import { SoftwareEngineeringApiService } from '../../services/software-engineering-api.service';
 import { PlanningV3ApiService } from '../../services/planning-v3-api.service';
+import { CodingTeamApiService } from '../../services/coding-team-api.service';
 import type {
   PendingQuestion,
   AnswerSubmission,
@@ -23,10 +24,26 @@ import type {
   ProductAnalysisStatusResponse,
   AutoAnswerResponse,
 } from '../../models';
+import type { CodingTeamJobStatus } from '../../models/coding-team.model';
 import { QuestionCardComponent } from './question-card/question-card.component';
 
 /** Endpoint type determines which API to call for submitting answers. */
-export type SubmitEndpointType = 'run-team' | 'planning-v2' | 'planning-v3' | 'product-analysis';
+export type SubmitEndpointType = 'run-team' | 'planning-v2' | 'planning-v3' | 'product-analysis' | 'coding-team';
+
+/**
+ * Per-endpoint capabilities. `Record` over the full union makes adding a new
+ * endpoint a compile error until its capabilities are declared here — the
+ * single source of truth for whether AI auto-answer is offered (default-deny:
+ * an endpoint must opt IN; coding-team decisions are user-only by policy and
+ * planning-v3 exposes no auto-answer API).
+ */
+const ENDPOINT_CAPABILITIES: Record<SubmitEndpointType, { autoAnswer: boolean }> = {
+  'run-team': { autoAnswer: true },
+  'planning-v2': { autoAnswer: true },
+  'planning-v3': { autoAnswer: false },
+  'product-analysis': { autoAnswer: true },
+  'coding-team': { autoAnswer: false },
+};
 
 interface QuestionAnswer {
   questionId: string;
@@ -63,13 +80,18 @@ interface QuestionAnswer {
 export class PendingQuestionsComponent implements OnChanges {
   private readonly api = inject(SoftwareEngineeringApiService);
   private readonly planningV3Api = inject(PlanningV3ApiService);
+  private readonly codingTeamApi = inject(CodingTeamApiService);
 
   @Input() jobId: string | null = null;
   @Input() questions: PendingQuestion[] = [];
-  /** Which endpoint to call: 'run-team' (default), 'planning-v3', or 'product-analysis'. */
+  /** Which endpoint to call: 'run-team' (default), 'planning-v3', 'product-analysis', or 'coding-team'. */
   @Input() submitEndpoint: SubmitEndpointType = 'run-team';
   @Output() answersSubmitted = new EventEmitter<
-    JobStatusResponse | PlanningV2StatusResponse | PlanningV3StatusResponse | ProductAnalysisStatusResponse
+    | JobStatusResponse
+    | PlanningV2StatusResponse
+    | PlanningV3StatusResponse
+    | ProductAnalysisStatusResponse
+    | CodingTeamJobStatus
   >();
 
   answers = new Map<string, QuestionAnswer>();
@@ -124,6 +146,15 @@ export class PendingQuestionsComponent implements OnChanges {
     const answer = this.answers.get(questionId);
     if (answer) {
       if (event.checked) {
+        const question = this.questions.find((q) => q.id === questionId);
+        // Single-select questions render as radios: the card only emits the newly
+        // checked option, so replace the previous selection instead of accumulating.
+        if (question?.allow_multiple !== true) {
+          answer.selectedOptionIds.clear();
+          if (event.optionId !== 'other') {
+            answer.otherText = '';
+          }
+        }
         answer.selectedOptionIds.add(event.optionId);
       } else {
         answer.selectedOptionIds.delete(event.optionId);
@@ -177,12 +208,39 @@ export class PendingQuestionsComponent implements OnChanges {
       .every((q) => this.isQuestionAnswered(q));
   }
 
+  /**
+   * True when the batch as a whole is valid to submit: every required question
+   * is answered AND no touched question is half-answered (e.g. an optional
+   * question with 'other' ticked but no text — the backend rejects the entire
+   * batch over a single invalid answer, so the gate must cover optional ones too).
+   */
+  get allAnswersSubmittable(): boolean {
+    return (
+      this.allRequiredAnswered &&
+      this.questions.every((q) => {
+        const answer = this.answers.get(q.id);
+        // Untouched questions are simply omitted from the submission.
+        if (!answer || answer.selectedOptionIds.size === 0) return true;
+        return this.isQuestionAnswered(q);
+      })
+    );
+  }
+
   get answeredCount(): number {
     return this.questions.filter((q) => this.isQuestionAnswered(q)).length;
   }
 
+  /**
+   * Whether the AI auto-answer affordance is offered for this endpoint.
+   * Driven by ENDPOINT_CAPABILITIES; an unknown value (impossible under the
+   * union type, but reachable from a template typo) denies by default.
+   */
+  get autoAnswerEnabled(): boolean {
+    return ENDPOINT_CAPABILITIES[this.submitEndpoint]?.autoAnswer ?? false;
+  }
+
   autoAnswerQuestion(question: PendingQuestion): void {
-    if (!this.jobId || this.isAutoAnswering(question.id)) return;
+    if (!this.autoAnswerEnabled || !this.jobId || this.isAutoAnswering(question.id)) return;
 
     this.autoAnsweringQuestions.add(question.id);
     this.error = null;
@@ -197,19 +255,26 @@ export class PendingQuestionsComponent implements OnChanges {
       this.error = `Auto-answer failed for Q${this.questions.indexOf(question) + 1}: ${err?.error?.detail ?? err?.message ?? 'Unknown error'}`;
     };
 
-    if (this.submitEndpoint === 'planning-v3') {
-      // Planning V3 API does not expose auto-answer; skip or use a future endpoint
-      this.autoAnsweringQuestions.delete(question.id);
-    } else if (this.submitEndpoint === 'product-analysis') {
-      this.api.autoAnswerProductAnalysis(this.jobId, question.id).subscribe({
-        next: handleSuccess,
-        error: handleError,
-      });
-    } else {
-      this.api.autoAnswerRunTeam(this.jobId, question.id).subscribe({
-        next: handleSuccess,
-        error: handleError,
-      });
+    // Explicit per-endpoint dispatch — never fall through to a foreign team's
+    // auto-answer endpoint. Endpoints without an auto-answer API are already
+    // excluded by the autoAnswerEnabled guard above.
+    switch (this.submitEndpoint) {
+      case 'product-analysis':
+        this.api.autoAnswerProductAnalysis(this.jobId, question.id).subscribe({
+          next: handleSuccess,
+          error: handleError,
+        });
+        break;
+      case 'run-team':
+      case 'planning-v2':
+        this.api.autoAnswerRunTeam(this.jobId, question.id).subscribe({
+          next: handleSuccess,
+          error: handleError,
+        });
+        break;
+      default:
+        this.autoAnsweringQuestions.delete(question.id);
+        break;
     }
   }
 
@@ -246,19 +311,51 @@ export class PendingQuestionsComponent implements OnChanges {
 
   private getSubmitObservable(
     request: { answers: AnswerSubmission[] }
-  ): Observable<JobStatusResponse | PlanningV3StatusResponse | ProductAnalysisStatusResponse> {
-    if (this.submitEndpoint === 'planning-v3') {
-      const body = request.answers.map((a) => ({
-        question_id: a.question_id,
-        selected_option_id: a.selected_option_id ?? undefined,
-        selected_option_ids: a.selected_option_ids,
-        other_text: a.other_text ?? undefined,
-      }));
-      return this.planningV3Api.submitAnswers(this.jobId!, body);
-    } else if (this.submitEndpoint === 'product-analysis') {
-      return this.api.submitProductAnalysisAnswers(this.jobId!, request) as Observable<ProductAnalysisStatusResponse>;
-    } else {
-      return this.api.submitAnswers(this.jobId!, request);
+  ): Observable<
+    | JobStatusResponse
+    | PlanningV2StatusResponse
+    | PlanningV3StatusResponse
+    | ProductAnalysisStatusResponse
+    | CodingTeamJobStatus
+  > {
+    switch (this.submitEndpoint) {
+      case 'planning-v3': {
+        const body = request.answers.map((a) => ({
+          question_id: a.question_id,
+          selected_option_id: a.selected_option_id ?? undefined,
+          selected_option_ids: a.selected_option_ids,
+          other_text: a.other_text ?? undefined,
+        }));
+        return this.planningV3Api.submitAnswers(this.jobId!, body);
+      }
+      case 'planning-v2':
+        return this.api.submitPlanningV2Answers(this.jobId!, request);
+      case 'product-analysis':
+        return this.api.submitProductAnalysisAnswers(this.jobId!, request) as Observable<ProductAnalysisStatusResponse>;
+      case 'coding-team': {
+        // Coding-team answers are single-select: strip the multi-select field to
+        // match the backend contract exactly.
+        const body = {
+          answers: request.answers.map((a) => ({
+            question_id: a.question_id,
+            selected_option_id: a.selected_option_id,
+            other_text: a.other_text,
+          })),
+        };
+        return this.codingTeamApi.submitAnswers(this.jobId!, body);
+      }
+      case 'run-team':
+        return this.api.submitAnswers(this.jobId!, request);
+      default: {
+        // Compile-time exhaustiveness: a new SubmitEndpointType member fails to
+        // build until it gets an explicit submit route (no silent fallthrough
+        // to a foreign team's endpoint). At runtime an out-of-union value (e.g.
+        // a string-typed binding) must flow through the subscriber's error path
+        // — a synchronous throw here would strand `submitting` on true with no
+        // visible error.
+        const unhandled: never = this.submitEndpoint;
+        return throwError(() => new Error(`Unsupported submit endpoint: ${String(unhandled)}`));
+      }
     }
   }
 
@@ -267,7 +364,7 @@ export class PendingQuestionsComponent implements OnChanges {
   }
 
   submitAnswers(): void {
-    if (!this.jobId || !this.allRequiredAnswered) return;
+    if (!this.jobId || !this.allAnswersSubmittable) return;
 
     const submissions: AnswerSubmission[] = [];
     for (const q of this.questions) {
@@ -291,44 +388,15 @@ export class PendingQuestionsComponent implements OnChanges {
 
     const request = { answers: submissions };
 
-    const handleSuccess = (
-      response: JobStatusResponse | PlanningV2StatusResponse | PlanningV3StatusResponse | ProductAnalysisStatusResponse,
-    ): void => {
-      this.submitting = false;
-      this.answersSubmitted.emit(response);
-    };
-
-    const handleError = (err: { error?: { detail?: string }; message?: string }): void => {
-      this.submitting = false;
-      this.error = err?.error?.detail ?? err?.message ?? 'Failed to submit answers';
-    };
-
-    if (this.submitEndpoint === 'planning-v3') {
-      const body = request.answers.map((a) => ({
-        question_id: a.question_id,
-        selected_option_id: a.selected_option_id ?? undefined,
-        selected_option_ids: a.selected_option_ids,
-        other_text: a.other_text ?? undefined,
-      }));
-      this.planningV3Api.submitAnswers(this.jobId, body).subscribe({
-        next: handleSuccess,
-        error: handleError,
-      });
-    } else if (this.submitEndpoint === 'planning-v2') {
-      this.api.submitPlanningV2Answers(this.jobId, request).subscribe({
-        next: handleSuccess,
-        error: handleError,
-      });
-    } else if (this.submitEndpoint === 'product-analysis') {
-      this.api.submitProductAnalysisAnswers(this.jobId, request).subscribe({
-        next: (res) => handleSuccess(res as ProductAnalysisStatusResponse),
-        error: handleError,
-      });
-    } else {
-      this.api.submitAnswers(this.jobId, request).subscribe({
-        next: handleSuccess,
-        error: handleError,
-      });
-    }
+    this.getSubmitObservable(request).subscribe({
+      next: (response) => {
+        this.submitting = false;
+        this.answersSubmitted.emit(response);
+      },
+      error: (err: { error?: { detail?: string }; message?: string }) => {
+        this.submitting = false;
+        this.error = err?.error?.detail ?? err?.message ?? 'Failed to submit answers';
+      },
+    });
   }
 }

--- a/user-interface/src/app/components/pending-questions/pending-questions.component.ts
+++ b/user-interface/src/app/components/pending-questions/pending-questions.component.ts
@@ -180,6 +180,9 @@ export class PendingQuestionsComponent implements OnChanges {
     const answer = this.answers.get(questionId);
     if (answer) {
       answer.otherText = text;
+      // Reassign the Map so derived bindings (isQuestionAnswered → child [isAnswered],
+      // submit-gate) re-evaluate, matching onQuestionOptionToggled's reference update.
+      this.answers = new Map(this.answers);
     }
   }
 

--- a/user-interface/src/app/components/pending-questions/question-card/question-card.component.html
+++ b/user-interface/src/app/components/pending-questions/question-card/question-card.component.html
@@ -9,6 +9,7 @@
       <button
         mat-icon-button
         class="auto-answer-btn"
+        aria-label="Auto-answer using AI based on industry best practices"
         [disabled]="isAutoAnswering"
         (click)="onAutoAnswerRequest()"
         matTooltip="Auto-answer using AI based on industry best practices"

--- a/user-interface/src/app/components/pending-questions/question-card/question-card.component.html
+++ b/user-interface/src/app/components/pending-questions/question-card/question-card.component.html
@@ -5,7 +5,7 @@
     @if (question.required) {
       <span class="required-badge">Required</span>
     }
-    @if (hasSelectableOptions) {
+    @if (autoAnswerEnabled && hasSelectableOptions) {
       <button
         mat-icon-button
         class="auto-answer-btn"

--- a/user-interface/src/app/components/pending-questions/question-card/question-card.component.spec.ts
+++ b/user-interface/src/app/components/pending-questions/question-card/question-card.component.spec.ts
@@ -127,4 +127,16 @@ describe('QuestionCardComponent', () => {
     expect(component.hasSelections()).toBe(true);
     expect(component.getSelectedOptionIds().sort()).toEqual(['a1', 'b1']);
   });
+
+  it('renders the auto-answer button by default', () => {
+    const btn = fixture.nativeElement.querySelector('.auto-answer-btn');
+    expect(btn).toBeTruthy();
+  });
+
+  it('hides the auto-answer button when autoAnswerEnabled is false', () => {
+    fixture.componentRef.setInput('autoAnswerEnabled', false);
+    fixture.detectChanges();
+    const btn = fixture.nativeElement.querySelector('.auto-answer-btn');
+    expect(btn).toBeFalsy();
+  });
 });

--- a/user-interface/src/app/components/pending-questions/question-card/question-card.component.ts
+++ b/user-interface/src/app/components/pending-questions/question-card/question-card.component.ts
@@ -34,6 +34,8 @@ export class QuestionCardComponent {
   @Input() autoAnswerResult?: AutoAnswerResponse;
   @Input() isAutoAnswering = false;
   @Input() isAnswered = false;
+  /** When false, the AI auto-answer affordance is hidden (user-only decisions). */
+  @Input() autoAnswerEnabled = true;
 
   @Output() optionToggled = new EventEmitter<{ optionId: string; checked: boolean }>();
   @Output() otherTextChanged = new EventEmitter<string>();

--- a/user-interface/src/app/components/pending-questions/question-card/question-card.component.ts
+++ b/user-interface/src/app/components/pending-questions/question-card/question-card.component.ts
@@ -1,4 +1,12 @@
-import { Component, EventEmitter, Input, Output, ChangeDetectionStrategy } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  ChangeDetectionStrategy,
+  OnChanges,
+  SimpleChanges,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -34,7 +42,7 @@ import type { PendingQuestion, AutoAnswerResponse } from '../../../models';
  * `PendingQuestionsComponent` via the outputs below; it never mutates its inputs. OnPush — the
  * parent feeds it fresh input references on change.
  */
-export class QuestionCardComponent {
+export class QuestionCardComponent implements OnChanges {
   /** The question to render (text, options, required/multi-select flags). */
   @Input({ required: true }) question!: PendingQuestion;
   /** Zero-based position in the batch; rendered as the 1-based "Q{n}" label. */
@@ -63,6 +71,18 @@ export class QuestionCardComponent {
   otherText = '';
   wasAutoAnswered = false;
   autoAnswerConfidence = 0;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    // When this card is reused for a different question (same DOM node, new question identity),
+    // clear the locally-held selection so stale checks/text can't carry over and desync from the
+    // parent's freshly-initialised answer for the new question.
+    const q = changes['question'];
+    if (q && !q.firstChange && q.previousValue?.id !== q.currentValue?.id) {
+      this.selectedOptionIds = new Set<string>();
+      this.otherText = '';
+      this.wasAutoAnswered = false;
+    }
+  }
 
   get isMultiSelect(): boolean {
     return this.question.allow_multiple === true;

--- a/user-interface/src/app/components/pending-questions/question-card/question-card.component.ts
+++ b/user-interface/src/app/components/pending-questions/question-card/question-card.component.ts
@@ -28,19 +28,35 @@ import type { PendingQuestion, AutoAnswerResponse } from '../../../models';
   templateUrl: './question-card.component.html',
   styleUrl: './question-card.component.scss',
 })
+/**
+ * Presentational card for a single pending question. Owns its own selection state
+ * (`selectedOptionIds`/`otherText`) and emits user intent to the parent
+ * `PendingQuestionsComponent` via the outputs below; it never mutates its inputs. OnPush — the
+ * parent feeds it fresh input references on change.
+ */
 export class QuestionCardComponent {
+  /** The question to render (text, options, required/multi-select flags). */
   @Input({ required: true }) question!: PendingQuestion;
+  /** Zero-based position in the batch; rendered as the 1-based "Q{n}" label. */
   @Input({ required: true }) questionIndex!: number;
+  /** AI auto-answer suggestion to surface for this question, when one has been fetched. */
   @Input() autoAnswerResult?: AutoAnswerResponse;
+  /** True while an auto-answer request for this question is in flight (drives the spinner). */
   @Input() isAutoAnswering = false;
+  /** True when the parent considers this question answered (drives the answered styling). */
   @Input() isAnswered = false;
   /** When false, the AI auto-answer affordance is hidden (user-only decisions). */
   @Input() autoAnswerEnabled = true;
 
+  /** Emitted when an option's checked state changes (checkbox toggle or radio select). */
   @Output() optionToggled = new EventEmitter<{ optionId: string; checked: boolean }>();
+  /** Emitted with the latest free-text value when the "other" text field changes. */
   @Output() otherTextChanged = new EventEmitter<string>();
+  /** Emitted when the user asks the AI to auto-answer this question. */
   @Output() autoAnswerRequested = new EventEmitter<void>();
+  /** Emitted when the user accepts the displayed auto-answer suggestion. */
   @Output() autoAnswerApplied = new EventEmitter<void>();
+  /** Emitted when the user dismisses the displayed auto-answer suggestion. */
   @Output() autoAnswerDismissed = new EventEmitter<void>();
 
   selectedOptionIds = new Set<string>();

--- a/user-interface/src/app/models/coding-team.model.ts
+++ b/user-interface/src/app/models/coding-team.model.ts
@@ -1,4 +1,14 @@
-import { CurrentActivityEntry } from './software-engineering.model';
+import type { CurrentActivityEntry, PendingQuestion } from './software-engineering.model';
+
+/** GitHub issue/PR metadata attached to a coding-team job started from an issue. */
+export interface CodingTeamGitHubContext {
+  owner: string;
+  repo: string;
+  issue_number?: number;
+  issue_url?: string;
+  pr_number?: number;
+  pr_url?: string;
+}
 
 export interface CodingTeamJobStatus {
   job_id: string;
@@ -8,14 +18,7 @@ export interface CodingTeamJobStatus {
   /** Most recent agent reasoning ("thinking") tokens, for live display. */
   thinking?: string;
   error?: string;
-  github_context?: {
-    owner: string;
-    repo: string;
-    issue_number?: number;
-    issue_url?: string;
-    pr_number?: number;
-    pr_url?: string;
-  };
+  github_context?: CodingTeamGitHubContext;
   github_pr_url?: string;
   /** Set by the PR-review flow with the posted-review stats. */
   review_summary?: CodeReviewSummary;
@@ -32,6 +35,22 @@ export interface CodingTeamJobStatus {
   progress?: number | null;
   /** Server UTC time when the response was built; staleness math uses this, not the browser clock. */
   server_time?: string | null;
+  /** Decisions awaiting a user answer before the job can proceed. */
+  pending_questions?: PendingQuestion[];
+  /** True when the job is paused waiting for the user to answer pending questions. */
+  waiting_for_answers?: boolean;
+}
+
+/** One row of GET /jobs — enough to spot active GitHub-issue runs without per-job status calls. */
+export interface CodingTeamJobListItem {
+  job_id: string;
+  status: string;
+  repo_path?: string;
+  phase?: string;
+  status_text?: string;
+  updated_at?: string;
+  waiting_for_answers?: boolean;
+  github_context?: CodingTeamGitHubContext;
 }
 
 /** Summary of a posted PR review (from the /review-pr flow). */

--- a/user-interface/src/app/services/coding-team-api.service.spec.ts
+++ b/user-interface/src/app/services/coding-team-api.service.spec.ts
@@ -28,4 +28,61 @@ describe('CodingTeamApiService', () => {
     expect(req.request.method).toBe('GET');
     req.flush({ status: 'ok' });
   });
+
+  it('GETs /status/{jobId}', () => {
+    service.getJobStatus('job-1').subscribe((r) => {
+      expect(r.job_id).toBe('job-1');
+      expect(r.waiting_for_answers).toBe(true);
+      expect(r.pending_questions?.[0]?.id).toBe('q1');
+    });
+    const req = httpMock.expectOne(`${baseUrl}/status/job-1`);
+    expect(req.request.method).toBe('GET');
+    req.flush({
+      job_id: 'job-1',
+      status: 'waiting_for_user',
+      waiting_for_answers: true,
+      pending_questions: [
+        { id: 'q1', question_text: 'Pick one', options: [], required: true, source: 'tech_lead' },
+      ],
+    });
+  });
+
+  it('POSTs answers to /run/{jobId}/answers', () => {
+    const body = {
+      answers: [{ question_id: 'q1', selected_option_id: 'opt-a', other_text: null }],
+    };
+    service.submitAnswers('job-1', body).subscribe((r) => {
+      expect(r.status).toBe('running');
+      expect(r.waiting_for_answers).toBe(false);
+    });
+    const req = httpMock.expectOne(`${baseUrl}/run/job-1/answers`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(body);
+    req.flush({ job_id: 'job-1', status: 'running', waiting_for_answers: false });
+  });
+
+  it('GETs /jobs?active=true by default (terminal jobs filtered server-side)', () => {
+    service.listJobs().subscribe((jobs) => {
+      expect(jobs.length).toBe(1);
+      expect(jobs[0].github_context?.issue_number).toBe(42);
+      expect(jobs[0].waiting_for_answers).toBe(true);
+    });
+    const req = httpMock.expectOne(`${baseUrl}/jobs?active=true`);
+    expect(req.request.method).toBe('GET');
+    req.flush([
+      {
+        job_id: 'job-1',
+        status: 'waiting_for_user',
+        waiting_for_answers: true,
+        github_context: { owner: 'acme', repo: 'widgets', issue_number: 42 },
+      },
+    ]);
+  });
+
+  it('GETs /jobs unfiltered when activeOnly is false', () => {
+    service.listJobs(false).subscribe();
+    const req = httpMock.expectOne(`${baseUrl}/jobs`);
+    expect(req.request.method).toBe('GET');
+    req.flush([]);
+  });
 });

--- a/user-interface/src/app/services/coding-team-api.service.spec.ts
+++ b/user-interface/src/app/services/coding-team-api.service.spec.ts
@@ -80,9 +80,13 @@ describe('CodingTeamApiService', () => {
   });
 
   it('GETs /jobs unfiltered when activeOnly is false', () => {
-    service.listJobs(false).subscribe();
+    service.listJobs(false).subscribe((jobs) => {
+      expect(jobs.length).toBe(1);
+      expect(jobs[0].job_id).toBe('job-9');
+      expect(jobs[0].status).toBe('completed');
+    });
     const req = httpMock.expectOne(`${baseUrl}/jobs`);
     expect(req.request.method).toBe('GET');
-    req.flush([]);
+    req.flush([{ job_id: 'job-9', status: 'completed' }]);
   });
 });

--- a/user-interface/src/app/services/coding-team-api.service.spec.ts
+++ b/user-interface/src/app/services/coding-team-api.service.spec.ts
@@ -89,4 +89,16 @@ describe('CodingTeamApiService', () => {
     expect(req.request.method).toBe('GET');
     req.flush([{ job_id: 'job-9', status: 'completed' }]);
   });
+
+  it('POSTs to /run/{jobId}/resume', () => {
+    service.resumeJob('job-1').subscribe((r) => {
+      expect(r.job_id).toBe('job-1');
+      expect(r.status).toBe('running');
+      expect(r.message).toBe('Job resumed.');
+    });
+    const req = httpMock.expectOne(`${baseUrl}/run/job-1/resume`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({});
+    req.flush({ job_id: 'job-1', status: 'running', message: 'Job resumed.' });
+  });
 });

--- a/user-interface/src/app/services/coding-team-api.service.ts
+++ b/user-interface/src/app/services/coding-team-api.service.ts
@@ -48,4 +48,21 @@ export class CodingTeamApiService {
     const suffix = activeOnly ? '?active=true' : '';
     return this.http.get<CodingTeamJobListItem[]>(`${this.baseUrl}/jobs${suffix}`);
   }
+
+  /**
+   * Restart a paused job whose thread died after answers were stored.
+   *
+   * Preconditions: `jobId` identifies a `waiting_for_user` job with no live
+   * thread or heartbeat; answers have already been submitted via
+   * `submitAnswers`.
+   * Postconditions: on success the orchestrator is restarted (or the response
+   * reports it was already running). Returns 400 for terminal or non-paused
+   * jobs, or a GitHub job with no available token.
+   */
+  resumeJob(jobId: string): Observable<{ job_id: string; status: string; message: string }> {
+    return this.http.post<{ job_id: string; status: string; message: string }>(
+      `${this.baseUrl}/run/${jobId}/resume`,
+      {},
+    );
+  }
 }

--- a/user-interface/src/app/services/coding-team-api.service.ts
+++ b/user-interface/src/app/services/coding-team-api.service.ts
@@ -3,7 +3,8 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 import type { HealthResponse } from '../models/health.model';
-import type { CodingTeamJobStatus } from '../models/coding-team.model';
+import type { CodingTeamJobListItem, CodingTeamJobStatus } from '../models/coding-team.model';
+import type { SubmitAnswersRequest } from '../models/software-engineering.model';
 
 /**
  * Coding Team API (Software Engineering sub-team). Base URL from environment.codingTeamApiUrl.
@@ -19,5 +20,32 @@ export class CodingTeamApiService {
 
   getJobStatus(jobId: string): Observable<CodingTeamJobStatus> {
     return this.http.get<CodingTeamJobStatus>(`${this.baseUrl}/status/${jobId}`);
+  }
+
+  /**
+   * Submit answers to a paused job's pending questions.
+   *
+   * Preconditions: `jobId` identifies a job with `waiting_for_answers: true`;
+   * every required pending question has an answer (the backend re-validates
+   * fail-closed and returns 400 otherwise).
+   * Postconditions: on success the job's pause flag is cleared and the
+   * orchestrator resumes; the returned status reflects the post-submit state.
+   */
+  submitAnswers(jobId: string, request: SubmitAnswersRequest): Observable<CodingTeamJobStatus> {
+    return this.http.post<CodingTeamJobStatus>(`${this.baseUrl}/run/${jobId}/answers`, request);
+  }
+
+  /**
+   * List coding-team jobs. Each item carries `github_context` and
+   * `waiting_for_answers` so callers can spot active GitHub-issue runs
+   * without per-job status calls.
+   *
+   * Postconditions: with `activeOnly` (default), only non-terminal jobs are
+   * returned and the filtering happens at the job service — terminal jobs'
+   * full records never cross the wire.
+   */
+  listJobs(activeOnly = true): Observable<CodingTeamJobListItem[]> {
+    const suffix = activeOnly ? '?active=true' : '';
+    return this.http.get<CodingTeamJobListItem[]>(`${this.baseUrl}/jobs${suffix}`);
   }
 }

--- a/user-interface/src/app/services/job-status-poller.spec.ts
+++ b/user-interface/src/app/services/job-status-poller.spec.ts
@@ -7,6 +7,18 @@ describe('pollJobStatus', () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
 
+  it('fetches immediately on subscribe, before the first interval elapses', () => {
+    const api = { getJobStatus: vi.fn(() => of({ job_id: 'j', status: 'running' })) };
+    const seen: CodingTeamJobStatus[] = [];
+
+    const sub = pollJobStatus(api, 'j', (s) => seen.push(s), vi.fn());
+    vi.advanceTimersByTime(0);
+
+    expect(api.getJobStatus).toHaveBeenCalledTimes(1);
+    expect(seen.map((s) => s.status)).toEqual(['running']);
+    sub.unsubscribe();
+  });
+
   it('emits each status until terminal, then stops', () => {
     const statuses: CodingTeamJobStatus[] = [
       { job_id: 'j', status: 'running' },
@@ -18,8 +30,8 @@ describe('pollJobStatus', () => {
     const lost = vi.fn();
 
     const sub = pollJobStatus(api, 'j', (s) => seen.push(s), lost);
-    vi.advanceTimersByTime(5000);
-    vi.advanceTimersByTime(5000);
+    vi.advanceTimersByTime(0); // immediate fetch → running
+    vi.advanceTimersByTime(5000); // → completed (terminal)
     vi.advanceTimersByTime(5000); // no further emissions after terminal
 
     expect(seen.map((s) => s.status)).toEqual(['running', 'completed']);
@@ -32,8 +44,8 @@ describe('pollJobStatus', () => {
     const lost = vi.fn();
 
     const sub = pollJobStatus(api, 'j', vi.fn(), lost);
-    vi.advanceTimersByTime(5000);
-    vi.advanceTimersByTime(5000);
+    vi.advanceTimersByTime(0); // 1st error (immediate fetch)
+    vi.advanceTimersByTime(5000); // 2nd error
     expect(lost).not.toHaveBeenCalled(); // only 2 errors so far
     vi.advanceTimersByTime(5000);
     expect(lost).toHaveBeenCalledTimes(1); // 3rd error trips the budget

--- a/user-interface/src/app/services/job-status-poller.spec.ts
+++ b/user-interface/src/app/services/job-status-poller.spec.ts
@@ -39,6 +39,44 @@ describe('pollJobStatus', () => {
     expect(sub.closed).toBe(true);
   });
 
+  it('counts only consecutive errors: a success resets the budget', () => {
+    // error, error, success, error, error — never 3 in a row, so onConnectionLost must not fire.
+    const seq = ['err', 'err', 'ok', 'err', 'err'];
+    let i = 0;
+    const api = {
+      getJobStatus: vi.fn(() =>
+        seq[i++] === 'ok'
+          ? of({ job_id: 'j', status: 'running' } as CodingTeamJobStatus)
+          : throwError(() => new Error('boom')),
+      ),
+    };
+    const lost = vi.fn();
+
+    const sub = pollJobStatus(api, 'j', vi.fn(), lost);
+    vi.advanceTimersByTime(0); // err (1)
+    vi.advanceTimersByTime(5000); // err (2)
+    vi.advanceTimersByTime(5000); // ok → resets to 0
+    vi.advanceTimersByTime(5000); // err (1 again)
+    vi.advanceTimersByTime(5000); // err (2)
+
+    expect(lost).not.toHaveBeenCalled();
+    expect(api.getJobStatus).toHaveBeenCalledTimes(5);
+    sub.unsubscribe();
+  });
+
+  it('stops polling once the returned subscription is unsubscribed', () => {
+    const api = { getJobStatus: vi.fn(() => of({ job_id: 'j', status: 'running' })) };
+
+    const sub = pollJobStatus(api, 'j', vi.fn(), vi.fn());
+    vi.advanceTimersByTime(0); // immediate fetch
+    expect(api.getJobStatus).toHaveBeenCalledTimes(1);
+
+    sub.unsubscribe();
+    vi.advanceTimersByTime(5000); // interval would fire, but we've torn down
+    vi.advanceTimersByTime(5000);
+    expect(api.getJobStatus).toHaveBeenCalledTimes(1); // no further calls after unsubscribe
+  });
+
   it('calls onConnectionLost after the error budget is exhausted', () => {
     const api = { getJobStatus: vi.fn(() => throwError(() => new Error('boom'))) };
     const lost = vi.fn();

--- a/user-interface/src/app/services/job-status-poller.ts
+++ b/user-interface/src/app/services/job-status-poller.ts
@@ -1,4 +1,4 @@
-import { EMPTY, Observable, Subject, Subscription, interval } from 'rxjs';
+import { EMPTY, Observable, Subject, Subscription, timer } from 'rxjs';
 import { catchError, switchMap, takeUntil, takeWhile, tap } from 'rxjs/operators';
 import type { CodingTeamJobStatus } from '../models/coding-team.model';
 import { isCodingTeamTerminalStatus } from '../models/job-status.model';
@@ -11,11 +11,13 @@ export interface JobStatusSource {
 /**
  * Poll a coding-team job's status until it reaches a terminal state.
  *
- * Emits each fetched status to `onStatus`; after `maxConsecutiveErrors` consecutive
- * fetch failures it calls `onConnectionLost` and stops. Polling also stops once the
- * status is terminal. Returns the `Subscription` so the caller can tear it down on
- * destroy. Shared by the Coding Team and Code Review panels so the interval, error
- * budget, and terminal-status handling stay consistent.
+ * The first fetch fires immediately on subscribe (then every `intervalMs`), so callers
+ * never wait a full interval for the initial status. Emits each fetched status to
+ * `onStatus`; after `maxConsecutiveErrors` consecutive fetch failures it calls
+ * `onConnectionLost` and stops. Polling also stops once the status is terminal.
+ * Returns the `Subscription` so the caller can tear it down on destroy. Shared by the
+ * Coding Team and Code Review panels so the interval, error budget, and
+ * terminal-status handling stay consistent.
  */
 export function pollJobStatus(
   api: JobStatusSource,
@@ -27,7 +29,7 @@ export function pollJobStatus(
 ): Subscription {
   let errors = 0;
   const stop$ = new Subject<void>();
-  return interval(intervalMs)
+  return timer(0, intervalMs)
     .pipe(
       switchMap(() =>
         api.getJobStatus(jobId).pipe(


### PR DESCRIPTION
…ient resume

The coding-team page now shows which GitHub issue the team is working on (surviving page reloads via GET /jobs restore, with "In progress" chips on the issue list), surfaces the team's escalated questions in a pending- questions panel, and submits answers through POST /run/{job_id}/answers so the paused run resumes.

Frontend:
- CodingTeamJobStatus gains pending_questions/waiting_for_answers; CodingTeamApiService gains submitAnswers() and listJobs(active).
- PendingQuestionsComponent gains a 'coding-team' submit endpoint with an ENDPOINT_CAPABILITIES record (compile-time default-deny dispatch; auto- answer hidden for user-only coding-team decisions), a stricter allAnswersSubmittable gate (a half-answered optional question can no longer 400 the whole batch), and a single-select fix (radio toggles replace the previous selection instead of accumulating).
- pollJobStatus fetches immediately (timer(0, interval)) so panels hydrate without waiting a full poll interval.
- Active-job restore matches the configured owner/repo case-insensitively, merges the displayed job into the chip set (stale snapshots can't wipe a just-started run), excludes session-dismissed jobs from re-adoption, and refreshes on issue-list load and dismiss; Dismiss is always available.

Backend (coding_team):
- Answer submission auto-resumes a dead orchestrator: standalone jobs restart directly, GitHub-issue jobs restart through the full hook path so publication (PR, issue comments) survives; without a token it falls back to an explicit-resume hint.
- The paused wait loop heartbeats the job record so resume decisions are safe across worker processes (a fresh heartbeat means a live wait loop elsewhere will consume the stored answers).
- Stored answers carry question_text so a revived run consumes them instead of re-asking; the resume status_text is written before the spawn to avoid clobbering newer orchestrator updates.
- job_store gains a NON_TERMINAL_STATUSES definition that includes waiting_for_user, so the duplicate-run and busy-checkout admission guards see paused jobs; GET /jobs?active=true filters at the job service so terminal jobs' full records never cross the wire; JobListItem carries github_context/waiting_for_answers/status_text/updated_at.