### PR TITLE
Findings-only synthesis pass for the merged review summary (Stage 2)

### DIFF
--- a/backend/agents/software_engineering_team/code_review_agent/coordinator.py
+++ b/backend/agents/software_engineering_team/code_review_agent/coordinator.py
@@ -50,6 +50,7 @@ from .models import (
     coerce_line,
     notify_review_progress,
 )
+from .synthesis import synthesize_review_findings
 
 logger = logging.getLogger(__name__)
 
@@ -671,6 +672,50 @@ def _reconcile_approval(
     return approved, issues
 
 
+def _merge_narrative(
+    llm: LLMClient,
+    input_data: CodeReviewInput,
+    approved: bool,
+    issues: List[CodeReviewIssue],
+    outcome: "_ChunkOutcome",
+) -> Tuple[str, str]:
+    """Produce the merged ``(summary, spec_compliance_notes)`` for the review.
+
+    The reduce phase's narrative — never the verdict, which is already fixed.
+
+    Preconditions:
+        - ``approved`` and ``issues`` are the authoritative deterministic
+          results from ``_reconcile_approval``; this function only shapes prose
+          and never reconsults or mutates them.
+        - ``outcome.summaries`` holds one entry per successful sub-review.
+
+    Postconditions:
+        - With exactly one sub-review, returns that sub-review's summary/notes
+          verbatim and makes no synthesis LLM call.
+        - With more than one sub-review, attempts a single findings-only
+          synthesis pass; on any failure (``None``) falls back to the
+          ``"\\n\\n"``-joined per-pass summaries/notes.
+    """
+    if len(outcome.summaries) == 1:
+        return outcome.summaries[0], (outcome.spec_notes[0] if outcome.spec_notes else "")
+
+    concatenated_summary = "\n\n".join(s for s in outcome.summaries if s.strip())
+    concatenated_notes = "\n\n".join(n for n in outcome.spec_notes if n.strip())
+
+    if len(outcome.summaries) > 1:
+        synthesized = synthesize_review_findings(
+            llm,
+            input_data=input_data,
+            approved=approved,
+            issues=issues,
+            chunk_summaries=outcome.summaries,
+        )
+        if synthesized is not None:
+            return synthesized.summary, synthesized.spec_compliance_notes
+
+    return concatenated_summary, concatenated_notes
+
+
 def _map_chunks(
     chunk_reviewer: ChunkReviewAgent,
     chunks: List[ReviewChunk],
@@ -845,10 +890,9 @@ def run_coordinator(
     )
     deduped = _dedupe_issues([*outcome.issues, *skipped_issues])
     all_llm_approved = bool(outcome.approved_flags) and all(outcome.approved_flags)
-    merged_summary = "\n\n".join(s for s in outcome.summaries if s.strip())
     approved, deduped = _reconcile_approval(all_llm_approved, deduped)
 
-    spec_notes = "\n\n".join(n for n in outcome.spec_notes if n.strip())
+    merged_summary, spec_notes = _merge_narrative(llm, input_data, approved, deduped, outcome)
     # A commit message synthesized from a fraction of the change is misleading,
     # so it is only forwarded when a single sub-review saw the whole submission
     # in one piece — a bisected recovery produces per-half messages and drops it.

--- a/backend/agents/software_engineering_team/code_review_agent/coordinator.py
+++ b/backend/agents/software_engineering_team/code_review_agent/coordinator.py
@@ -709,6 +709,7 @@ def _merge_narrative(
             approved=approved,
             issues=issues,
             chunk_summaries=outcome.summaries,
+            chunk_spec_notes=outcome.spec_notes,
         )
         if synthesized is not None:
             return synthesized.summary, synthesized.spec_compliance_notes

--- a/backend/agents/software_engineering_team/code_review_agent/prompts.py
+++ b/backend/agents/software_engineering_team/code_review_agent/prompts.py
@@ -131,7 +131,7 @@ Be thorough but fair. Focus on issues that actually matter for production code q
 REVIEW_SYNTHESIS_PROMPT = (
     """You consolidate the findings of an automated per-file code review into one coherent report.
 
-A large submission was reviewed in several independent passes. You are given ONLY the findings from those passes — the issues that were flagged and the per-pass summaries. You are NOT given any source code, and you must work only from what is provided.
+A large submission was reviewed in several independent passes. You are given ONLY the findings from those passes — the issues that were flagged, the per-pass summaries, and the per-pass spec-compliance notes. You are NOT given any source code, and you must work only from what is provided.
 
 **Your job:**
 Rewrite the fragmented per-pass material into a single, coherent narrative that reads as one review of the whole submission, not a list of disconnected pieces.

--- a/backend/agents/software_engineering_team/code_review_agent/prompts.py
+++ b/backend/agents/software_engineering_team/code_review_agent/prompts.py
@@ -126,3 +126,27 @@ Be thorough but fair. Focus on issues that actually matter for production code q
 """
     + JSON_OUTPUT_INSTRUCTION
 )
+
+
+REVIEW_SYNTHESIS_PROMPT = (
+    """You consolidate the findings of an automated per-file code review into one coherent report.
+
+A large submission was reviewed in several independent passes. You are given ONLY the findings from those passes — the issues that were flagged and the per-pass summaries. You are NOT given any source code, and you must work only from what is provided.
+
+**Your job:**
+Rewrite the fragmented per-pass material into a single, coherent narrative that reads as one review of the whole submission, not a list of disconnected pieces.
+- Produce a "summary": a unified overview of the review across all passes — what was looked at, the overall health of the code, and the most important findings, ordered by severity.
+- Produce "spec_compliance_notes": a unified statement of how well the submission meets the specification and acceptance criteria, consolidating the per-pass spec observations.
+
+**Hard rules:**
+- Do NOT invent findings. Only describe issues that appear in the provided findings.
+- Do NOT change, upgrade, or downgrade any severity. Report severities exactly as given.
+- Do NOT re-decide the approval verdict — it has already been decided deterministically and is given to you for context only. Your prose must be consistent with it.
+- Do NOT request source code or claim you cannot proceed; synthesize from the findings provided.
+
+Return a single JSON object with exactly these keys:
+- "summary": string — the unified review summary.
+- "spec_compliance_notes": string — the unified spec-compliance narrative.
+"""
+    + JSON_OUTPUT_INSTRUCTION
+)

--- a/backend/agents/software_engineering_team/code_review_agent/synthesis.py
+++ b/backend/agents/software_engineering_team/code_review_agent/synthesis.py
@@ -56,22 +56,31 @@ class SynthesisResult(BaseModel):
 def build_findings_digest(
     issues: List[CodeReviewIssue],
     chunk_summaries: List[str],
+    chunk_spec_notes: Optional[List[str]] = None,
 ) -> str:
     """Render findings as plain text for the synthesis prompt — never any code.
 
     Issues are ordered ``critical → high → medium → low → info`` (then unknown
     severities) purely so the digest reads blocking-first; this is presentation
-    order, not truncation. Every issue and every summary is rendered in full —
-    there are no length caps of any kind.
+    order, not truncation. Every issue, summary, and per-pass spec note is
+    rendered in full — there are no length caps of any kind.
+
+    The per-pass spec-compliance notes are included because the synthesized
+    ``spec_compliance_notes`` *replaces* the concatenated per-pass notes
+    downstream; without them in the digest the synthesizer would have to
+    reconstruct acceptance-criteria observations from findings alone and could
+    drop or contradict concrete evidence a reviewer already recorded.
 
     Preconditions:
         - ``issues`` is a list of ``CodeReviewIssue`` (may be empty).
         - ``chunk_summaries`` is a list of strings (may be empty); each is one
           per-pass summary.
+        - ``chunk_spec_notes`` is None or a list of strings (may be empty); each
+          is one per-pass spec-compliance note.
 
     Postconditions:
-        - The returned text contains every issue and every non-empty summary in
-          full, with no source code.
+        - The returned text contains every issue, every non-empty summary, and
+          every non-empty spec note in full, with no source code.
         - Ordering within the issue section is stable for equal severities
           (input order preserved).
     """
@@ -106,6 +115,16 @@ def build_findings_digest(
     else:
         lines.append("(no per-pass summaries were produced)")
 
+    lines.append("")
+    lines.append("## Per-pass spec-compliance notes")
+    non_empty_notes = [n for n in (chunk_spec_notes or []) if n.strip()]
+    if non_empty_notes:
+        for idx, note in enumerate(non_empty_notes, start=1):
+            lines.append(f"### Pass {idx}")
+            lines.append(note)
+    else:
+        lines.append("(no per-pass spec-compliance notes were produced)")
+
     return "\n".join(lines)
 
 
@@ -116,6 +135,7 @@ def synthesize_review_findings(
     approved: bool,
     issues: List[CodeReviewIssue],
     chunk_summaries: List[str],
+    chunk_spec_notes: Optional[List[str]] = None,
 ) -> Optional[SynthesisResult]:
     """Run exactly one LLM pass to merge per-pass findings into one narrative.
 
@@ -130,6 +150,9 @@ def synthesize_review_findings(
           ``Model`` interface, in which case it is used as the model directly).
         - ``approved`` is the deterministic verdict already decided by the
           coordinator; it is passed for context only and is never recomputed.
+        - ``chunk_spec_notes`` is None or the per-pass spec-compliance notes;
+          they are fed into the digest so the synthesized notes consolidate the
+          reviewers' actual evidence rather than reconstructing it.
 
     Postconditions:
         - Returns a ``SynthesisResult`` with two non-empty strings on success.
@@ -139,7 +162,7 @@ def synthesize_review_findings(
         - Never raises, and never mutates ``issues`` or the verdict.
     """
     try:
-        digest = build_findings_digest(issues, chunk_summaries)
+        digest = build_findings_digest(issues, chunk_summaries, chunk_spec_notes)
         framing = _build_framing(input_data, approved)
         prompt = f"{framing}\n\n{digest}"
 

--- a/backend/agents/software_engineering_team/code_review_agent/synthesis.py
+++ b/backend/agents/software_engineering_team/code_review_agent/synthesis.py
@@ -1,0 +1,184 @@
+"""Reduce-phase synthesis: one findings-only LLM pass over a map-reduce review.
+
+Stage 1 (the map-reduce coordinator) reviews a large submission in several
+independent passes and then merges the results. The deterministic merge —
+issue dedupe and the critical/high approval gate — is authoritative and lives
+in ``coordinator.py``. This module owns only the *narrative*: a single cheap
+LLM call that rewrites the per-pass summaries and spec notes into one coherent
+report.
+
+Two invariants hold for everything here:
+    - The digest is built from findings only — issue metadata and per-pass
+      summaries. Source code is never included.
+    - Synthesis is best-effort and never authoritative. It cannot change the
+      verdict or the issue list, and any failure returns ``None`` so the caller
+      falls back to the deterministic concatenation behavior.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+from strands import Agent
+from strands.models.model import Model as _StrandsModel
+
+from llm_service import LLMClient, get_strands_model
+
+from .models import CodeReviewInput, CodeReviewIssue
+from .prompts import REVIEW_SYNTHESIS_PROMPT
+
+logger = logging.getLogger(__name__)
+
+# Severity ordering for the digest, mirroring ``_VALID_SEVERITIES`` in
+# coordinator.py. Lower rank prints first so the digest reads blocking-first.
+# Unknown severities sort after every known one (stable within the bucket).
+_SEVERITY_RANK = {"critical": 0, "high": 1, "medium": 2, "low": 3, "info": 4}
+_UNKNOWN_SEVERITY_RANK = len(_SEVERITY_RANK)
+
+
+class SynthesisResult(BaseModel):
+    """The narrative produced by one successful synthesis pass.
+
+    Invariants:
+        - Both fields are non-empty strings; ``synthesize_review_findings``
+          returns ``None`` rather than a result with an empty field.
+    """
+
+    summary: str = Field(description="Unified review summary across all passes")
+    spec_compliance_notes: str = Field(
+        description="Unified spec/acceptance-criteria narrative across all passes"
+    )
+
+
+def build_findings_digest(
+    issues: List[CodeReviewIssue],
+    chunk_summaries: List[str],
+) -> str:
+    """Render findings as plain text for the synthesis prompt — never any code.
+
+    Issues are ordered ``critical → high → medium → low → info`` (then unknown
+    severities) purely so the digest reads blocking-first; this is presentation
+    order, not truncation. Every issue and every summary is rendered in full —
+    there are no length caps of any kind.
+
+    Preconditions:
+        - ``issues`` is a list of ``CodeReviewIssue`` (may be empty).
+        - ``chunk_summaries`` is a list of strings (may be empty); each is one
+          per-pass summary.
+
+    Postconditions:
+        - The returned text contains every issue and every non-empty summary in
+          full, with no source code.
+        - Ordering within the issue section is stable for equal severities
+          (input order preserved).
+    """
+    ordered = sorted(
+        enumerate(issues),
+        key=lambda pair: (
+            _SEVERITY_RANK.get((pair[1].severity or "").strip().lower(), _UNKNOWN_SEVERITY_RANK),
+            pair[0],
+        ),
+    )
+
+    lines: List[str] = ["## Findings"]
+    if ordered:
+        for _, issue in ordered:
+            location = issue.file_path or "(file unknown)"
+            if issue.line is not None:
+                location = f"{location}:{issue.line}"
+            parts = [f"- [{issue.severity}] {issue.category} {location} — {issue.description}"]
+            if issue.suggestion:
+                parts.append(f" (suggestion: {issue.suggestion})")
+            lines.append("".join(parts))
+    else:
+        lines.append("- (no issues were flagged)")
+
+    lines.append("")
+    lines.append("## Per-pass summaries")
+    non_empty_summaries = [s for s in chunk_summaries if s.strip()]
+    if non_empty_summaries:
+        for idx, summary in enumerate(non_empty_summaries, start=1):
+            lines.append(f"### Pass {idx}")
+            lines.append(summary)
+    else:
+        lines.append("(no per-pass summaries were produced)")
+
+    return "\n".join(lines)
+
+
+def synthesize_review_findings(
+    llm: LLMClient,
+    *,
+    input_data: CodeReviewInput,
+    approved: bool,
+    issues: List[CodeReviewIssue],
+    chunk_summaries: List[str],
+) -> Optional[SynthesisResult]:
+    """Run exactly one LLM pass to merge per-pass findings into one narrative.
+
+    The model sees only the findings digest plus framing context (task, the
+    deterministic verdict) — never source code. The strands model is resolved
+    the same way as ``chunk_reviewer``: an injected ``llm`` is used directly
+    when it implements the strands ``Model`` interface, otherwise the shared
+    ``get_strands_model("code_review")`` is used.
+
+    Preconditions:
+        - ``llm`` is an ``LLMClient`` (and may also implement the strands
+          ``Model`` interface, in which case it is used as the model directly).
+        - ``approved`` is the deterministic verdict already decided by the
+          coordinator; it is passed for context only and is never recomputed.
+
+    Postconditions:
+        - Returns a ``SynthesisResult`` with two non-empty strings on success.
+        - Returns ``None`` on ANY failure — exception, malformed JSON, missing
+          ``summary``/``spec_compliance_notes`` keys, or empty/whitespace-only
+          values — so the caller falls back to deterministic concatenation.
+        - Never raises, and never mutates ``issues`` or the verdict.
+    """
+    try:
+        digest = build_findings_digest(issues, chunk_summaries)
+        framing = _build_framing(input_data, approved)
+        prompt = f"{framing}\n\n{digest}"
+
+        _model = llm if isinstance(llm, _StrandsModel) else get_strands_model("code_review")
+        agent = Agent(model=_model, system_prompt=REVIEW_SYNTHESIS_PROMPT)
+        result = agent(prompt)
+        data = json.loads(str(result).strip())
+
+        if not isinstance(data, dict):
+            logger.warning("ReviewSynthesis: model returned non-object JSON; falling back")
+            return None
+
+        summary = str(data.get("summary", "") or "").strip()
+        spec_notes = str(data.get("spec_compliance_notes", "") or "").strip()
+        if not summary or not spec_notes:
+            logger.warning("ReviewSynthesis: missing/empty summary or spec notes; falling back")
+            return None
+
+        return SynthesisResult(summary=summary, spec_compliance_notes=spec_notes)
+    except Exception as exc:  # noqa: BLE001 - best-effort cosmetic pass; never fail the review
+        # Synthesis is purely narrative; any failure must fall back to the
+        # deterministic concatenation rather than break an otherwise valid
+        # review verdict, so the broad except here is the intended contract.
+        logger.warning("ReviewSynthesis: synthesis failed (%s); falling back", exc)
+        return None
+
+
+def _build_framing(input_data: CodeReviewInput, approved: bool) -> str:
+    """Render the non-code context lines that precede the findings digest.
+
+    Postconditions:
+        - The returned text carries the task description, acceptance criteria,
+          and the deterministic verdict, and never includes any source code.
+    """
+    verdict = "approved" if approved else "rejected"
+    lines = [f"The deterministic review verdict is: {verdict.upper()}."]
+    if input_data.task_description.strip():
+        lines.append(f"Task: {input_data.task_description.strip()}")
+    if input_data.acceptance_criteria:
+        lines.append("Acceptance criteria:")
+        lines.extend(f"- {c}" for c in input_data.acceptance_criteria)
+    return "\n".join(lines)

--- a/backend/agents/software_engineering_team/tests/test_code_review_coordinator.py
+++ b/backend/agents/software_engineering_team/tests/test_code_review_coordinator.py
@@ -646,7 +646,9 @@ def test_failing_multi_segment_chunk_bisects_and_recovers() -> None:
             language="python",
         ),
     )
-    assert client.calls == 3  # combined fail + two single-file successes
+    # combined fail + two single-file successes + 1 reduce-phase synthesis pass
+    # (two recovered sub-reviews → one findings-only synthesis call).
+    assert client.calls == 4
     assert result.approved is True
     assert all(i.severity != "info" for i in result.issues)
 
@@ -698,7 +700,8 @@ def test_transient_failure_in_bisected_child_recovers() -> None:
     )
     assert result.approved is True
     # combined fail + a fail + a retry success + b success
-    assert client.calls == 4
+    # + 1 reduce-phase synthesis pass (two recovered sub-reviews).
+    assert client.calls == 5
 
 
 def test_persistent_small_chunk_failure_raises_unavailable() -> None:
@@ -1106,16 +1109,20 @@ def test_coordinator_single_chunk_propagates_notes_and_commit_message() -> None:
     assert result.suggested_commit_message == "feat: add a()"
 
 
-def test_coordinator_multi_chunk_joins_notes_and_drops_commit_message() -> None:
-    """Spec notes are joinable per-chunk observations and must survive
-    multi-chunk reviews; a commit message synthesized from a fraction of the
-    change is misleading and is dropped."""
+def test_coordinator_multi_chunk_synthesizes_notes_and_drops_commit_message() -> None:
+    """Spec notes must survive multi-chunk reviews; the reduce phase runs one
+    findings-only synthesis pass that produces a single coherent value (not a
+    raw join). A commit message synthesized from a fraction of the change is
+    misleading and is still dropped."""
     llm_probe = DummyLLMClient()
     cap = compute_code_review_map_chunk_chars(llm_probe)
     files = {
         "a.py": "a = 1\n".ljust(cap - 1_000, "#"),
         "b.py": "b = 2\n".ljust(cap - 1_000, "#"),
     }
+    # The scripted client answers both chunk reviews and the synthesis pass with
+    # the same canned payload, so the synthesized notes are "chunk notes" (one
+    # coherent value), never the old "chunk notes\n\nchunk notes" concatenation.
     client = _ScriptedClient(
         [
             {
@@ -1129,15 +1136,16 @@ def test_coordinator_multi_chunk_joins_notes_and_drops_commit_message() -> None:
     )
     result = run_coordinator(client, CodeReviewInput(files=files, task_description="t"))
     assert result.approved is True
-    assert result.spec_compliance_notes == "chunk notes\n\nchunk notes"
+    assert result.spec_compliance_notes == "chunk notes"
     assert result.suggested_commit_message == ""
 
 
 def test_single_chunk_keeps_notes_but_drops_commit_message_after_bisection() -> None:
     """A logically-single-chunk review that recovers via bisection keeps its
-    spec notes (joined), but drops the commit message: each half's message was
-    written having seen only part of the change, so forwarding one would
-    present a partial view as covering the whole submission."""
+    spec notes (now via the findings-only synthesis pass over the two halves),
+    but drops the commit message: each half's message was written having seen
+    only part of the change, so forwarding one would present a partial view as
+    covering the whole submission."""
 
     class _FailCombinedWithNotes(DummyLLMClient):
         def __init__(self) -> None:
@@ -1164,7 +1172,7 @@ def test_single_chunk_keeps_notes_but_drops_commit_message_after_bisection() -> 
             language="python",
         ),
     )
-    assert result.spec_compliance_notes == "half notes\n\nhalf notes"
+    assert result.spec_compliance_notes == "half notes"
     # Two sub-reviews → neither commit message saw the whole change.
     assert result.suggested_commit_message == ""
 

--- a/backend/agents/software_engineering_team/tests/test_code_review_synthesis.py
+++ b/backend/agents/software_engineering_team/tests/test_code_review_synthesis.py
@@ -125,6 +125,22 @@ def test_digest_handles_no_issues_and_no_summaries() -> None:
     digest = build_findings_digest([], [])
     assert "no issues" in digest.lower()
     assert "no per-pass summaries" in digest.lower()
+    assert "no per-pass spec-compliance notes" in digest.lower()
+
+
+def test_digest_includes_per_pass_spec_notes_in_full() -> None:
+    """Per-pass spec notes are rendered (the synthesized notes replace the
+    concatenated ones, so the evidence must reach the digest)."""
+    long_note = "N" * 4_000
+    digest = build_findings_digest([], ["summary"], [long_note, "  ", "second note"])
+    assert "Per-pass spec-compliance notes" in digest
+    assert long_note in digest  # full, untruncated
+    assert "second note" in digest
+    # Blank notes are skipped, so only two passes are rendered in that section.
+    section = digest.split("## Per-pass spec-compliance notes", 1)[1]
+    assert "### Pass 1" in section
+    assert "### Pass 2" in section
+    assert "### Pass 3" not in section
 
 
 # ---------------------------------------------------------------------------
@@ -151,6 +167,35 @@ class _PayloadClient(DummyLLMClient):
 class _RaisingClient(DummyLLMClient):
     def complete_json(self, prompt: str, **kwargs: Any) -> Dict[str, Any]:
         raise RuntimeError("synthesis model boom")
+
+
+class _RecordingClient(DummyLLMClient):
+    """Captures the synthesis prompt, then returns a fixed payload."""
+
+    def __init__(self, payload: Dict[str, Any]) -> None:
+        super().__init__()
+        self._payload = payload
+        self.prompts: list[str] = []
+
+    def complete_json(self, prompt: str, **kwargs: Any) -> Dict[str, Any]:
+        self.prompts.append(prompt)
+        return self._payload
+
+
+def test_synthesize_forwards_per_pass_spec_notes_into_prompt() -> None:
+    client = _RecordingClient({"summary": "merged", "spec_compliance_notes": "merged notes"})
+    result = synthesize_review_findings(
+        client,
+        input_data=_input(),
+        approved=True,
+        issues=[],
+        chunk_summaries=["s1", "s2"],
+        chunk_spec_notes=["AC1 satisfied via endpoint X", "AC2 partially met"],
+    )
+    assert isinstance(result, SynthesisResult)
+    assert len(client.prompts) == 1
+    assert "AC1 satisfied via endpoint X" in client.prompts[0]
+    assert "AC2 partially met" in client.prompts[0]
 
 
 def test_synthesize_success_returns_result() -> None:

--- a/backend/agents/software_engineering_team/tests/test_code_review_synthesis.py
+++ b/backend/agents/software_engineering_team/tests/test_code_review_synthesis.py
@@ -1,0 +1,332 @@
+"""Tests for the reduce-phase findings synthesis (Stage 2).
+
+``synthesis.py`` owns the narrative only: a single findings-only LLM pass that
+merges per-chunk summaries/notes. These tests cover the digest builder (ordering
+and completeness, no code), the synthesis call's success path and its ``None``
+fallback on every failure mode, and the coordinator integration — synthesis is
+used for multi-chunk reviews, skipped for single-chunk ones, never mutates the
+verdict or issues, and falls back to concatenation when it returns ``None``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from code_review_agent import coordinator as coordinator_mod
+from code_review_agent.coordinator import run_coordinator
+from code_review_agent.models import CodeReviewInput, CodeReviewIssue
+from code_review_agent.synthesis import (
+    SynthesisResult,
+    build_findings_digest,
+    synthesize_review_findings,
+)
+
+from llm_service.clients.dummy import DummyLLMClient
+from software_engineering_team.shared.context_sizing import compute_code_review_map_chunk_chars
+
+
+def _issue(
+    severity: str,
+    description: str,
+    *,
+    file_path: str = "app/x.py",
+    suggestion: str = "fix it",
+    line: int | None = None,
+) -> CodeReviewIssue:
+    return CodeReviewIssue(
+        severity=severity,
+        category="logic",
+        file_path=file_path,
+        description=description,
+        suggestion=suggestion,
+        line=line,
+    )
+
+
+def _input(**kwargs: Any) -> CodeReviewInput:
+    base: Dict[str, Any] = dict(code="### a.py ###\nx = 1", task_description="t", language="python")
+    base.update(kwargs)
+    return CodeReviewInput(**base)
+
+
+# ---------------------------------------------------------------------------
+# build_findings_digest — ordering & completeness, never any code
+# ---------------------------------------------------------------------------
+
+
+def test_digest_orders_critical_first_and_renders_everything_in_full() -> None:
+    """Issues are ordered critical→info and every issue/summary is rendered in
+    full — there are no length caps of any kind."""
+    long_desc = "D" * 5_000
+    long_summary = "S" * 5_000
+    issues = [
+        _issue("info", "info finding"),
+        _issue("critical", long_desc),
+        _issue("low", "low finding"),
+        _issue("high", "high finding"),
+        _issue("medium", "medium finding"),
+    ]
+    digest = build_findings_digest(issues, [long_summary, "second summary"])
+
+    # Severity ordering: critical → high → medium → low → info.
+    assert (
+        digest.index("[critical]")
+        < digest.index("[high]")
+        < digest.index("[medium]")
+        < digest.index("[low]")
+        < digest.index("[info]")
+    )
+    # Completeness: long strings survive in full (no truncation), every summary present.
+    assert long_desc in digest
+    assert long_summary in digest
+    assert "second summary" in digest
+
+
+def test_digest_is_stable_within_a_severity() -> None:
+    """Equal severities keep their input order (stable sort)."""
+    issues = [
+        _issue("high", "first high"),
+        _issue("high", "second high"),
+        _issue("high", "third high"),
+    ]
+    digest = build_findings_digest(issues, [])
+    assert digest.index("first high") < digest.index("second high") < digest.index("third high")
+
+
+def test_digest_unknown_severity_sorts_after_known_and_survives() -> None:
+    issues = [_issue("weird", "mystery finding"), _issue("critical", "boom")]
+    digest = build_findings_digest(issues, [])
+    assert digest.index("[critical]") < digest.index("[weird]")
+    assert "mystery finding" in digest
+
+
+def test_digest_renders_line_and_suggestion() -> None:
+    issues = [_issue("high", "desc", file_path="a.py", suggestion="do x", line=42)]
+    digest = build_findings_digest(issues, [])
+    assert "a.py:42" in digest
+    assert "suggestion: do x" in digest
+
+
+def test_digest_renders_unknown_file_and_omits_empty_suggestion() -> None:
+    issues = [_issue("high", "desc", file_path="", suggestion="")]
+    digest = build_findings_digest(issues, [])
+    assert "(file unknown)" in digest
+    assert "suggestion:" not in digest
+
+
+def test_digest_skips_blank_summaries() -> None:
+    digest = build_findings_digest([], ["   ", "real summary"])
+    assert "real summary" in digest
+    assert "Pass 1" in digest
+    assert "Pass 2" not in digest
+
+
+def test_digest_handles_no_issues_and_no_summaries() -> None:
+    digest = build_findings_digest([], [])
+    assert "no issues" in digest.lower()
+    assert "no per-pass summaries" in digest.lower()
+
+
+# ---------------------------------------------------------------------------
+# synthesize_review_findings — success and None on every failure mode
+# ---------------------------------------------------------------------------
+
+
+class _PayloadClient(DummyLLMClient):
+    """Routes the strands Agent call for the synthesis pass to a fixed payload.
+
+    The dummy's strands ``stream`` serializes whatever ``complete_json`` returns,
+    so a dict payload becomes the agent's JSON text and a raw string becomes the
+    agent's literal (used to drive the malformed/non-object JSON branches).
+    """
+
+    def __init__(self, payload: Any) -> None:
+        super().__init__()
+        self._payload = payload
+
+    def complete_json(self, prompt: str, **kwargs: Any) -> Any:
+        return self._payload
+
+
+class _RaisingClient(DummyLLMClient):
+    def complete_json(self, prompt: str, **kwargs: Any) -> Dict[str, Any]:
+        raise RuntimeError("synthesis model boom")
+
+
+def test_synthesize_success_returns_result() -> None:
+    client = _PayloadClient({"summary": "merged summary", "spec_compliance_notes": "merged notes"})
+    result = synthesize_review_findings(
+        client,
+        input_data=_input(acceptance_criteria=["AC1", "AC2"]),
+        approved=True,
+        issues=[_issue("high", "h")],
+        chunk_summaries=["s1", "s2"],
+    )
+    assert isinstance(result, SynthesisResult)
+    assert result.summary == "merged summary"
+    assert result.spec_compliance_notes == "merged notes"
+
+
+def test_synthesize_returns_none_on_missing_keys() -> None:
+    client = _PayloadClient({"summary": "only a summary"})
+    assert (
+        synthesize_review_findings(
+            client, input_data=_input(), approved=True, issues=[], chunk_summaries=["s1", "s2"]
+        )
+        is None
+    )
+
+
+def test_synthesize_returns_none_on_empty_values() -> None:
+    client = _PayloadClient({"summary": "   ", "spec_compliance_notes": ""})
+    assert (
+        synthesize_review_findings(
+            client, input_data=_input(), approved=False, issues=[], chunk_summaries=["s1", "s2"]
+        )
+        is None
+    )
+
+
+def test_synthesize_returns_none_on_malformed_json() -> None:
+    client = _PayloadClient("<<< not valid json >>>")
+    assert (
+        synthesize_review_findings(
+            client, input_data=_input(), approved=True, issues=[], chunk_summaries=["s1", "s2"]
+        )
+        is None
+    )
+
+
+def test_synthesize_returns_none_on_non_object_json() -> None:
+    client = _PayloadClient('"a bare json string"')
+    assert (
+        synthesize_review_findings(
+            client, input_data=_input(), approved=True, issues=[], chunk_summaries=["s1", "s2"]
+        )
+        is None
+    )
+
+
+def test_synthesize_returns_none_on_exception() -> None:
+    assert (
+        synthesize_review_findings(
+            _RaisingClient(),
+            input_data=_input(),
+            approved=False,
+            issues=[_issue("critical", "c")],
+            chunk_summaries=["s1", "s2"],
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# coordinator integration — multi-chunk synthesis, single-chunk no-call,
+# verdict/issues untouched, concatenation fallback
+# ---------------------------------------------------------------------------
+
+
+def _two_chunk_files() -> Dict[str, str]:
+    cap = compute_code_review_map_chunk_chars(DummyLLMClient())
+    return {
+        "a.py": "a = 1\n".ljust(cap - 1_000, "#"),
+        "b.py": "b = 2\n".ljust(cap - 1_000, "#"),
+    }
+
+
+class _NoNotesClient(DummyLLMClient):
+    """Per-chunk summaries but never spec notes → synthesis returns None."""
+
+    def complete_json(self, prompt: str, **kwargs: Any) -> Dict[str, Any]:
+        if "### a.py ###" in prompt:
+            return {"approved": True, "issues": [], "summary": "alpha summary"}
+        if "### b.py ###" in prompt:
+            return {"approved": True, "issues": [], "summary": "beta summary"}
+        # Synthesis pass: missing spec_compliance_notes → None → fall back.
+        return {"summary": "ignored", "missing_notes": True}
+
+
+class _SynthOkClient(DummyLLMClient):
+    """One chunk flags a critical issue; the synthesis pass returns clean prose."""
+
+    def complete_json(self, prompt: str, **kwargs: Any) -> Dict[str, Any]:
+        if "### a.py ###" in prompt:
+            return {
+                "approved": False,
+                "issues": [
+                    {
+                        "severity": "critical",
+                        "category": "security",
+                        "file_path": "a.py",
+                        "description": "SQL injection risk",
+                        "suggestion": "Use parameterized queries",
+                    }
+                ],
+                "summary": "alpha",
+            }
+        if "### b.py ###" in prompt:
+            return {"approved": True, "issues": [], "summary": "beta"}
+        return {
+            "summary": "SYNTHESIZED SUMMARY",
+            "spec_compliance_notes": "SYNTHESIZED NOTES",
+        }
+
+
+def test_coordinator_falls_back_to_concatenation_when_synthesis_unavailable() -> None:
+    result = run_coordinator(
+        _NoNotesClient(),
+        CodeReviewInput(files=_two_chunk_files(), task_description="t", language="python"),
+    )
+    assert "alpha summary" in result.summary
+    assert "beta summary" in result.summary
+
+
+def test_coordinator_uses_synthesis_without_mutating_verdict_or_issues() -> None:
+    result = run_coordinator(
+        _SynthOkClient(),
+        CodeReviewInput(files=_two_chunk_files(), task_description="t", language="python"),
+    )
+    # Narrative comes from the synthesis pass...
+    assert result.summary == "SYNTHESIZED SUMMARY"
+    assert result.spec_compliance_notes == "SYNTHESIZED NOTES"
+    # ...but the deterministic verdict and issue list are untouched.
+    assert result.approved is False
+    assert len(result.issues) == 1
+    assert result.issues[0].severity == "critical"
+
+
+def test_single_chunk_makes_no_synthesis_call(monkeypatch) -> None:
+    calls: list[int] = []
+    real = coordinator_mod.synthesize_review_findings
+
+    def _counting(*args: Any, **kwargs: Any):
+        calls.append(1)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(coordinator_mod, "synthesize_review_findings", _counting)
+
+    client = _PayloadClient({"summary": "x", "spec_compliance_notes": "y"})
+    result = run_coordinator(
+        client,
+        CodeReviewInput(code="### a.py ###\nx = 1", task_description="t", language="python"),
+    )
+    assert calls == []  # exactly one sub-review → summary/notes pass through directly
+    assert result.summary == "x"
+    assert result.spec_compliance_notes == "y"
+
+
+def test_multi_chunk_invokes_synthesis_exactly_once(monkeypatch) -> None:
+    calls: list[int] = []
+    real = coordinator_mod.synthesize_review_findings
+
+    def _counting(*args: Any, **kwargs: Any):
+        calls.append(1)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(coordinator_mod, "synthesize_review_findings", _counting)
+
+    run_coordinator(
+        _SynthOkClient(),
+        CodeReviewInput(files=_two_chunk_files(), task_description="t", language="python"),
+    )
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary

Stage 2 of 4. With the map-reduce review in place, the merged review summary was a crude `"\n\n"`-concatenation of per-chunk summaries, and multi-chunk reviews lost a coherent `spec_compliance_notes`. This adds one cheap **findings-only** LLM pass (never code) in the reduce phase to produce a coherent merged summary, while deterministic gating stays authoritative.

## Changes

- **New `code_review_agent/synthesis.py`**
  - `build_findings_digest(issues, chunk_summaries)` — renders findings as plain text, ordered `critical → info` (stable within a severity) so the digest reads blocking-first. Every issue and every per-pass summary is rendered **in full** (no length caps), and source code is never included.
  - `synthesize_review_findings(llm, *, input_data, approved, issues, chunk_summaries) -> Optional[SynthesisResult]` — exactly one strands LLM call (same injected-client-vs-`get_strands_model("code_review")` pattern as `chunk_reviewer.py`). Returns `None` on **any** failure (exception, malformed/non-object JSON, missing keys, empty values); never raises; never mutates the verdict or issues.
- **New `REVIEW_SYNTHESIS_PROMPT`** in `prompts.py` — consolidate findings only; do not invent findings, change severities, or re-decide the verdict; return JSON `{"summary", "spec_compliance_notes"}`.
- **`coordinator.py` integration** (`_merge_narrative`) — exactly one sub-review uses its summary/notes directly (no extra call); more than one runs the synthesis call after the deterministic approval gate, falling back to the concatenated-summaries behavior when it returns `None`. The synthesis result never changes `approved`, `issues`, or `suggested_commit_message` (still empty for multi-chunk reviews).

## Tests

- New `tests/test_code_review_synthesis.py`: digest ordering & completeness (criticals first, everything rendered in full, no code); synthesis success with a scripted client; `None` fallback on exception / malformed JSON / non-object JSON / missing keys / empty values; coordinator falls back to concatenation; coordinator uses synthesis without mutating the verdict or issues; single-chunk reviews make no synthesis call (call-counting), multi-chunk invoke it exactly once.
- Updated the existing multi-chunk coordinator assertions for the synthesis path (notes now come from one coherent pass; bisection call-counts include the reduce-phase synthesis call).
- `synthesis.py` at 100% line coverage; `ruff check` and `ruff format --check` clean on all changed files.

## Notes

The two collection errors in unrelated SE test modules (`test_release_hook.py`, `test_orchestrator_sprint_path.py`) are pre-existing import-chain/dependency issues, not introduced here.

Closes #849


---
_Generated by [Claude Code](https://claude.ai/code/session_01TW4n15o3fKEGt1k83fXZzD)_