### PR TITLE
Slim CLAUDE.md to core guidance with pointers to detailed docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,69 +8,33 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Structure
 
+One directory per agent team under `backend/agents/` — the authoritative team list is `TEAM_CONFIGS` in `backend/unified_api/config.py`. Load-bearing entries:
+
 ```
 backend/
-  agents/                    # All agent team implementations
-    software_engineering_team/  # Primary team — full dev pipeline; contains
-                                # backend_code_v2_team/, frontend_code_v2_team/,
-                                # devops_team/, planning_v2_team/, planning_v2_adapter.py,
-                                # planning_v3_adapter.py, integration_team/, qa_agent/, etc.
-    planning_v3_team/        # Client-facing discovery/PRD team (mounted at /api/planning-v3)
-    coding_team/             # SE sub-team: tech lead + stack specialists (logical sub-team)
-    blogging/                # Blog content pipeline
-    personal_assistant_team/
-    market_research_team/
-    soc2_compliance_team/
-    social_media_marketing_team/
-    branding_team/
-    agent_provisioning_team/
-    accessibility_audit_team/
-    ai_systems_team/
-    investment_team/         # Advisor/IPS + Strategy Lab (one /api/investment prefix)
-    nutrition_meal_planning_team/
-    sales_team/
-    road_trip_planning_team/
-    agentic_team_provisioning/
-    startup_advisor/
-    user_agent_founder/
-    deepthought/
-    job_matching_team/       # Scans open roles vs a job-seeker profile; ranks best-to-apply
+  agents/
+    software_engineering_team/  # Primary team — full dev pipeline; contains the backend/frontend
+                                # code-v2, devops, planning-v2, integration, and QA sub-teams
+    coding_team/             # Standalone /api/coding-team; SE uses it as a logical sub-team
+    planning_v3_team/        # Client-facing discovery/PRD team (/api/planning-v3)
+    product_delivery/        # Persistent Product Delivery Loop (/api/product-delivery)
     llm_service/             # Centralized LLM client (Ollama, Claude)
-    agent_registry/          # Agent Console catalog: loads per-agent YAML manifests, serves /api/agents
-    agent_console/           # Agent Console data layer: Postgres-backed saved inputs, run history, diff, pruner
-    product_delivery/        # Persistent Product Delivery Loop, in-process module mounted by
-                             # unified_api at /api/product-delivery. Backlog tables
-                             # (products → initiatives → epics → stories → tasks + acceptance criteria
-                             # + feedback_items), ProductOwnerAgent (WSJF/RICE); sprints + releases
-                             # tables, sprint_planner_agent, _load_requirements_from_sprint in the SE
-                             # orchestrator; release_manager_agent ships sprint completion →
-                             # plan/releases/<version>.md + product_delivery_releases row, auto-promotes
-                             # Integration-phase failures into sprint-tagged feedback_items (queryable
-                             # via GET /feedback; operator triage feeds the next groom — POST /groom
-                             # does not consume feedback automatically); POST/GET /releases routes;
-                             # SE Integration-phase hook (legacy SE path only — default
-                             # use_coding_team=True path currently skips the hook).
-    shared_agent_invoke/     # Invoke shim mounted inside the sandbox image; exposes POST /_agents/{id}/invoke
+    agent_registry/          # Agent Console catalog: per-agent YAML manifests → /api/agents
+    agent_console/           # Agent Console data layer: runs, saved inputs, diff
+    shared_postgres/         # \
+    shared_temporal/         #  > Shared infra (see Architecture below)
+    shared_agent_invoke/     # /
     integrations/            # Shared integration contracts (Google login, Medium, etc.)
     artifact_registry/       # Shared artifact persistence
     event_bus/               # Cross-team event publishing
-    shared_temporal/         # Temporal worker/workflow plumbing
     api/                     # Legacy blog API surface (see blogging/ for current pipeline)
-  unified_api/               # Single-entry-point FastAPI server (port 8080)
-    config.py                # TEAM_CONFIGS, security gateway, Temporal settings
-    main.py                  # App with team route mounting + security gateway
+  unified_api/               # Single-entry-point FastAPI server (port 8080);
+                             # config.py = TEAM_CONFIGS + security gateway + Temporal settings
   run_unified_api.py         # CLI launcher
   Makefile                   # Primary build/run targets
-  requirements.txt           # Top-level Python deps
   pyproject.toml             # Ruff config (line-length 120, Python 3.10 target)
-docker/
-  docker-compose.yml         # Full stack: Postgres, Temporal, Ollama, Agents, UI
-  .env.example               # Template for OLLAMA_API_KEY, LLM settings
-user-interface/              # Angular 19 frontend
-  src/app/
-    components/              # Feature + shared components
-    models/                  # TypeScript request/response models
-    services/                # API client services
+docker/                      # Full-stack compose: Postgres, Temporal, Ollama, Agents, UI
+user-interface/              # Angular 19 frontend (src/app: components/, models/, services/)
 ```
 
 ## Common Commands
