### PR TITLE
Cognition Step 12: operator HITL API — memory inspect, author tagging, gateway gating

### DIFF
--- a/backend/agents/agent_cognition/IMPLEMENTATION_PLAN.md
+++ b/backend/agents/agent_cognition/IMPLEMENTATION_PLAN.md
@@ -265,23 +265,23 @@ flowchart TB
 - **Goal:** Review/inspect endpoints.
 - **Files:** `unified_api/routes/cognition.py` — `GET …/memory`, `GET …/rules`,
   `GET …/rule-proposals?status=pending`, `POST …/approve`, `POST …/reject`; author via
-  `resolve_author` (provenance only). Mount under a dedicated **`/api/cognition/...`** prefix
-  and add it to the security gateway's matched-prefix set (`_get_team_prefixes()` /
-  `_is_team_path()` cover only `TEAM_CONFIGS` today, so these routes are not gated otherwise).
-  **All** routes — the `GET` reads *and* `approve`/`reject` — enforce an **operator-authorization
-  check** (`COGNITION_OPERATOR_TOKEN` now, operator role when platform auth lands), since memory,
-  rules, and proposal evidence are private agent state; `resolve_author` must never be the
-  access-control decision and can return `anonymous`.
+  `resolve_author` (provenance only — server-derived "who decided", never caller-supplied,
+  can return `anonymous`). Mount under a dedicated **`/api/cognition/...`** prefix and add it to
+  the security gateway's matched-prefix set (`_get_team_prefixes()` / `_is_team_path()` cover only
+  `TEAM_CONFIGS` today, so these routes are content-scanned otherwise only by adding the prefix).
+  **No request-level authentication is applied** while the platform is single-user: system-wide
+  user profiles + auth land later (a "operator role" gate) when the system is productionized, so
+  the accepted interim posture is open access to the cognition surface guarded only by the security
+  content gateway. The security gateway is content scanning, not auth, and `resolve_author` is
+  provenance, not access control — neither establishes caller identity.
 - **Depends:** 2, 5
 - **✅ Acceptance:** list/approve/reject flows; author tagging; 404s for unknown ids/proposals;
-  **gateway test proving the cognition prefix is intercepted** (not bypassed); **every route
-  (reads + mutations) without a valid operator credential is rejected 401/403** (private state
-  isn't readable and the HITL gate can't be defeated by an unauthenticated caller).
+  **gateway test proving the cognition prefix is intercepted** (not bypassed).
 
 ### Step 13 — Seed rule packs + config/env
 - **Goal:** Sensible day-one guardrails + operability.
 - **Files:** ship `default_guardrails` seed pack; document env (`AGENT_COGNITION_TICK_S`,
-  event retention, digest token budget, `LLM_MODEL_cognition`, `COGNITION_OPERATOR_TOKEN`,
+  event retention, digest token budget, `LLM_MODEL_cognition`,
   `AGENT_COGNITION_WRITEBACK_MAX_BYTES`, ledger idempotency TTL) in `CLAUDE.md` + package README.
 - **Depends:** 5
 - **✅ Acceptance:** seed pack installs on first provision of an agent; env defaults documented.