@@ -95,35 +59,21 @@ python run_unified_api.py --port 9000 --reload --workers 4
 
 ### Local dev with Postgres
 
-All migrated teams (blogging, branding, startup_advisor, team_assistant,
-user_agent_founder, agentic_team_provisioning, nutrition_meal_planning,
-unified_api credentials) now require Postgres for local dev and tests —
-no SQLite fallback.
+Migrated teams (blogging, branding, startup_advisor, team_assistant, user_agent_founder, agentic_team_provisioning, nutrition_meal_planning, unified_api credentials) require Postgres for local dev and tests — no SQLite fallback. Every team's `JobServiceClient` requires `JOB_SERVICE_URL` (no file-backed fallback), except under `pytest`, where `backend/conftest.py` spins up the job service in-process.
 
 ```bash
-# Start Postgres + the central job service (every team's JobServiceClient
-# requires JOB_SERVICE_URL — there is no longer a file-backed fallback).
 cp docker/.env.example docker/.env              # once, if not done
 docker compose -f docker/docker-compose.yml up -d postgres job-service
 
-# Export the vars every shared_postgres caller reads
 export POSTGRES_HOST=localhost
 export POSTGRES_PORT=5432
 export POSTGRES_USER=postgres
 export POSTGRES_PASSWORD=postgres
 export POSTGRES_DB=postgres
-
-# Required by every team for job tracking
 export JOB_SERVICE_URL=http://localhost:8085
-
-# Now `make run`, `uvicorn <team>.api.main:app`, etc. all work.
-# `pytest` does not need JOB_SERVICE_URL exported — backend/conftest.py
-# spins up the job service in-process for the test session.
 ```
 
-Pool sizing is controlled by `POSTGRES_POOL_MIN_SIZE` (default 2) and
-`POSTGRES_POOL_MAX_SIZE` (default 10); slow-query logging threshold is
-`POSTGRES_SLOW_QUERY_MS` (default 100).
+Pool sizing and slow-query logging knobs (`POSTGRES_POOL_MIN_SIZE`/`POSTGRES_POOL_MAX_SIZE`, `POSTGRES_SLOW_QUERY_MS`): see `docs/ENV_VARS.md`.
 
 ### Frontend
 
@@ -147,7 +97,7 @@ docker compose -f docker/docker-compose.yml --env-file docker/.env up --build
 
 ### Docker Volumes
 
-All agent team containers share a single `agents_data` named volume mounted at `/data/agents`. Every service sets `AGENT_CACHE=/data/agents`, so all team artifacts (job state, caches, profiles, workspaces) persist across container restarts. Teams naturally namespace via `{team_name}/` subdirectories under `AGENT_CACHE`. Blogging-specific paths (`BLOGGING_RUN_ARTIFACTS_ROOT`, `BLOGGING_MEDIUM_STATS_ROOT`, `INTEGRATIONS_BROWSER_SESSION_ROOT`) and SE workspaces (`SE_WORKSPACE_DIR`) also point into this volume.
+All agent containers share one `agents_data` named volume mounted at `/data/agents` (`AGENT_CACHE`); teams namespace artifacts under `{team_name}/`, so job state, caches, profiles, and workspaces persist across restarts. Blogging paths and SE workspaces (`SE_WORKSPACE_DIR`) also point into this volume.
 
 ## Architecture
 
@@ -194,17 +144,15 @@ All teams mount under `/api/{team-slug}`. Team configs are defined in `backend/u
 
 ### Agent Console & Agent Registry
 
-The **Agent Console** (UI at `/agent-console`) is the single entry point for discovering, inspecting, and running every specialist agent in the system. Three tabs: **Catalog** (searchable card grid + anatomy drawer), **Runner** (isolated invocation in an ephemeral sandbox), and **Provisioning & Environments** (embeds `AgentProvisioningDashboardComponent`).
+The **Agent Console** (UI at `/agent-console`; the old `/agent-provisioning` route redirects there) is the single entry point for discovering, inspecting, and running every specialist agent. Three parts, each with its own docs:
 
-- **Catalog / registry** — `backend/agents/agent_registry/` loads declarative per-agent YAML manifests from `backend/agents/<team_dir>/agent_console/manifests/*.yaml` and serves them at `/api/agents`. Manifest schema, field rules, route list, and golden-sample generation: `backend/agents/agent_registry/README.md`.
-- **Runner + sandboxes** — each invocation runs the agent in its own ephemeral docker compose stack (the unified `khala-agent-sandbox` image plus a sandbox-internal Postgres, Temporal, Prometheus, and Grafana); the unified API proxies `POST /api/agents/{id}/invoke`. Stack contents, lifecycle, and idle teardown: `backend/agents/agent_provisioning_team/sandbox/README.md`. Agents tagged `requires-live-integration` are catalogued but not runnable.
-- **Runs, saved inputs, diff** — `backend/agents/agent_console/` is the Postgres-backed data layer (run history, user-saved inputs, unified-diff) plus a background pruner; the Runner UI adds a Form/JSON editor, a saved-inputs picker, and a history panel. Tables, routes, and env vars: `backend/agents/agent_console/README.md`.
-
-The old `/agent-provisioning` route redirects to `/agent-console` for backward compatibility.
+- **Catalog** — `backend/agents/agent_registry/` serves per-agent YAML manifests at `/api/agents`. Manifest schema and routes: `backend/agents/agent_registry/README.md`.
+- **Runner** — each invocation runs in an ephemeral docker compose sandbox, proxied via `POST /api/agents/{id}/invoke`. Stack contents and lifecycle: `backend/agents/agent_provisioning_team/sandbox/README.md`.
+- **Runs, saved inputs, diff** — `backend/agents/agent_console/` is the Postgres-backed data layer. Tables, routes, and env vars: `backend/agents/agent_console/README.md`.
 
 ### Product Delivery Loop
 
-The `product_delivery` team (`backend/agents/product_delivery/`, mounted at `/api/product-delivery`) wraps the SE 4-phase pipeline in a persistent loop: backlog → groom (`ProductOwnerAgent`) → sprint plan (`SprintPlannerAgent`) → SE run with `{sprint_id}` → release hook (`ReleaseManagerAgent`) → feedback → next groom. The release hook (`_maybe_ship_sprint_release`) fires only on the legacy SE path today; the default `use_coding_team=True` path completes before reaching it. See `docs/ARCHITECTURE.md` §11 ("Product Delivery Loop") for the sequence diagram, runtime contracts, and known limitations.
+The `product_delivery` team (`backend/agents/product_delivery/`, mounted at `/api/product-delivery`) wraps the SE 4-phase pipeline in a persistent loop: backlog → groom → sprint plan → SE run → release hook → feedback → next groom. Sequence diagram, runtime contracts, and known limitations (including which SE path fires the release hook): `docs/ARCHITECTURE.md` §11 ("Product Delivery Loop").
 
 ### LLM Integration
 
@@ -235,81 +183,24 @@ Environment variables for LLM: `LLM_PROVIDER`, `LLM_BASE_URL`, `LLM_MODEL`
 
 ## Key Environment Variables
 
-One-line index below. The full reference — defaults, backoff math, fallback semantics, and edge cases — lives in [`docs/ENV_VARS.md`](docs/ENV_VARS.md). All numeric vars parse defensively: garbage → documented default, out-of-range → clamped to the documented floor/ceiling unless noted.
+Core vars only. The complete reference — every var, defaults, backoff math, fallback semantics, edge cases — lives in [`docs/ENV_VARS.md`](docs/ENV_VARS.md); team-specific tuning knobs (Strategy Lab, agent cognition, blogging, social marketing, etc.) are also covered in the owning team's README. All numeric vars parse defensively: garbage → documented default, out-of-range → clamped to the documented floor/ceiling unless noted.
 
 | Variable | Purpose |
 |---|---|
 | `OLLAMA_API_KEY` | Required for Ollama Cloud API |
-| `LLM_PROVIDER` | LLM provider selection |
-| `LLM_BASE_URL` | LLM server URL |
-| `LLM_MODEL` | Model name |
-| `LLM_NUM_CTX_FALLBACK_TTL_S` | TTL (default `300`s) for the Ollama client's provisional `num_ctx` fallback after an `/api/show` miss, so a transient outage can't permanently truncate prompts. [details](docs/ENV_VARS.md#llm-client-and-thinking) |
-| `LLM_MAX_RETRIES` / `LLM_BACKOFF_BASE` / `LLM_BACKOFF_MAX` | Transient (5xx/conn/timeout) retry schedule for the central Ollama client (defaults `10`/`2`s/`120`s; 429s use `LLM_RATE_LIMIT_*`). [details](docs/ENV_VARS.md#llm-client-and-thinking) |
-| `LLM_ENABLE_THINKING` | Global thinking default for calls that don't set `think` (default on; registered models think at their max level). [details](docs/ENV_VARS.md#llm-client-and-thinking) |
-| `LLM_THINKING_LEVEL` | Overrides the thinking level for models with registered levels (e.g. `medium`); invalid → max with a warning. [details](docs/ENV_VARS.md#llm-client-and-thinking) |
-| `LLM_RATE_LIMIT_MAX_RETRIES` / `LLM_RATE_LIMIT_BACKOFF_INITIAL` / `LLM_RATE_LIMIT_BACKOFF_MAX` | Slow backoff schedule for HTTP 429 rate limits (defaults `5` retries, `300`s→`3600`s), independent of the transient schedule. [details](docs/ENV_VARS.md#llm-rate-limits) |
-| `LLM_RATE_LIMIT_HONOR_RETRY_AFTER` | When on (default), honor an integer-seconds `Retry-After` on a 429 additively — never below the configured floor. [details](docs/ENV_VARS.md#llm-rate-limits) |
-| `TEMPORAL_ADDRESS` | Enables Temporal mode when set |
-| `TEMPORAL_NAMESPACE` | Temporal namespace |
-| `TEMPORAL_TASK_QUEUE` | Temporal task queue name |
-| `SECURITY_GATEWAY_ENABLED` | Security gateway toggle (default: true) |
-| `ENABLE_LOG_API` | Exposes HTTP log endpoint |
-| `BLOGGING_RUN_ARTIFACTS_ROOT` | Optional root for pipeline run artifacts (default: `{tempdir}/blogging_runs`; Docker sets `/data/blogging/runs`) |
-| `BLOGGING_MEDIUM_STATS_ROOT` | Optional base dir for Medium stats job `work_dir` (default: `{AGENT_CACHE}/blogging_team/medium_stats_runs`) |
-| `MEDIUM_GOOGLE_REDIRECT_URI` | Optional; fixed OAuth redirect for Medium’s Google identity link (`…/api/integrations/medium/oauth/google/callback`) when the API is behind a proxy |
-| `BLOG_PLANNING_MAX_ITERATIONS` | Blog planning refine loop cap (default 5) |
-| `BLOG_PLANNING_MAX_PARSE_RETRIES` | JSON parse/repair attempts per planning LLM call (default 3) |
-| `BLOG_PLANNING_MODEL` | Optional Ollama model name for **planning only** (same base URL as `LLM_*`) |
-| `INTEGRATIONS_BROWSER_SESSION_ROOT` | Root for Playwright `storage_state` files used by browser-based integrations (Medium, etc.); Docker maps to the shared `agents_data` volume |
-| `SE_WORKSPACE_DIR` | Root for software-engineering team per-job workspaces |
+| `LLM_PROVIDER` / `LLM_BASE_URL` / `LLM_MODEL` | LLM provider selection, server URL, model name |
+| `POSTGRES_HOST` (+ `_PORT`/`_USER`/`_PASSWORD`/`_DB`) | Required for migrated teams; enables Postgres-backed stores via `shared_postgres`; no SQLite fallback |
+| `JOB_SERVICE_URL` | Central job service; required by every team's `JobServiceClient` |
+| `TEMPORAL_ADDRESS` (+ `TEMPORAL_NAMESPACE`/`TEMPORAL_TASK_QUEUE`) | Enables Temporal mode when set |
 | `AGENT_CACHE` | Shared cache root for all teams (Docker: `/data/agents`); each team namespaces under `{team_name}/` |
+| `SE_WORKSPACE_DIR` | Root for software-engineering team per-job workspaces |
+| `SECURITY_GATEWAY_ENABLED` | Security gateway toggle (default: true) |
 | `UNIFIED_API_PORT` / `UNIFIED_API_HOST` | Bind address/port for the Unified API (default `0.0.0.0:8080`) |
-| `POSTGRES_HOST` (and `POSTGRES_PORT`/`USER`/`PASSWORD`/`DB`) | Required for migrated teams; enables Postgres-backed stores via `shared_postgres`; no SQLite fallback. [details](docs/ENV_VARS.md#shared-infrastructure-and-storage) |
-| `ARCHITECT_MODEL_SPECIALIST` / `ARCHITECT_MODEL_ORCHESTRATOR` | Per-role model overrides for the AI Systems team |
-| `ALPHA_VANTAGE_API_KEY` / `FRED_API_KEY` | Market data providers used by the Investment Strategy Lab |
-| `INVESTMENT_MARKET_DATA_CACHE_ROOT` | Override for the on-disk root of the Investment Team's market-data cache (falls back to `${AGENT_CACHE}/investment_team/market_data`, then a tempdir). [details](docs/ENV_VARS.md#investment-and-market-data) |
-| `MARKET_DATA_FETCH_WORKERS` | Worker count for multi-symbol market-data fetch (default `min(len(symbols), 16)`). [details](docs/ENV_VARS.md#investment-and-market-data) |
-| `STRATEGY_LAB_LLM_*` | LLM fault-tolerance envelope for every Strategy Lab call: per-call `_TIMEOUT`, `_MAX_RETRIES`, transient `_BACKOFF_BASE`/`_BACKOFF_MAX`, 429 `_RATE_LIMIT_BACKOFF_INITIAL`/`_RATE_LIMIT_BACKOFF_MAX`, and cumulative `_TOTAL_BUDGET` (each falls back to the matching `LLM_*`). [full reference](backend/agents/investment_team/strategy_lab/README.md) |
-| `STRATEGY_LAB_DESIGN_*` / `STRATEGY_LAB_MECHANICAL_REPAIR_ENABLED` | Design ↔ review loop tuning: `_DESIGN_REVIEW_ROUNDS`/`_DESIGN_REVIEW_STALL_ROUNDS`, mechanical-repair pre-flight toggle, `_DESIGN_SELF_REVIEW_ENABLED`/`_DESIGN_SELF_REVISION_ROUNDS`, `_DESIGN_PARSE_RETRIES`/`_REFINEMENT_PARSE_RETRIES`, `_STRUCTURED_OUTPUT_ENABLED`, and the per-cycle `_DESIGN_MAX_LLM_CALLS` cap. [full reference](backend/agents/investment_team/strategy_lab/README.md) |
-| `STRATEGY_LAB_*` (sizing, alignment, universe) | Gates & data tuning: `_SIZING_COHERENCE_TOLERANCE`, `_CODE_CONFORMANCE_RETRIES`, `_ALIGNMENT_RETRIES`/`_ALIGNMENT_ADJUDICATION_CONCURRENCY`, `_MAX_UNIVERSE_SYMBOLS`, `_MARKET_DATA_*`. Full knob reference (defaults, backoff math, edge cases): [`strategy_lab/README.md`](backend/agents/investment_team/strategy_lab/README.md). |
-| `AGENT_INVOKE_MAX_PAYLOAD_BYTES` | Hard cap on invoke request body (default 1 MiB; overflow → 413 without spinning up a sandbox). [details](docs/ENV_VARS.md#agent-console-and-invoke) |
-| `AGENT_INVOKE_MAX_OUTPUT_BYTES` | Hard cap on agent response body; oversized → truncated with `truncated: true` (default 1 MiB). [details](docs/ENV_VARS.md#agent-console-and-invoke) |
-| `AGENT_EXEC_TIMEOUT_S` | Default per-agent execution timeout in the sandbox (default `60`; overflow → 504). [details](docs/ENV_VARS.md#agent-console-and-invoke) |
-| `AGENT_COGNITION_REFLECTION_SUMMARY_LIMIT` | Most-recent summaries per scale fed to the reflection engine (default `6`). [details](docs/ENV_VARS.md#agent-cognition-and-knowledge-graph) |
-| `AGENT_COGNITION_REFLECTION_MAX_PROPOSALS` | Cap on `pending` rule proposals per `reflect` run (default `5`). [details](docs/ENV_VARS.md#agent-cognition-and-knowledge-graph) |
-| `AGENT_COGNITION_REFLECTION_INPUT_CHARS` | Character budget for the reflection LLM input block (default `8000`; uses the `cognition` model). [details](docs/ENV_VARS.md#agent-cognition-and-knowledge-graph) |
-| `GITHUB_TOKEN` | Default token for the coding team's `run-from-github` flow; per-request `github_token` overrides. Needs Issues/PRs/Contents read-write + Metadata read. [details](docs/ENV_VARS.md#coding-team-and-github) |
-| `GITHUB_API_URL` | Optional override for the GitHub REST base URL (default `https://api.github.com`; set for GH Enterprise). [details](docs/ENV_VARS.md#coding-team-and-github) |
-| `GITHUB_DEPENDENCY_CONCURRENCY` | Semaphore width for per-issue `blocked_by` dependency fetches enriching the issue picker (default `8`). [details](docs/ENV_VARS.md#coding-team-and-github) |
-| `GIT_COMMIT_USER_NAME` | Author/committer name for platform git commits (default `Khala`; native `GIT_AUTHOR_*`/`GIT_COMMITTER_*` win). [details](docs/ENV_VARS.md#se-ci-gate-and-git-identity) |
-| `GIT_COMMIT_USER_EMAIL` | Author/committer email for platform git commits (default `brandon.kindred@gmail.com`). [details](docs/ENV_VARS.md#se-ci-gate-and-git-identity) |
-| `SE_CI_GATE_ENABLED` | Master toggle for CI gate verification after code generation (default `true`) |
-| `SE_CI_GATE_TIMEOUT_S` | Timeout (s) for GitHub CI status polling when a remote is available (default `300`) |
-| `SE_CI_GATE_LOCAL_FALLBACK` | When `true` (default), run CI checks locally via subprocess when no GitHub remote is available |
-| `CODING_TEAM_REVIEW_RETRIES` | Retries for the Tech Lead `run_code_review` LLM call on transient failure (default `2` → 3 attempts). [details](docs/ENV_VARS.md#coding-team-and-github) |
-| `CODING_TEAM_ANSWER_WAIT_TIMEOUT_S` | Wall-clock cap the human-in-the-loop decision gate blocks for answers (default `3600`s; timeout → fail closed). [details](docs/ENV_VARS.md#coding-team-and-github) |
-| `NEO4J_BOLT_URL` | Bolt URL of the Neo4j server backing the Graphiti knowledge-graph layer; also the layer's enablement gate. [details](docs/ENV_VARS.md#agent-cognition-and-knowledge-graph) |
-| `NEO4J_USER` / `NEO4J_PASSWORD` / `NEO4J_DATABASE` | Neo4j credentials/database (defaults `neo4j` / empty / `neo4j`). Change the password before any non-local deployment |
-| `GRAPHITI_LLM_MODEL` | Model Graphiti uses for entity/edge extraction (defaults to the resolved `cognition` model). [details](docs/ENV_VARS.md#agent-cognition-and-knowledge-graph) |
-| `GRAPHITI_EMBED_MODEL` / `GRAPHITI_EMBED_DIM` | Embedding model + dimensionality for Graphiti hybrid search (defaults `nomic-embed-text` / `768`). [details](docs/ENV_VARS.md#agent-cognition-and-knowledge-graph) |
-| `AGENT_COGNITION_GRAPH_SYNC_INTERVAL_S` / `AGENT_COGNITION_GRAPH_SYNC_BATCH` | Cadence (default `300`s) and batch size (default `50`) of the background graph sync worker. [details](docs/ENV_VARS.md#agent-cognition-and-knowledge-graph) |
-| `NEO4J_SLOW_OP_MS` | Slow-call log threshold (ms, default `1000`) for `shared_neo4j.timed_graph_op` |
-| `AGENT_COGNITION_SCHEDULER_INTERVAL_S` | Cadence (default `3600`s, floored `60`) of the cognition scheduler (rollups → reflect → prune; never activates rules). [details](docs/ENV_VARS.md#agent-cognition-and-knowledge-graph) |
-| `AGENT_COGNITION_GRAPH_SEARCH_TOP_K` | Max related facts per knowledge-graph search in `build_graph_context` (default `10`), scoped to the agent's `group_id` |
-| `AUTHOR_PROFILE_PATH` | Path to author profile YAML injected into blogging prompts (falls back to `$AGENT_CACHE/author_profile.yaml`, then the bundled example) |
-| `AUTHOR_PROFILE_STRICT` | When `true`, missing/invalid profile raises instead of falling back to the bundled example. Recommended for production |
-| `JOB_SEEKER_PROFILE_PATH` | Path to the job-matching job-seeker profile YAML (falls back to `$AGENT_CACHE/job_seeker_profile.yaml`, then the bundled example) |
-| `JOB_SEEKER_PROFILE_STRICT` | When `true`, a missing/invalid job-seeker profile raises instead of falling back to the bundled example |
-| `JOB_MATCHING_SERVICE_URL` | Upstream URL the unified API proxies `/api/job-matching/*` to (the team reuses `OLLAMA_API_KEY` for web search) |
-| `SOCIAL_MARKETING_WINNING_POSTS_TOP_K` | Max exemplars retrieved from the social marketing Winning Posts Bank per concept run (default `5`) |
-| `SOCIAL_MARKETING_WINNING_POSTS_RERANK_ENABLED` | Enable LLM rerank stage in the Winning Posts Bank retrieval (default `true`; set to `false` to disable) |
-| `SOCIAL_MARKETING_WINNING_POSTS_INGEST_THRESHOLD` | Engagement-score cutoff (0..1) above which performance observations are auto-promoted into the Winning Posts Bank (default `0.7`) |
+| `GITHUB_TOKEN` | Token for the coding team's `run-from-github` flow (Issues/PRs/Contents read-write + Metadata read) |
 
-**Blogging pipeline:** `research → planning (ContentPlan) → writer → gates`; `POST /research-and-review` runs research + the same planning step. See `backend/agents/blogging/README.md` and repo `CHANGELOG.md`.
+**Blogging pipeline:** `research → planning (ContentPlan) → writer → gates`. See `backend/agents/blogging/README.md`.
 
-**Google browser login (shared):** **`GET/PUT/DELETE /api/integrations/google-browser-login`** stores one Fernet-encrypted Gmail/Google email+password for **any** integration that signs in with Google via Playwright in **Postgres only** (`encrypted_integration_credentials` when `POSTGRES_HOST` is set, e.g. Docker). **Not available** without Postgres (credentials are never stored in SQLite). Code: `unified_api/google_browser_login_credentials.py` — reuse for new integrations when the site uses “Sign in with Google”.
-
-**Medium.com integration:** **Medium statistics** need **`storage_state`** on disk (`INTEGRATIONS_BROWSER_SESSION_ROOT`). With provider **Google**, Playwright uses the **shared** credentials above; **`POST /api/integrations/medium/session/browser-login`** captures the session; the stats resolver **auto-logs in** if the session file is missing. Optional **Google OAuth client** in the UI is only for `GET /api/integrations/medium/oauth/google/connect`.
+**Google browser login (shared):** `GET/PUT/DELETE /api/integrations/google-browser-login` stores one Fernet-encrypted Google credential (Postgres only — never SQLite) for any Playwright integration that signs in with Google. Reuse `unified_api/google_browser_login_credentials.py` for new "Sign in with Google" integrations. Medium uses this flow; details in `backend/agents/blogging/README.md`.
 
 ## Testing
 


### PR DESCRIPTION
Closes #843

Reduces CLAUDE.md from 328 lines (~30 KB) to 219 lines (~16 KB) by removing content that duplicates dedicated documentation. No information is lost — every cut section now points at the doc that already owns it.

## Changes

- **Environment variables**: cut the table from 67 rows to 10 core vars (LLM, Postgres, `JOB_SERVICE_URL`, Temporal, `AGENT_CACHE`, `SE_WORKSPACE_DIR`, security gateway, bind address, `GITHUB_TOKEN`). The full reference remains `docs/ENV_VARS.md`; team-specific knobs stay in the owning teams' READMEs.
- **Repository structure**: collapsed the tree from 64 lines to 26, keeping only load-bearing entries. The authoritative team list is `TEAM_CONFIGS` in `backend/unified_api/config.py`, which the doc now points to instead of enumerating all 21 team directories.
- **Deep-dive sections → pointers**: the Agent Console section defers to the three component READMEs; the Product Delivery Loop section defers to `docs/ARCHITECTURE.md` §11 (which already documents the release-hook path caveat); the Medium/Google browser-login paragraphs collapse to the shared-credential convention plus a pointer to `backend/agents/blogging/README.md`.
- **Command blocks**: moved prose out of the local-dev Postgres bash block into a short intro paragraph (keeping the no-SQLite-fallback, `JOB_SERVICE_URL`, and pytest conftest facts) and shrank the Docker Volumes paragraph to two sentences.

Untouched: Project Overview, Common Commands, Execution Model, SE pipeline, Sub-Team Variants, Code Style, Project Rules, Testing, and Reference Docs.

https://claude.ai/code/session_01MaXfGwwTiYUQyCBWWSeBU1

---
_Generated by [Claude Code](https://claude.ai/code/session_01MaXfGwwTiYUQyCBWWSeBU1)_