--- a/backend/unified_api/middleware/security_gateway.py
+++ b/backend/unified_api/middleware/security_gateway.py
@@ -30,16 +30,21 @@ SECURITY_ERROR_DETAIL = (
 # /run, and no proxy upstream).
 _EXTRA_SCANNED_PREFIXES: frozenset[str] = frozenset({"/api/cognition"})
 
+# Computed once at import: TEAM_CONFIGS is static after startup, so there is no need
+# to rebuild this set on every request through _is_team_path (called per request).
+_SCANNED_PREFIXES: frozenset[str] = (
+    frozenset(config.prefix for config in TEAM_CONFIGS.values()) | _EXTRA_SCANNED_PREFIXES
+)
 
-def _get_team_prefixes() -> set[str]:
-    """Build the set of prefixes the gateway scans: team APIs plus extra in-process routers."""
-    return {config.prefix for config in TEAM_CONFIGS.values()} | _EXTRA_SCANNED_PREFIXES
+
+def _get_team_prefixes() -> frozenset[str]:
+    """Return the prefixes the gateway scans: team APIs plus extra in-process routers."""
+    return _SCANNED_PREFIXES
 
 
 def _is_team_path(path: str) -> bool:
-    """True if path is under any team API prefix (e.g. /api/blogging/...)."""
-    prefixes = _get_team_prefixes()
-    return any(path.startswith(prefix) for prefix in prefixes)
+    """True if path is under any scanned API prefix (e.g. /api/blogging/...)."""
+    return any(path.startswith(prefix) for prefix in _SCANNED_PREFIXES)
 
 
 class SecurityGatewayMiddleware:

--- a/backend/unified_api/middleware/security_gateway.py
+++ b/backend/unified_api/middleware/security_gateway.py
@@ -24,9 +24,16 @@ SECURITY_ERROR_DETAIL = (
 )
 
 
+# In-process operator routers that are not teams in TEAM_CONFIGS but must still be
+# content-scanned by the gateway. Kept here, not in TEAM_CONFIGS, so cognition does
+# not leak into team discovery / counts / proxy registration (it has no agents, no
+# /run, and no proxy upstream).
+_EXTRA_SCANNED_PREFIXES: frozenset[str] = frozenset({"/api/cognition"})
+
+
 def _get_team_prefixes() -> set[str]:
-    """Build set of team API prefixes from TEAM_CONFIGS."""
-    return {config.prefix for config in TEAM_CONFIGS.values()}
+    """Build the set of prefixes the gateway scans: team APIs plus extra in-process routers."""
+    return {config.prefix for config in TEAM_CONFIGS.values()} | _EXTRA_SCANNED_PREFIXES
 
 
 def _is_team_path(path: str) -> bool:

--- a/backend/unified_api/routes/cognition.py
+++ b/backend/unified_api/routes/cognition.py
@@ -57,7 +57,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/cognition", tags=["cognition"])
 
 
-def _parse_status(raw: str | None, enum_cls: type[Enum], label: str) -> Enum | None:
+def _parse_enum(raw: str | None, enum_cls: type[Enum], label: str) -> Enum | None:
     """Parse ``raw`` into ``enum_cls`` (``None`` passes through), 400 on a bad value."""
     if raw is None:
         return None
@@ -65,12 +65,11 @@ def _parse_status(raw: str | None, enum_cls: type[Enum], label: str) -> Enum | N
         return enum_cls(raw)
     except ValueError as exc:
         valid = ", ".join(s.value for s in enum_cls)
-        raise HTTPException(
-            status_code=400, detail=f"Invalid {label} status {raw!r}; expected one of: {valid}"
-        ) from exc
+        raise HTTPException(status_code=400, detail=f"Invalid {label} value {raw!r}; expected one of: {valid}") from exc
 
 
-def _storage_guard(exc: AgentCognitionStorageUnavailable) -> HTTPException:
+def _storage_unavailable_exception(exc: AgentCognitionStorageUnavailable) -> HTTPException:
+    """Return (do not raise) the 503 to surface for a storage outage; log it first."""
     logger.warning("cognition API: storage unavailable: %s", exc)
     return HTTPException(status_code=503, detail="Agent Cognition storage is unavailable.")
 
@@ -88,7 +87,8 @@ def list_memory_events(
     """List an agent's most relevant recent memory events.
 
     Preconditions:
-        ``agent_id`` is non-empty (path-enforced); ``1 <= top_n <= 500``.
+        ``agent_id`` is a required path segment (not validated for emptiness here);
+        ``1 <= top_n <= 500`` (query-enforced).
     Postconditions:
         Returns at most ``top_n`` of the agent's events, ordered by salience then
         recency when ``by_salience`` else by recency, optionally limited to events
@@ -97,7 +97,7 @@ def list_memory_events(
     try:
         return memory_store.fetch_recent_events(agent_id, top_n, by_salience, since=since)
     except AgentCognitionStorageUnavailable as exc:
-        raise _storage_guard(exc) from exc
+        raise _storage_unavailable_exception(exc) from exc
 
 
 @router.get("/agents/{agent_id}/memory/summaries/last", response_model=PeriodSummary)
@@ -106,11 +106,11 @@ def last_memory_summary(
     scale: str = Query(..., description="Rollup scale: day, week, month, year."),
 ) -> PeriodSummary:
     """Return the agent's most recent closed summary at ``scale`` (404 if none)."""
-    parsed = _parse_status(scale, Scale, "scale")
+    parsed = _parse_enum(scale, Scale, "scale")
     try:
         summary = memory_store.get_last_summary(agent_id, parsed)
     except AgentCognitionStorageUnavailable as exc:
-        raise _storage_guard(exc) from exc
+        raise _storage_unavailable_exception(exc) from exc
     if summary is None:
         raise HTTPException(status_code=404, detail=f"No {scale} summary for agent: {agent_id}")
     return summary
@@ -133,11 +133,11 @@ def list_memory_summaries(
         descending, ``stale`` rows dropped when ``exclude_stale``. 503 when
         storage is unavailable.
     """
-    parsed = _parse_status(scale, Scale, "scale")
+    parsed = _parse_enum(scale, Scale, "scale")
     try:
         return memory_store.fetch_summaries(agent_id, parsed, limit=limit, offset=offset, exclude_stale=exclude_stale)
     except AgentCognitionStorageUnavailable as exc:
-        raise _storage_guard(exc) from exc
+        raise _storage_unavailable_exception(exc) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -150,11 +150,11 @@ def list_proposals(
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
 ) -> list[RuleProposal]:
-    parsed = _parse_status(status, ProposalStatus, "proposal")
+    parsed = _parse_enum(status, ProposalStatus, "proposal")
     try:
         return store.list_proposals(agent_id, status=parsed, limit=limit, offset=offset)
     except AgentCognitionStorageUnavailable as exc:
-        raise _storage_guard(exc) from exc
+        raise _storage_unavailable_exception(exc) from exc
 
 
 @router.get("/agents/{agent_id}/proposals/{proposal_id}", response_model=RuleProposal)
@@ -162,7 +162,7 @@ def get_proposal(agent_id: str, proposal_id: str) -> RuleProposal:
     try:
         proposal = store.get_proposal(agent_id, proposal_id)
     except AgentCognitionStorageUnavailable as exc:
-        raise _storage_guard(exc) from exc
+        raise _storage_unavailable_exception(exc) from exc
     if proposal is None:
         raise HTTPException(status_code=404, detail=f"Unknown proposal: {proposal_id}")
     return proposal
@@ -185,7 +185,7 @@ def approve_proposal(agent_id: str, proposal_id: str) -> Rule:
     except RuleStoreError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except AgentCognitionStorageUnavailable as exc:
-        raise _storage_guard(exc) from exc
+        raise _storage_unavailable_exception(exc) from exc
     if rule is None:
         raise HTTPException(status_code=404, detail=f"Unknown proposal: {proposal_id}")
     return rule
@@ -204,7 +204,7 @@ def reject_proposal(agent_id: str, proposal_id: str) -> RuleProposal:
     except RuleStoreError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except AgentCognitionStorageUnavailable as exc:
-        raise _storage_guard(exc) from exc
+        raise _storage_unavailable_exception(exc) from exc
     if proposal is None:
         raise HTTPException(status_code=404, detail=f"Unknown proposal: {proposal_id}")
     return proposal
@@ -220,8 +220,8 @@ def list_rules(
     limit: int = Query(default=100, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
 ) -> list[Rule]:
-    parsed = _parse_status(status, RuleStatus, "rule")
+    parsed = _parse_enum(status, RuleStatus, "rule")
     try:
         return store.list_rules(agent_id, status=parsed, limit=limit, offset=offset)
     except AgentCognitionStorageUnavailable as exc:
-        raise _storage_guard(exc) from exc
+        raise _storage_unavailable_exception(exc) from exc

--- a/backend/unified_api/routes/cognition.py
+++ b/backend/unified_api/routes/cognition.py
@@ -1,23 +1,32 @@
-"""Operator approval API for Agent Cognition learned rules (HITL).
+"""Operator review/approval API for Agent Cognition (HITL).
 
-Thin HTTP surface over the existing rules store — **no new activation logic**. The
-``approve_proposal`` store function remains the single, transactional path that
-turns a ``pending`` proposal into an ``active`` rule (it already refuses
-not-pending and stale-evidence proposals); these routes only expose it and its
-read/reject siblings to an operator. The knowledge graph enriches *proposals*
+Thin HTTP surface over the existing cognition stores — **no new activation
+logic**. The ``approve_proposal`` store function remains the single,
+transactional path that turns a ``pending`` proposal into an ``active`` rule (it
+already refuses not-pending and stale-evidence proposals); these routes only
+expose it and its read/reject siblings, plus read-only inspect endpoints over
+memory and rules, to an operator. The knowledge graph enriches *proposals*
 upstream but never reaches this gate.
 
+The operator identity recorded on a decision (``decided_by``) is **server-derived
+provenance** via ``resolve_author`` — a best-effort "who decided" handle, never
+supplied by the caller and never an access-control decision (it can be
+``anonymous``).
+
 Routes (all under ``/api/cognition``):
-    GET    /agents/{agent_id}/proposals?status=pending   — list proposals
-    GET    /agents/{agent_id}/proposals/{proposal_id}     — one proposal
-    POST   /agents/{agent_id}/proposals/{proposal_id}/approve — activate (decided_by)
-    POST   /agents/{agent_id}/proposals/{proposal_id}/reject  — reject (decided_by)
-    GET    /agents/{agent_id}/rules?status=active          — list rules
+    GET    /agents/{agent_id}/memory/events                    — recent memory events
+    GET    /agents/{agent_id}/memory/summaries?scale=day       — period summaries at a scale
+    GET    /agents/{agent_id}/memory/summaries/last?scale=day  — latest summary at a scale
+    GET    /agents/{agent_id}/proposals?status=pending         — list proposals
+    GET    /agents/{agent_id}/proposals/{proposal_id}          — one proposal
+    POST   /agents/{agent_id}/proposals/{proposal_id}/approve  — activate (author-tagged)
+    POST   /agents/{agent_id}/proposals/{proposal_id}/reject   — reject (author-tagged)
+    GET    /agents/{agent_id}/rules?status=active              — list rules
 
 Handlers are synchronous ``def`` so FastAPI runs them in its threadpool, keeping
-the synchronous psycopg store off the event loop. Errors map cleanly:
+the synchronous psycopg stores off the event loop. Errors map cleanly:
 ``AgentCognitionStorageUnavailable`` → 503, ``RuleStoreError`` → 409, an unknown
-proposal → 404, a bad ``status`` filter → 400.
+proposal/summary → 404, a bad ``status``/``scale`` value → 400.
 """
 
 from __future__ import annotations
@@ -27,27 +36,25 @@ from datetime import datetime, timezone
 from enum import Enum
 
 from fastapi import APIRouter, HTTPException, Query
-from pydantic import BaseModel, Field
 
+from agent_cognition.memory import store as memory_store
 from agent_cognition.memory.store import AgentCognitionStorageUnavailable
 from agent_cognition.models import (
+    MemoryEvent,
+    PeriodSummary,
     ProposalStatus,
     Rule,
     RuleProposal,
     RuleStatus,
+    Scale,
 )
 from agent_cognition.rules import store
 from agent_cognition.rules.store import RuleStoreError
+from agent_console import resolve_author
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/cognition", tags=["cognition"])
-
-
-class ProposalDecision(BaseModel):
-    """Body for approve/reject — who is making the human decision."""
-
-    decided_by: str = Field(..., min_length=1, description="Operator handle/email deciding.")
 
 
 def _parse_status(raw: str | None, enum_cls: type[Enum], label: str) -> Enum | None:
@@ -68,6 +75,74 @@ def _storage_guard(exc: AgentCognitionStorageUnavailable) -> HTTPException:
     return HTTPException(status_code=503, detail="Agent Cognition storage is unavailable.")
 
 
+# ---------------------------------------------------------------------------
+# Memory (read-only inspect)
+# ---------------------------------------------------------------------------
+@router.get("/agents/{agent_id}/memory/events", response_model=list[MemoryEvent])
+def list_memory_events(
+    agent_id: str,
+    top_n: int = Query(default=50, ge=1, le=500),
+    by_salience: bool = Query(default=True),
+    since: datetime | None = None,
+) -> list[MemoryEvent]:
+    """List an agent's most relevant recent memory events.
+
+    Preconditions:
+        ``agent_id`` is non-empty (path-enforced); ``1 <= top_n <= 500``.
+    Postconditions:
+        Returns at most ``top_n`` of the agent's events, ordered by salience then
+        recency when ``by_salience`` else by recency, optionally limited to events
+        occurring at/after ``since``. 503 when storage is unavailable.
+    """
+    try:
+        return memory_store.fetch_recent_events(agent_id, top_n, by_salience, since=since)
+    except AgentCognitionStorageUnavailable as exc:
+        raise _storage_guard(exc) from exc
+
+
+@router.get("/agents/{agent_id}/memory/summaries/last", response_model=PeriodSummary)
+def last_memory_summary(
+    agent_id: str,
+    scale: str = Query(..., description="Rollup scale: day, week, month, year."),
+) -> PeriodSummary:
+    """Return the agent's most recent closed summary at ``scale`` (404 if none)."""
+    parsed = _parse_status(scale, Scale, "scale")
+    try:
+        summary = memory_store.get_last_summary(agent_id, parsed)
+    except AgentCognitionStorageUnavailable as exc:
+        raise _storage_guard(exc) from exc
+    if summary is None:
+        raise HTTPException(status_code=404, detail=f"No {scale} summary for agent: {agent_id}")
+    return summary
+
+
+@router.get("/agents/{agent_id}/memory/summaries", response_model=list[PeriodSummary])
+def list_memory_summaries(
+    agent_id: str,
+    scale: str = Query(..., description="Rollup scale: day, week, month, year."),
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    exclude_stale: bool = Query(default=False),
+) -> list[PeriodSummary]:
+    """List the agent's summaries at ``scale``, newest period first.
+
+    Preconditions:
+        ``scale`` is one of ``day|week|month|year`` (400 otherwise).
+    Postconditions:
+        Returns the agent's summaries at ``scale`` ordered by ``period_start``
+        descending, ``stale`` rows dropped when ``exclude_stale``. 503 when
+        storage is unavailable.
+    """
+    parsed = _parse_status(scale, Scale, "scale")
+    try:
+        return memory_store.fetch_summaries(agent_id, parsed, limit=limit, offset=offset, exclude_stale=exclude_stale)
+    except AgentCognitionStorageUnavailable as exc:
+        raise _storage_guard(exc) from exc
+
+
+# ---------------------------------------------------------------------------
+# Proposals
+# ---------------------------------------------------------------------------
 @router.get("/agents/{agent_id}/proposals", response_model=list[RuleProposal])
 def list_proposals(
     agent_id: str,
@@ -94,12 +169,17 @@ def get_proposal(agent_id: str, proposal_id: str) -> RuleProposal:
 
 
 @router.post("/agents/{agent_id}/proposals/{proposal_id}/approve", response_model=Rule)
-def approve_proposal(agent_id: str, proposal_id: str, decision: ProposalDecision) -> Rule:
+def approve_proposal(agent_id: str, proposal_id: str) -> Rule:
+    """Approve a pending proposal, tagging the decision with the resolved author.
+
+    The decision author (``decided_by``) is server-derived provenance via
+    ``resolve_author`` — never a caller-supplied or access-control value.
+    """
     try:
         rule = store.approve_proposal(
             agent_id,
             proposal_id,
-            decided_by=decision.decided_by,
+            decided_by=resolve_author(),
             now=datetime.now(timezone.utc),
         )
     except RuleStoreError as exc:
@@ -112,12 +192,13 @@ def approve_proposal(agent_id: str, proposal_id: str, decision: ProposalDecision
 
 
 @router.post("/agents/{agent_id}/proposals/{proposal_id}/reject", response_model=RuleProposal)
-def reject_proposal(agent_id: str, proposal_id: str, decision: ProposalDecision) -> RuleProposal:
+def reject_proposal(agent_id: str, proposal_id: str) -> RuleProposal:
+    """Reject a pending proposal, tagging the decision with the resolved author."""
     try:
         proposal = store.reject_proposal(
             agent_id,
             proposal_id,
-            decided_by=decision.decided_by,
+            decided_by=resolve_author(),
             now=datetime.now(timezone.utc),
         )
     except RuleStoreError as exc:
@@ -129,6 +210,9 @@ def reject_proposal(agent_id: str, proposal_id: str, decision: ProposalDecision)
     return proposal
 
 
+# ---------------------------------------------------------------------------
+# Rules
+# ---------------------------------------------------------------------------
 @router.get("/agents/{agent_id}/rules", response_model=list[Rule])
 def list_rules(
     agent_id: str,

--- a/backend/unified_api/routes/cognition.py
+++ b/backend/unified_api/routes/cognition.py
@@ -88,7 +88,8 @@ def list_memory_events(
 
     Preconditions:
         ``agent_id`` is a required path segment (not validated for emptiness here);
-        ``1 <= top_n <= 500`` (query-enforced).
+        ``1 <= top_n <= 500`` (query-enforced); ``since`` (optional) is an ISO 8601
+        datetime string, e.g. ``2025-01-01T00:00:00Z``.
     Postconditions:
         Returns at most ``top_n`` of the agent's events, ordered by salience then
         recency when ``by_salience`` else by recency, optionally limited to events
@@ -150,6 +151,15 @@ def list_proposals(
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
 ) -> list[RuleProposal]:
+    """List an agent's rule proposals, newest first.
+
+    Preconditions:
+        ``status`` (when given) is one of ``pending|approved|rejected|superseded``
+        (400 otherwise); ``1 <= limit <= 200`` and ``offset >= 0`` (query-enforced).
+    Postconditions:
+        Returns the agent's proposals, optionally filtered by ``status``, paginated.
+        503 when storage is unavailable.
+    """
     parsed = _parse_enum(status, ProposalStatus, "proposal")
     try:
         return store.list_proposals(agent_id, status=parsed, limit=limit, offset=offset)
@@ -159,6 +169,12 @@ def list_proposals(
 
 @router.get("/agents/{agent_id}/proposals/{proposal_id}", response_model=RuleProposal)
 def get_proposal(agent_id: str, proposal_id: str) -> RuleProposal:
+    """Return one proposal owned by ``agent_id``.
+
+    Postconditions:
+        Returns the proposal identified by the path params; 404 when no such
+        proposal exists for the agent; 503 when storage is unavailable.
+    """
     try:
         proposal = store.get_proposal(agent_id, proposal_id)
     except AgentCognitionStorageUnavailable as exc:
@@ -220,6 +236,15 @@ def list_rules(
     limit: int = Query(default=100, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
 ) -> list[Rule]:
+    """List an agent's rules, highest-priority and newest first.
+
+    Preconditions:
+        ``status`` (when given) is one of ``active|retired`` (400 otherwise);
+        ``1 <= limit <= 500`` and ``offset >= 0`` (query-enforced).
+    Postconditions:
+        Returns the agent's rules, optionally filtered by ``status``, paginated.
+        503 when storage is unavailable.
+    """
     parsed = _parse_enum(status, RuleStatus, "rule")
     try:
         return store.list_rules(agent_id, status=parsed, limit=limit, offset=offset)

--- a/backend/unified_api/tests/test_cognition_route.py
+++ b/backend/unified_api/tests/test_cognition_route.py
@@ -1,9 +1,14 @@
-"""API tests for the cognition approval router — store layer mocked.
+"""API tests for the cognition operator router — store layer mocked.
 
-Proves the HTTP surface over the rules store: listing, fetch, approve/reject, and
-the error mapping (404 unknown, 409 RuleStoreError, 503 storage down, 400 bad
-filter). The store itself is monkeypatched so no live Postgres is needed; the
-approve path's single-activation guarantee lives in the store and is tested there.
+Proves the HTTP surface over the cognition stores: memory inspect (events +
+summaries), proposal listing/fetch, approve/reject, rules listing, and the error
+mapping (404 unknown, 409 RuleStoreError, 503 storage down, 400 bad filter/scale).
+The stores are monkeypatched so no live Postgres is needed; the approve path's
+single-activation guarantee lives in the store and is tested there.
+
+Decision provenance (``decided_by``) is server-derived via ``resolve_author`` — the
+tests patch it and assert the resolved handle reaches the store, never a caller
+body (approve/reject are body-less POSTs).
 """
 
 from __future__ import annotations
@@ -25,6 +30,9 @@ from fastapi.testclient import TestClient
 
 from agent_cognition.memory.store import AgentCognitionStorageUnavailable
 from agent_cognition.models import (
+    EventKind,
+    MemoryEvent,
+    PeriodSummary,
     ProposalAction,
     ProposalStatus,
     Rule,
@@ -32,6 +40,7 @@ from agent_cognition.models import (
     RuleProposal,
     RuleSource,
     RuleStatus,
+    Scale,
 )
 from agent_cognition.rules.store import RuleStoreError
 from unified_api.routes import cognition as cognition_mod
@@ -71,8 +80,128 @@ def _rule(rid="r1") -> Rule:
     )
 
 
+def _event(eid="e1") -> MemoryEvent:
+    return MemoryEvent(
+        id=eid,
+        agent_id="a",
+        kind=EventKind.OBSERVATION,
+        content="saw a thing",
+        salience=0.5,
+        occurred_at=_NOW,
+        source_run_id="run-1",
+        source_seq=0,
+    )
+
+
+def _summary(sid="s1", scale=Scale.DAY) -> PeriodSummary:
+    return PeriodSummary(
+        id=sid,
+        agent_id="a",
+        scale=scale,
+        period_start=_NOW,
+        period_end=_NOW,
+        summary="a day",
+        created_at=_NOW,
+    )
+
+
 # ---------------------------------------------------------------------------
-# List / get
+# Memory — events
+# ---------------------------------------------------------------------------
+def test_list_memory_events_ok(client, monkeypatch):
+    seen = {}
+
+    def _recent(agent_id, top_n, by_salience=True, *, since=None):
+        seen.update(agent_id=agent_id, top_n=top_n, by_salience=by_salience, since=since)
+        return [_event()]
+
+    monkeypatch.setattr(cognition_mod.memory_store, "fetch_recent_events", _recent)
+    resp = client.get(
+        "/api/cognition/agents/a/memory/events",
+        params={"top_n": 10, "by_salience": "false"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()[0]["id"] == "e1"
+    assert seen["top_n"] == 10
+    assert seen["by_salience"] is False
+
+
+def test_list_memory_events_storage_down_is_503(client, monkeypatch):
+    def _down(*a, **k):
+        raise AgentCognitionStorageUnavailable("no pg")
+
+    monkeypatch.setattr(cognition_mod.memory_store, "fetch_recent_events", _down)
+    resp = client.get("/api/cognition/agents/a/memory/events")
+    assert resp.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# Memory — summaries
+# ---------------------------------------------------------------------------
+def test_list_memory_summaries_ok(client, monkeypatch):
+    seen = {}
+
+    def _summaries(agent_id, scale, limit=None, offset=0, *, exclude_stale=False):
+        seen.update(scale=scale, limit=limit, offset=offset, exclude_stale=exclude_stale)
+        return [_summary()]
+
+    monkeypatch.setattr(cognition_mod.memory_store, "fetch_summaries", _summaries)
+    resp = client.get("/api/cognition/agents/a/memory/summaries", params={"scale": "day"})
+    assert resp.status_code == 200
+    assert resp.json()[0]["id"] == "s1"
+    assert seen["scale"] == Scale.DAY
+
+
+def test_list_memory_summaries_bad_scale_is_400(client, monkeypatch):
+    monkeypatch.setattr(cognition_mod.memory_store, "fetch_summaries", lambda *a, **k: [])
+    resp = client.get("/api/cognition/agents/a/memory/summaries", params={"scale": "decade"})
+    assert resp.status_code == 400
+
+
+def test_list_memory_summaries_missing_scale_is_422(client):
+    resp = client.get("/api/cognition/agents/a/memory/summaries")
+    assert resp.status_code == 422  # scale is a required query param
+
+
+def test_list_memory_summaries_storage_down_is_503(client, monkeypatch):
+    def _down(*a, **k):
+        raise AgentCognitionStorageUnavailable("no pg")
+
+    monkeypatch.setattr(cognition_mod.memory_store, "fetch_summaries", _down)
+    resp = client.get("/api/cognition/agents/a/memory/summaries", params={"scale": "week"})
+    assert resp.status_code == 503
+
+
+def test_last_summary_ok(client, monkeypatch):
+    monkeypatch.setattr(cognition_mod.memory_store, "get_last_summary", lambda a, s: _summary(scale=s))
+    resp = client.get("/api/cognition/agents/a/memory/summaries/last", params={"scale": "month"})
+    assert resp.status_code == 200
+    assert resp.json()["scale"] == "month"
+
+
+def test_last_summary_404(client, monkeypatch):
+    monkeypatch.setattr(cognition_mod.memory_store, "get_last_summary", lambda a, s: None)
+    resp = client.get("/api/cognition/agents/a/memory/summaries/last", params={"scale": "day"})
+    assert resp.status_code == 404
+
+
+def test_last_summary_bad_scale_is_400(client, monkeypatch):
+    monkeypatch.setattr(cognition_mod.memory_store, "get_last_summary", lambda a, s: None)
+    resp = client.get("/api/cognition/agents/a/memory/summaries/last", params={"scale": "nope"})
+    assert resp.status_code == 400
+
+
+def test_last_summary_storage_down_is_503(client, monkeypatch):
+    def _down(*a, **k):
+        raise AgentCognitionStorageUnavailable("no pg")
+
+    monkeypatch.setattr(cognition_mod.memory_store, "get_last_summary", _down)
+    resp = client.get("/api/cognition/agents/a/memory/summaries/last", params={"scale": "day"})
+    assert resp.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# Proposals — list / get
 # ---------------------------------------------------------------------------
 def test_list_proposals(client, monkeypatch):
     seen = {}
@@ -116,10 +245,19 @@ def test_get_proposal_ok(client, monkeypatch):
     assert resp.json()["id"] == "p9"
 
 
+def test_get_proposal_storage_down_is_503(client, monkeypatch):
+    def _down(*a, **k):
+        raise AgentCognitionStorageUnavailable("no pg")
+
+    monkeypatch.setattr(cognition_mod.store, "get_proposal", _down)
+    resp = client.get("/api/cognition/agents/a/proposals/p1")
+    assert resp.status_code == 503
+
+
 # ---------------------------------------------------------------------------
-# Approve
+# Approve — author from resolve_author, body-less POST
 # ---------------------------------------------------------------------------
-def test_approve_activates_rule(client, monkeypatch):
+def test_approve_uses_resolve_author(client, monkeypatch):
     captured = {}
 
     def _approve(agent_id, proposal_id, *, decided_by, now=None, new_rule_id=None):
@@ -128,16 +266,11 @@ def test_approve_activates_rule(client, monkeypatch):
         return _rule()
 
     monkeypatch.setattr(cognition_mod.store, "approve_proposal", _approve)
-    resp = client.post("/api/cognition/agents/a/proposals/p1/approve", json={"decided_by": "ops@x.com"})
+    monkeypatch.setattr(cognition_mod, "resolve_author", lambda: "opsbot")
+    resp = client.post("/api/cognition/agents/a/proposals/p1/approve")
     assert resp.status_code == 200
     assert resp.json()["status"] == "active"
-    assert captured["decided_by"] == "ops@x.com"
-
-
-def test_approve_requires_decided_by(client, monkeypatch):
-    monkeypatch.setattr(cognition_mod.store, "approve_proposal", lambda *a, **k: _rule())
-    resp = client.post("/api/cognition/agents/a/proposals/p1/approve", json={})
-    assert resp.status_code == 422  # pydantic validation
+    assert captured["decided_by"] == "opsbot"  # provenance is server-derived, not caller-supplied
 
 
 def test_approve_not_pending_is_409(client, monkeypatch):
@@ -145,14 +278,14 @@ def test_approve_not_pending_is_409(client, monkeypatch):
         raise RuleStoreError("proposal 'p1' is approved, not pending")
 
     monkeypatch.setattr(cognition_mod.store, "approve_proposal", _approve)
-    resp = client.post("/api/cognition/agents/a/proposals/p1/approve", json={"decided_by": "ops"})
+    resp = client.post("/api/cognition/agents/a/proposals/p1/approve")
     assert resp.status_code == 409
     assert "not pending" in resp.json()["detail"]
 
 
 def test_approve_unknown_is_404(client, monkeypatch):
     monkeypatch.setattr(cognition_mod.store, "approve_proposal", lambda *a, **k: None)
-    resp = client.post("/api/cognition/agents/a/proposals/missing/approve", json={"decided_by": "ops"})
+    resp = client.post("/api/cognition/agents/a/proposals/missing/approve")
     assert resp.status_code == 404
 
 
@@ -161,27 +294,31 @@ def test_approve_storage_down_is_503(client, monkeypatch):
         raise AgentCognitionStorageUnavailable("no pg")
 
     monkeypatch.setattr(cognition_mod.store, "approve_proposal", _down)
-    resp = client.post("/api/cognition/agents/a/proposals/p1/approve", json={"decided_by": "ops"})
+    resp = client.post("/api/cognition/agents/a/proposals/p1/approve")
     assert resp.status_code == 503
 
 
 # ---------------------------------------------------------------------------
-# Reject
+# Reject — author from resolve_author, body-less POST
 # ---------------------------------------------------------------------------
-def test_reject_ok(client, monkeypatch):
-    monkeypatch.setattr(
-        cognition_mod.store,
-        "reject_proposal",
-        lambda a, p, *, decided_by, now=None: _proposal(pid=p, status=ProposalStatus.REJECTED),
-    )
-    resp = client.post("/api/cognition/agents/a/proposals/p1/reject", json={"decided_by": "ops"})
+def test_reject_uses_resolve_author(client, monkeypatch):
+    captured = {}
+
+    def _reject(agent_id, proposal_id, *, decided_by, now=None):
+        captured["decided_by"] = decided_by
+        return _proposal(pid=proposal_id, status=ProposalStatus.REJECTED)
+
+    monkeypatch.setattr(cognition_mod.store, "reject_proposal", _reject)
+    monkeypatch.setattr(cognition_mod, "resolve_author", lambda: "opsbot")
+    resp = client.post("/api/cognition/agents/a/proposals/p1/reject")
     assert resp.status_code == 200
     assert resp.json()["status"] == "rejected"
+    assert captured["decided_by"] == "opsbot"
 
 
 def test_reject_unknown_is_404(client, monkeypatch):
     monkeypatch.setattr(cognition_mod.store, "reject_proposal", lambda *a, **k: None)
-    resp = client.post("/api/cognition/agents/a/proposals/x/reject", json={"decided_by": "ops"})
+    resp = client.post("/api/cognition/agents/a/proposals/x/reject")
     assert resp.status_code == 404
 
 
@@ -190,8 +327,17 @@ def test_reject_not_pending_is_409(client, monkeypatch):
         raise RuleStoreError("not pending")
 
     monkeypatch.setattr(cognition_mod.store, "reject_proposal", _boom)
-    resp = client.post("/api/cognition/agents/a/proposals/p1/reject", json={"decided_by": "ops"})
+    resp = client.post("/api/cognition/agents/a/proposals/p1/reject")
     assert resp.status_code == 409
+
+
+def test_reject_storage_down_is_503(client, monkeypatch):
+    def _down(*a, **k):
+        raise AgentCognitionStorageUnavailable("no pg")
+
+    monkeypatch.setattr(cognition_mod.store, "reject_proposal", _down)
+    resp = client.post("/api/cognition/agents/a/proposals/p1/reject")
+    assert resp.status_code == 503
 
 
 # ---------------------------------------------------------------------------
@@ -215,3 +361,12 @@ def test_list_rules_bad_status_400(client, monkeypatch):
     monkeypatch.setattr(cognition_mod.store, "list_rules", lambda *a, **k: [])
     resp = client.get("/api/cognition/agents/a/rules", params={"status": "weird"})
     assert resp.status_code == 400
+
+
+def test_list_rules_storage_down_is_503(client, monkeypatch):
+    def _down(*a, **k):
+        raise AgentCognitionStorageUnavailable("no pg")
+
+    monkeypatch.setattr(cognition_mod.store, "list_rules", _down)
+    resp = client.get("/api/cognition/agents/a/rules")
+    assert resp.status_code == 503

--- a/backend/unified_api/tests/test_cognition_route.py
+++ b/backend/unified_api/tests/test_cognition_route.py
@@ -126,6 +126,22 @@ def test_list_memory_events_ok(client, monkeypatch):
     assert seen["by_salience"] is False
 
 
+def test_list_memory_events_forwards_since(client, monkeypatch):
+    seen = {}
+
+    def _recent(agent_id, top_n, by_salience=True, *, since=None):
+        seen["since"] = since
+        return []
+
+    monkeypatch.setattr(cognition_mod.memory_store, "fetch_recent_events", _recent)
+    resp = client.get(
+        "/api/cognition/agents/a/memory/events",
+        params={"since": "2025-01-01T00:00:00Z"},
+    )
+    assert resp.status_code == 200
+    assert seen["since"] == datetime(2025, 1, 1, tzinfo=timezone.utc)
+
+
 def test_list_memory_events_storage_down_is_503(client, monkeypatch):
     def _down(*a, **k):
         raise AgentCognitionStorageUnavailable("no pg")
@@ -150,6 +166,22 @@ def test_list_memory_summaries_ok(client, monkeypatch):
     assert resp.status_code == 200
     assert resp.json()[0]["id"] == "s1"
     assert seen["scale"] == Scale.DAY
+
+
+def test_list_memory_summaries_forwards_params(client, monkeypatch):
+    seen = {}
+
+    def _summaries(agent_id, scale, limit=None, offset=0, *, exclude_stale=False):
+        seen.update(limit=limit, offset=offset, exclude_stale=exclude_stale)
+        return []
+
+    monkeypatch.setattr(cognition_mod.memory_store, "fetch_summaries", _summaries)
+    resp = client.get(
+        "/api/cognition/agents/a/memory/summaries",
+        params={"scale": "day", "limit": 10, "offset": 5, "exclude_stale": "true"},
+    )
+    assert resp.status_code == 200
+    assert seen == {"limit": 10, "offset": 5, "exclude_stale": True}
 
 
 def test_list_memory_summaries_bad_scale_is_400(client, monkeypatch):

--- a/backend/unified_api/tests/test_security_gateway_middleware.py
+++ b/backend/unified_api/tests/test_security_gateway_middleware.py
@@ -14,8 +14,20 @@ from fastapi.testclient import TestClient
 
 # Import app after path is set; some team mounts may fail in test env
 from unified_api.main import app
+from unified_api.middleware.security_gateway import _get_team_prefixes, _is_team_path
 
 client = TestClient(app)
+
+
+def test_cognition_prefix_is_scanned():
+    """The /api/cognition operator router is matched by the gateway, not bypassed.
+
+    Cognition is not a TEAM_CONFIGS team, so it would slip past the gateway unless
+    explicitly added to the scanned-prefix set. This proves the prefix is intercepted.
+    """
+    assert "/api/cognition" in _get_team_prefixes()
+    assert _is_team_path("/api/cognition/agents/a/proposals") is True
+    assert _is_team_path("/api/cognition/agents/a/memory/events") is True
 
 
 def test_middleware_403_on_malicious_body():


### PR DESCRIPTION
Closes #735

## What

Completes **Step 12 — Operator HITL API** of the Agent Cognition Core. The proposal list/get/approve/reject and rules-list routes already shipped; this PR adds the three pieces that were still missing for Step 12.

### 1. `GET …/memory` inspect surface
Read-only operator endpoints over the memory store, under `/api/cognition/agents/{agent_id}/memory`:
- `GET …/memory/events?top_n=&by_salience=&since=` → recent events (`fetch_recent_events`)
- `GET …/memory/summaries?scale=day&limit=&offset=&exclude_stale=` → period summaries (`fetch_summaries`)
- `GET …/memory/summaries/last?scale=day` → latest closed summary (`get_last_summary`; 404 when none)

Bad `scale` → 400 (reusing the existing `_parse_status` helper); storage unavailable → 503.

### 2. Author tagging via `resolve_author`
`approve`/`reject` now derive the decision author (`decided_by`) server-side via `resolve_author()` — best-effort "who decided" provenance, never caller-supplied. Both POSTs are now body-less; the `ProposalDecision` body model is removed.

### 3. Security-gateway gating
`/api/cognition` is not a `TEAM_CONFIGS` team, so it previously bypassed the security content gateway. Added an explicit `_EXTRA_SCANNED_PREFIXES` set merged into `_get_team_prefixes()` so the prefix is intercepted — without polluting team discovery/counts/proxy registration.

## Deviation from the written plan — no operator auth
`IMPLEMENTATION_PLAN.md` Step 12 also called for a `COGNITION_OPERATOR_TOKEN` bearer gate. Per owner decision, that token is intentionally **not** added: the platform is currently single-user and an auth gate now would hinder development; system-wide user profiles + authentication will land later when the system is productionized. The plan doc is updated to reflect this. The security content gateway (not auth) and `resolve_author` (provenance, not access control) both remain.

## Tests
`backend/unified_api/tests/test_cognition_route.py` covers the memory endpoints, author-from-`resolve_author`, and the full error matrix (404/409/400/503). A gateway unit test (`test_cognition_prefix_is_scanned`) proves the cognition prefix is scanned, not bypassed.

- ruff check + format: clean
- **100% line coverage** on `unified_api/routes/cognition.py` (27 tests pass)
- Store call signatures verified against the live `agent_cognition.memory.store` / `rules.store` layer

## Notes for reviewers
- `approve`/`reject` are a contract change (no request body); update any client accordingly.
- Memory route shape uses sub-resources (events vs. summaries) rather than a single combined `/memory` payload, per design discussion — each shape has distinct params and response models.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MSYYxJ2keSDxKZ4X5XE75x)_