### PR TITLE
[Cognition][Step 13] Seed rule packs install on first provision + config/env docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,8 @@ Core vars only. The complete reference — every var, defaults, backoff math, fa
 | `UNIFIED_API_PORT` / `UNIFIED_API_HOST` | Bind address/port for the Unified API (default `0.0.0.0:8080`) |
 | `GITHUB_TOKEN` | Token for the coding team's `run-from-github` flow (Issues/PRs/Contents read-write + Metadata read) |
 
+**Agent Cognition:** operability/tuning env lives in `backend/agents/agent_cognition/README.md` (§"Configuration & operability") — the scheduler tick (`AGENT_COGNITION_SCHEDULER_INTERVAL_S`), event retention (manifest `cognition.memory.retention_days_events`), digest budget (`AGENT_COGNITION_DIGEST_EVENT_TOP_N`), per-key model (`LLM_MODEL_cognition`), writeback cap (`AGENT_COGNITION_WRITEBACK_MAX_BYTES`), and ledger TTL (`AGENT_COGNITION_RUN_TTL_S`). Seed rule packs declared in an agent's `cognition.rule_packs` manifest field install lazily and idempotently on the agent's first cognition-gated invoke.
+
 **Blogging pipeline:** `research → planning (ContentPlan) → writer → gates`. See `backend/agents/blogging/README.md`.
 
 **Google browser login (shared):** `GET/PUT/DELETE /api/integrations/google-browser-login` stores one Fernet-encrypted Google credential (Postgres only — never SQLite) for any Playwright integration that signs in with Google. Reuse `unified_api/google_browser_login_credentials.py` for new "Sign in with Google" integrations. Medium uses this flow; details in `backend/agents/blogging/README.md`.

--- a/backend/agents/agent_cognition/README.md
+++ b/backend/agents/agent_cognition/README.md
@@ -218,3 +218,47 @@ completes the ledger row with `{status_code, content}` for replay. The stored en
 never carries the per-invoke `sandbox` block, so a replay cannot masquerade as a fresh
 boot. Blocked outcomes carry structured `block_phase` / `block_reason` fields — callers
 read those, never parse the stored HTTP body.
+
+## Seed rule packs (`rules/seed_packs.py`, `rules/provision.py`)
+
+A *seed pack* is a named, versioned set of day-one guardrail rules an agent can install at
+provision time. `SEED_PACKS` in `rules/seed_packs.py` is the catalog; the shipped
+`default_guardrails` pack carries a single advisory rule (`no-secrets-in-output`) — richer
+content lands in a later step.
+
+An agent declares the packs it wants in its manifest (`cognition.rule_packs`, e.g.
+`[default_guardrails]`). The packs install **lazily on first provision**: the first time the
+cognition core handles an invoke for an agent, `prepare_invoke` calls
+`rules/provision.py::ensure_seed_packs_installed(agent_id)`, which reads the declared packs
+(`manifest_scope.rule_packs`) and installs each via `store.install_seed_pack`. The install is:
+
+- **idempotent** — each seed rule is keyed on a deterministic `(agent_id, pack, seed_key)` id and
+  inserted `ON CONFLICT DO NOTHING`, so re-provisioning (or a concurrent/cross-process install) adds
+  nothing;
+- **memoized per process** — a successful pass records the agent so later invokes skip the Postgres
+  round-trip (the deterministic ids keep correctness even without the memo);
+- **best-effort** — an unknown pack name is logged and skipped, a storage outage defers the install
+  to a later invoke, and nothing here ever breaks the invoke.
+
+Installing before the context load means the seeded rules are active for that very first invoke's
+context read and precondition gate.
+
+## Configuration & operability
+
+All cognition env vars parse defensively (unset/garbage → the documented default; out-of-range →
+clamped to the documented floor) and are detailed in [`docs/ENV_VARS.md`](../../../docs/ENV_VARS.md).
+Consolidated reference:
+
+| Knob | Where | Default | Purpose |
+|---|---|---|---|
+| `AGENT_COGNITION_SCHEDULER_INTERVAL_S` | `scheduler.py` | `3600` (floor `60`) | The scheduler **tick**: cadence of the per-agent `ensure_rollups_current` → `reflect` → `prune_events` pass plus one platform-wide ledger GC. (The aspirational name `AGENT_COGNITION_TICK_S` refers to this same knob.) No-op when `POSTGRES_HOST` is unset. |
+| `cognition.memory.retention_days_events` (manifest) | `manifest_scope.py` | `90` | **Event retention**: raw episodic events older than this are pruned by the scheduler's `prune_events` once the covering day summary exists and is non-stale. A per-agent manifest field, not an env var. |
+| `AGENT_COGNITION_DIGEST_EVENT_TOP_N` | `memory/retrieval.py` | `20` | In-progress event count folded into an agent's memory digest. The summary half is bounded by the caller-supplied **digest token budget** (`build_memory_digest(..., token_budget)`, trimmed via `compact_text`). |
+| `LLM_MODEL_cognition` | `llm_service` | resolved | Per-key model override for the cognition stack (rollup, reflection, graph). Resolution: `LLM_MODEL_cognition` → `LLM_MODEL` → platform fallback (`resolve_model("cognition")`). |
+| `AGENT_COGNITION_WRITEBACK_MAX_BYTES` | `shared_agent_invoke/limits.py` | `1048576` (1 MiB) | Byte cap on the `cognition_writeback` half of an invoke envelope; over-cap is truncated and flagged, never starving the user `output` (bounded separately by `AGENT_INVOKE_MAX_OUTPUT_BYTES`). |
+| `AGENT_COGNITION_RUN_TTL_S` | `context.py` | `604800` (7 days, floor `3600`) | Ledger **idempotency TTL**: how long a terminal run row is retained for replay before the scheduler GCs it. |
+| `AGENT_COGNITION_RUN_LEASE_S` | `context.py` | `120` (floor `30`) | Lease an `in_progress` run claim holds before lazy expired-lease reclaim. |
+| `AGENT_COGNITION_INVOKE_ROLLUP_BUDGET` | `invoke_gate.py` | `8` (floor `1`) | Max rollup periods the lazy catch-up processes inline per invoke. |
+| `AGENT_COGNITION_ROLLUP_INPUT_CHARS` / `…_ROLLUP_MAX_LOOKBACK_DAYS` | `memory/rollup.py` | `12000` / `400` | Rollup input char budget and cold-start backfill bound. |
+| `AGENT_COGNITION_REFLECTION_*` | `rules/reflection.py` | see [Reflection](#reflection-rule-learning) | Reflection summary limit, proposal cap, input char budget. |
+| `AGENT_COGNITION_GRAPH_*` / `NEO4J_*` / `GRAPHITI_*` | `graph/` | see [`docs/ENV_VARS.md`](../../../docs/ENV_VARS.md) | Knowledge-graph sync cadence/batch, search top-K, and Neo4j/Graphiti connection + models. |

--- a/backend/agents/agent_cognition/README.md
+++ b/backend/agents/agent_cognition/README.md
@@ -246,8 +246,8 @@ context read and precondition gate.
 ## Configuration & operability
 
 All cognition env vars parse defensively (unset/garbage → the documented default; out-of-range →
-clamped to the documented floor) and are detailed in [`docs/ENV_VARS.md`](../../../docs/ENV_VARS.md).
-Consolidated reference:
+clamped to the documented floor, or the default where no floor is given) and are detailed in
+[`docs/ENV_VARS.md`](../../../docs/ENV_VARS.md). Consolidated reference:
 
 | Knob | Where | Default | Purpose |
 |---|---|---|---|

--- a/backend/agents/agent_cognition/invoke_gate.py
+++ b/backend/agents/agent_cognition/invoke_gate.py
@@ -388,6 +388,19 @@ async def prepare_invoke(
     attempt_token = claim_token or str(uuid4())
     event_run_id = _event_scoped_run_id(source_run_id, attempt_token)
 
+    # First-provision seed packs — best-effort and idempotent. Installing the
+    # agent's manifest-declared rule packs before the context load means the
+    # seed rules are active for this very first invoke's context read and
+    # precondition gate. Lazily imported so the facade-import path stays cheap.
+    try:
+        from agent_cognition.rules.provision import ensure_seed_packs_installed
+
+        await asyncio.to_thread(ensure_seed_packs_installed, agent_id)
+    except Exception:
+        logger.warning(
+            "cognition: seed-pack provisioning failed for %s; continuing", agent_id, exc_info=True
+        )
+
     # Lazy catch-up + context load — both best-effort; a cognition subsystem
     # hiccup must never break the invoke (matching the proxy's prior posture).
     # The catch-up is budgeted: a cold-start backlog must not run hundreds of

--- a/backend/agents/agent_cognition/manifest_scope.py
+++ b/backend/agents/agent_cognition/manifest_scope.py
@@ -99,3 +99,18 @@ def retention_days(agent_id: str) -> int:
     if cognition is not None:
         return cognition.memory.retention_days_events
     return _retention_default()
+
+
+def rule_packs(agent_id: str) -> list[str]:
+    """Seed rule-pack names the agent declares for first-provision install.
+
+    Postconditions:
+        * Returns the manifest's ``cognition.rule_packs`` list (e.g.
+          ``["default_guardrails"]``); ``[]`` when there is no manifest, no
+          cognition block, or any lookup failure — a manifest-less agent
+          provisions no seed packs. Never raises.
+    """
+    cognition = _manifest_cognition(agent_id)
+    if cognition is not None:
+        return list(cognition.rule_packs)
+    return []

--- a/backend/agents/agent_cognition/rules/__init__.py
+++ b/backend/agents/agent_cognition/rules/__init__.py
@@ -24,6 +24,7 @@ from agent_cognition.rules.predicate import (
     parse_predicate,
     validate_predicate,
 )
+from agent_cognition.rules.provision import ensure_seed_packs_installed
 from agent_cognition.rules.reflection import ReflectionReport, reflect
 from agent_cognition.rules.seed_packs import SEED_PACKS, SeedRule
 from agent_cognition.rules.store import (
@@ -67,6 +68,8 @@ __all__ = [
     "is_valid_predicate",
     "parse_predicate",
     "validate_predicate",
+    # seed-pack provisioning
+    "ensure_seed_packs_installed",
     # reflection (rule learning)
     "ReflectionReport",
     "reflect",

--- a/backend/agents/agent_cognition/rules/provision.py
+++ b/backend/agents/agent_cognition/rules/provision.py
@@ -1,0 +1,98 @@
+"""First-provision seed-pack installation for cognition agents.
+
+A cognition agent declares the seed rule packs it wants in its manifest
+(``cognition.rule_packs`` — see :mod:`agent_cognition.manifest_scope`). This
+module turns that declaration into installed rules the first time the cognition
+core handles the agent, via :func:`ensure_seed_packs_installed`.
+
+The install is **lazy** (driven from the invoke boundary, not a separate
+provisioning step), **idempotent** (the underlying
+:func:`agent_cognition.rules.store.install_seed_pack` keys each seed rule on a
+deterministic ``(agent_id, pack, seed_key)`` id with ``ON CONFLICT DO NOTHING``),
+and **best-effort** (a cognition hiccup must never break the invoke). A
+per-process memo skips the Postgres round-trip on every invoke after the first
+successful pass for an agent; the deterministic ids keep cross-process and
+concurrent installs correct on their own, so the memo is only an optimization.
+
+Invariant: this module never raises — every failure path logs and returns ``[]``.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+from agent_cognition import manifest_scope
+from agent_cognition.memory.store import AgentCognitionStorageUnavailable
+from agent_cognition.rules import store
+from shared_postgres import is_postgres_enabled
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["ensure_seed_packs_installed"]
+
+# Per-process record of agents whose declared packs we have already installed,
+# so the common (already-provisioned) invoke skips the DB round-trip. Guarded by
+# a lock because the invoke boundary calls this from a thread pool. Only a clean
+# pass records the agent — a tolerated storage outage leaves it absent so a later
+# invoke retries.
+_PROVISIONED: set[str] = set()
+_LOCK = threading.Lock()
+
+
+def ensure_seed_packs_installed(agent_id: str) -> list[str]:
+    """Install the agent's manifest-declared seed rule packs, once, best-effort.
+
+    Preconditions:
+        * ``agent_id`` is non-empty.
+    Postconditions:
+        * No-op returning ``[]`` when Postgres is unconfigured or the agent was
+          already provisioned in this process.
+        * Otherwise each pack named in the manifest's ``cognition.rule_packs`` is
+          installed idempotently; returns the rule ids newly inserted across all
+          packs (``[]`` when every declared rule already existed). An unknown
+          pack name is logged and skipped — one bad name does not block the rest.
+        * On a clean pass the agent is memoized so later invokes skip the work; a
+          storage outage (or any unexpected error) is logged, leaves the memo
+          untouched (so a later invoke retries), and still returns ``[]``.
+        * Never raises — a cognition failure must not break the invoke.
+    """
+    assert agent_id, "ensure_seed_packs_installed: agent_id must be non-empty"
+    if not is_postgres_enabled():
+        return []
+    with _LOCK:
+        if agent_id in _PROVISIONED:
+            return []
+
+    packs = manifest_scope.rule_packs(agent_id)
+    new_ids: list[str] = []
+    try:
+        for pack in packs:
+            try:
+                new_ids.extend(store.install_seed_pack(agent_id, pack))
+            except store.RuleStoreError:
+                logger.warning(
+                    "cognition: skipping unknown seed pack %r declared by agent %s", pack, agent_id
+                )
+    except AgentCognitionStorageUnavailable:
+        logger.warning(
+            "cognition: seed-pack install for %s deferred (storage unavailable)", agent_id
+        )
+        return []
+    except Exception:
+        logger.warning(
+            "cognition: seed-pack install for %s failed; continuing", agent_id, exc_info=True
+        )
+        return []
+
+    with _LOCK:
+        _PROVISIONED.add(agent_id)
+    if new_ids:
+        logger.info("cognition: installed %d seed rule(s) for %s", len(new_ids), agent_id)
+    return new_ids
+
+
+def _reset_provisioned_cache() -> None:
+    """Clear the per-process provisioned memo. Test-only hook."""
+    with _LOCK:
+        _PROVISIONED.clear()

--- a/backend/agents/agent_cognition/rules/provision.py
+++ b/backend/agents/agent_cognition/rules/provision.py
@@ -52,9 +52,15 @@ def ensure_seed_packs_installed(agent_id: str) -> list[str]:
           installed idempotently; returns the rule ids newly inserted across all
           packs (``[]`` when every declared rule already existed). An unknown
           pack name is logged and skipped — one bad name does not block the rest.
-        * On a clean pass the agent is memoized so later invokes skip the work; a
-          storage outage (or any unexpected error) is logged, leaves the memo
-          untouched (so a later invoke retries), and still returns ``[]``.
+        * The agent is memoized (so later invokes skip the work) only after a
+          clean install of a **non-empty** pack list. An empty result is never
+          memoized — it is indistinguishable from a transient registry-lookup
+          failure (``manifest_scope.rule_packs`` returns ``[]`` for both a
+          declared-empty manifest and a failed lookup), so a later invoke re-reads
+          the registry and installs the declared packs once it recovers. The
+          re-read is a cheap in-process registry call, not a DB round-trip.
+        * A storage outage (or any unexpected error) is logged, leaves the memo
+          untouched, and still returns ``[]``.
         * Never raises — a cognition failure must not break the invoke.
     """
     assert agent_id, "ensure_seed_packs_installed: agent_id must be non-empty"
@@ -65,6 +71,12 @@ def ensure_seed_packs_installed(agent_id: str) -> list[str]:
             return []
 
     packs = manifest_scope.rule_packs(agent_id)
+    if not packs:
+        # No declared packs, or a transient registry-lookup failure that yielded
+        # an empty list — nothing to install, and memoizing would wrongly mark a
+        # failed lookup as provisioned. Return without recording; a real empty
+        # declaration just re-reads the cheap registry next invoke.
+        return []
     new_ids: list[str] = []
     try:
         for pack in packs:

--- a/backend/agents/agent_cognition/tests/test_invoke_gate.py
+++ b/backend/agents/agent_cognition/tests/test_invoke_gate.py
@@ -29,6 +29,7 @@ from agent_cognition.models import (
     Rule,
     RuleMode,
 )
+from agent_cognition.rules import provision
 from agent_cognition.testing import FakeRunLedger, make_rule
 from agent_cognition.tools.envelope import try_unwrap_request
 
@@ -168,6 +169,32 @@ def test_prepare_rollup_budget_env_override_and_truncation_tolerated(
     out = _run(gate.prepare_invoke(_AGENT, {"q": 1}))
     assert seams.rollups == [(_AGENT, 3)]
     assert out.kind is gate.GateOutcomeKind.PROCEED  # a truncated pass never blocks
+
+
+def test_prepare_triggers_seed_provisioning(
+    seams: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The first-provision install fires once per invoke, before context load."""
+    seen: list[str] = []
+    monkeypatch.setattr(
+        provision, "ensure_seed_packs_installed", lambda agent_id: seen.append(agent_id)
+    )
+    out = _run(gate.prepare_invoke(_AGENT, {"q": 1}))
+    assert out.kind is gate.GateOutcomeKind.PROCEED
+    assert seen == [_AGENT]
+
+
+def test_prepare_tolerates_provisioning_failure(
+    seams: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A seed-pack provisioning error must never break the invoke."""
+
+    def _boom(_agent_id):
+        raise RuntimeError("provision blew up")
+
+    monkeypatch.setattr(provision, "ensure_seed_packs_installed", _boom)
+    out = _run(gate.prepare_invoke(_AGENT, {"q": 1}))
+    assert out.kind is gate.GateOutcomeKind.PROCEED  # never-break: the invoke proceeds
 
 
 def test_prepare_unledgered_attempts_get_distinct_event_run_ids(

--- a/backend/agents/agent_cognition/tests/test_manifest_scope.py
+++ b/backend/agents/agent_cognition/tests/test_manifest_scope.py
@@ -16,7 +16,13 @@ def _patch_registry(monkeypatch, manifest):
 
 
 def _manifest(
-    *, enabled=True, ingest_events=True, ingest_summaries=True, ground=True, retention=90
+    *,
+    enabled=True,
+    ingest_events=True,
+    ingest_summaries=True,
+    ground=True,
+    retention=90,
+    rule_packs=(),
 ):
     kg = types.SimpleNamespace(
         enabled=enabled,
@@ -25,7 +31,9 @@ def _manifest(
         ground_rule_proposals=ground,
     )
     memory = types.SimpleNamespace(retention_days_events=retention)
-    cognition = types.SimpleNamespace(knowledge_graph=kg, memory=memory)
+    cognition = types.SimpleNamespace(
+        knowledge_graph=kg, memory=memory, rule_packs=list(rule_packs)
+    )
     return types.SimpleNamespace(cognition=cognition)
 
 
@@ -49,6 +57,17 @@ def test_defaults_when_manifest_missing(monkeypatch):
     assert manifest_scope.graph_scope("a") == (True, True)
     assert manifest_scope.ground_rule_proposals("a") is True
     assert manifest_scope.retention_days("a") == 90
+    assert manifest_scope.rule_packs("a") == []
+
+
+def test_rule_packs_empty_when_registry_raises(monkeypatch):
+    import agent_registry
+
+    def _boom():
+        raise RuntimeError("no registry")
+
+    monkeypatch.setattr(agent_registry, "get_registry", _boom)
+    assert manifest_scope.rule_packs("a") == []
 
 
 def test_defaults_when_no_cognition_block(monkeypatch):
@@ -79,3 +98,13 @@ def test_ground_flag_respected(monkeypatch):
 def test_retention_from_manifest(monkeypatch):
     _patch_registry(monkeypatch, _manifest(retention=30))
     assert manifest_scope.retention_days("a") == 30
+
+
+def test_rule_packs_from_manifest(monkeypatch):
+    _patch_registry(monkeypatch, _manifest(rule_packs=["default_guardrails", "extra"]))
+    assert manifest_scope.rule_packs("a") == ["default_guardrails", "extra"]
+
+
+def test_rule_packs_default_when_no_cognition_block(monkeypatch):
+    _patch_registry(monkeypatch, types.SimpleNamespace(cognition=None))
+    assert manifest_scope.rule_packs("a") == []

--- a/backend/agents/agent_cognition/tests/test_provision.py
+++ b/backend/agents/agent_cognition/tests/test_provision.py
@@ -1,0 +1,108 @@
+"""Tests for lazy first-provision seed-pack installation (`rules/provision.py`).
+
+The install-path cases run against live Postgres (skipped when ``POSTGRES_HOST``
+is unset, like the other store tests); the Postgres-off and error paths
+monkeypatch their dependency, so they exercise the guard branches without a DB.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_cognition import manifest_scope
+from agent_cognition.memory.store import AgentCognitionStorageUnavailable
+from agent_cognition.models import RuleSource
+from agent_cognition.postgres import SCHEMA
+from agent_cognition.rules import provision, store
+from shared_postgres import is_postgres_enabled, register_team_schemas
+from shared_postgres.testing import truncate_team_tables
+
+pytestmark = pytest.mark.skipif(
+    not is_postgres_enabled(),
+    reason="POSTGRES_HOST not set; skipping live-Postgres provision tests",
+)
+
+
+@pytest.fixture(autouse=True)
+def _provision_schema() -> None:
+    register_team_schemas(SCHEMA)
+    truncate_team_tables(SCHEMA)
+    provision._reset_provisioned_cache()
+    yield
+    provision._reset_provisioned_cache()
+
+
+# ---------------------------------------------------------------------------
+# Happy path + idempotency
+# ---------------------------------------------------------------------------
+def test_installs_declared_packs(monkeypatch):
+    monkeypatch.setattr(manifest_scope, "rule_packs", lambda _id: ["default_guardrails"])
+    ids = provision.ensure_seed_packs_installed("a")
+    assert len(ids) == 1
+    rules = store.list_rules("a")
+    assert len(rules) == 1 and rules[0].source == RuleSource.SEED
+
+
+def test_idempotent_via_memo(monkeypatch):
+    monkeypatch.setattr(manifest_scope, "rule_packs", lambda _id: ["default_guardrails"])
+    assert len(provision.ensure_seed_packs_installed("a")) == 1
+    # Second call short-circuits on the per-process memo: nothing new, no duplicate.
+    assert provision.ensure_seed_packs_installed("a") == []
+    assert len(store.list_rules("a")) == 1
+
+
+def test_idempotent_across_processes(monkeypatch):
+    """Even without the memo, the deterministic ids make a re-install a no-op."""
+    monkeypatch.setattr(manifest_scope, "rule_packs", lambda _id: ["default_guardrails"])
+    assert len(provision.ensure_seed_packs_installed("a")) == 1
+    provision._reset_provisioned_cache()  # simulate a fresh process
+    assert provision.ensure_seed_packs_installed("a") == []
+    assert len(store.list_rules("a")) == 1
+
+
+def test_empty_rule_packs_is_noop(monkeypatch):
+    monkeypatch.setattr(manifest_scope, "rule_packs", lambda _id: [])
+    assert provision.ensure_seed_packs_installed("a") == []
+    assert store.list_rules("a") == []
+
+
+def test_unknown_pack_skipped_others_install(monkeypatch):
+    monkeypatch.setattr(manifest_scope, "rule_packs", lambda _id: ["nope", "default_guardrails"])
+    ids = provision.ensure_seed_packs_installed("a")
+    assert len(ids) == 1  # the unknown pack is skipped, the known one installs
+    assert len(store.list_rules("a")) == 1
+
+
+# ---------------------------------------------------------------------------
+# Best-effort guard branches (no DB needed beyond the monkeypatch)
+# ---------------------------------------------------------------------------
+def test_noop_when_postgres_disabled(monkeypatch):
+    monkeypatch.setattr(provision, "is_postgres_enabled", lambda: False)
+    # rule_packs must never be consulted once we've decided to no-op.
+    monkeypatch.setattr(
+        manifest_scope, "rule_packs", lambda _id: (_ for _ in ()).throw(AssertionError)
+    )
+    assert provision.ensure_seed_packs_installed("a") == []
+
+
+def test_storage_outage_defers_without_memoizing(monkeypatch):
+    monkeypatch.setattr(manifest_scope, "rule_packs", lambda _id: ["default_guardrails"])
+
+    def _raise(*_a, **_k):
+        raise AgentCognitionStorageUnavailable("down")
+
+    monkeypatch.setattr(store, "install_seed_pack", _raise)
+    assert provision.ensure_seed_packs_installed("a") == []
+    # Not memoized: a later invoke retries.
+    assert "a" not in provision._PROVISIONED
+
+
+def test_unexpected_error_is_swallowed(monkeypatch):
+    monkeypatch.setattr(manifest_scope, "rule_packs", lambda _id: ["default_guardrails"])
+
+    def _boom(*_a, **_k):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(store, "install_seed_pack", _boom)
+    assert provision.ensure_seed_packs_installed("a") == []
+    assert "a" not in provision._PROVISIONED

--- a/backend/agents/agent_cognition/tests/test_provision.py
+++ b/backend/agents/agent_cognition/tests/test_provision.py
@@ -60,10 +60,24 @@ def test_idempotent_across_processes(monkeypatch):
     assert len(store.list_rules("a")) == 1
 
 
-def test_empty_rule_packs_is_noop(monkeypatch):
+def test_empty_rule_packs_is_noop_and_not_memoized(monkeypatch):
     monkeypatch.setattr(manifest_scope, "rule_packs", lambda _id: [])
     assert provision.ensure_seed_packs_installed("a") == []
     assert store.list_rules("a") == []
+    # An empty result is indistinguishable from a transient lookup failure, so it
+    # must not be memoized — a later invoke has to retry.
+    assert "a" not in provision._PROVISIONED
+
+
+def test_recovers_after_transient_empty_lookup(monkeypatch):
+    """An empty list (e.g. registry not yet loaded) must not block a later install."""
+    packs: list[str] = []
+    monkeypatch.setattr(manifest_scope, "rule_packs", lambda _id: list(packs))
+    assert provision.ensure_seed_packs_installed("a") == []  # registry "unavailable"
+    assert store.list_rules("a") == []
+    packs.append("default_guardrails")  # registry recovers
+    assert len(provision.ensure_seed_packs_installed("a")) == 1
+    assert len(store.list_rules("a")) == 1
 
 
 def test_unknown_pack_skipped_others_install(monkeypatch):

--- a/backend/agents/agent_cognition/tests/test_provision.py
+++ b/backend/agents/agent_cognition/tests/test_provision.py
@@ -1,8 +1,10 @@
 """Tests for lazy first-provision seed-pack installation (`rules/provision.py`).
 
-The install-path cases run against live Postgres (skipped when ``POSTGRES_HOST``
-is unset, like the other store tests); the Postgres-off and error paths
-monkeypatch their dependency, so they exercise the guard branches without a DB.
+Split by dependency: the install-path cases hit live Postgres (marked
+``_requires_pg`` so they skip when ``POSTGRES_HOST`` is unset, and request the
+``pg_schema`` fixture); the best-effort guard branches mock the Postgres gate and
+the store boundary, so they run everywhere — including the standard no-Postgres
+environment, where they are the only coverage of the failure paths.
 """
 
 from __future__ import annotations
@@ -17,25 +19,34 @@ from agent_cognition.rules import provision, store
 from shared_postgres import is_postgres_enabled, register_team_schemas
 from shared_postgres.testing import truncate_team_tables
 
-pytestmark = pytest.mark.skipif(
+# Applied per-test (not module-wide) so the DB-independent guard-branch tests
+# below still run when Postgres is absent.
+_requires_pg = pytest.mark.skipif(
     not is_postgres_enabled(),
     reason="POSTGRES_HOST not set; skipping live-Postgres provision tests",
 )
 
 
 @pytest.fixture(autouse=True)
-def _provision_schema() -> None:
-    register_team_schemas(SCHEMA)
-    truncate_team_tables(SCHEMA)
+def _reset_cache() -> None:
+    """Clear the per-process provisioned memo around every test (no DB)."""
     provision._reset_provisioned_cache()
     yield
     provision._reset_provisioned_cache()
 
 
+@pytest.fixture
+def pg_schema() -> None:
+    """Register + truncate the cognition tables. Requested only by live-DB tests."""
+    register_team_schemas(SCHEMA)
+    truncate_team_tables(SCHEMA)
+
+
 # ---------------------------------------------------------------------------
-# Happy path + idempotency
+# Happy path + idempotency (live Postgres)
 # ---------------------------------------------------------------------------
-def test_installs_declared_packs(monkeypatch):
+@_requires_pg
+def test_installs_declared_packs(pg_schema, monkeypatch):
     monkeypatch.setattr(manifest_scope, "rule_packs", lambda _id: ["default_guardrails"])
     ids = provision.ensure_seed_packs_installed("a")
     assert len(ids) == 1
@@ -43,7 +54,8 @@ def test_installs_declared_packs(monkeypatch):
     assert len(rules) == 1 and rules[0].source == RuleSource.SEED
 
 
-def test_idempotent_via_memo(monkeypatch):
+@_requires_pg
+def test_idempotent_via_memo(pg_schema, monkeypatch):
     monkeypatch.setattr(manifest_scope, "rule_packs", lambda _id: ["default_guardrails"])
     assert len(provision.ensure_seed_packs_installed("a")) == 1
     # Second call short-circuits on the per-process memo: nothing new, no duplicate.
@@ -51,7 +63,8 @@ def test_idempotent_via_memo(monkeypatch):
     assert len(store.list_rules("a")) == 1
 
 
-def test_idempotent_across_processes(monkeypatch):
+@_requires_pg
+def test_idempotent_across_processes(pg_schema, monkeypatch):
     """Even without the memo, the deterministic ids make a re-install a no-op."""
     monkeypatch.setattr(manifest_scope, "rule_packs", lambda _id: ["default_guardrails"])
     assert len(provision.ensure_seed_packs_installed("a")) == 1
@@ -60,7 +73,8 @@ def test_idempotent_across_processes(monkeypatch):
     assert len(store.list_rules("a")) == 1
 
 
-def test_empty_rule_packs_is_noop_and_not_memoized(monkeypatch):
+@_requires_pg
+def test_empty_rule_packs_is_noop_and_not_memoized(pg_schema, monkeypatch):
     monkeypatch.setattr(manifest_scope, "rule_packs", lambda _id: [])
     assert provision.ensure_seed_packs_installed("a") == []
     assert store.list_rules("a") == []
@@ -69,7 +83,8 @@ def test_empty_rule_packs_is_noop_and_not_memoized(monkeypatch):
     assert "a" not in provision._PROVISIONED
 
 
-def test_recovers_after_transient_empty_lookup(monkeypatch):
+@_requires_pg
+def test_recovers_after_transient_empty_lookup(pg_schema, monkeypatch):
     """An empty list (e.g. registry not yet loaded) must not block a later install."""
     packs: list[str] = []
     monkeypatch.setattr(manifest_scope, "rule_packs", lambda _id: list(packs))
@@ -80,7 +95,8 @@ def test_recovers_after_transient_empty_lookup(monkeypatch):
     assert len(store.list_rules("a")) == 1
 
 
-def test_unknown_pack_skipped_others_install(monkeypatch):
+@_requires_pg
+def test_unknown_pack_skipped_others_install(pg_schema, monkeypatch):
     monkeypatch.setattr(manifest_scope, "rule_packs", lambda _id: ["nope", "default_guardrails"])
     ids = provision.ensure_seed_packs_installed("a")
     assert len(ids) == 1  # the unknown pack is skipped, the known one installs
@@ -88,7 +104,8 @@ def test_unknown_pack_skipped_others_install(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Best-effort guard branches (no DB needed beyond the monkeypatch)
+# Best-effort guard branches — DB-independent, so they run without Postgres.
+# Each patches the Postgres gate and mocks the store, never touching a real DB.
 # ---------------------------------------------------------------------------
 def test_noop_when_postgres_disabled(monkeypatch):
     monkeypatch.setattr(provision, "is_postgres_enabled", lambda: False)
@@ -100,6 +117,8 @@ def test_noop_when_postgres_disabled(monkeypatch):
 
 
 def test_storage_outage_defers_without_memoizing(monkeypatch):
+    # Patch the gate True so we reach the (mocked) store boundary without a DB.
+    monkeypatch.setattr(provision, "is_postgres_enabled", lambda: True)
     monkeypatch.setattr(manifest_scope, "rule_packs", lambda _id: ["default_guardrails"])
 
     def _raise(*_a, **_k):
@@ -112,6 +131,7 @@ def test_storage_outage_defers_without_memoizing(monkeypatch):
 
 
 def test_unexpected_error_is_swallowed(monkeypatch):
+    monkeypatch.setattr(provision, "is_postgres_enabled", lambda: True)
     monkeypatch.setattr(manifest_scope, "rule_packs", lambda _id: ["default_guardrails"])
 
     def _boom(*_a, **_k):

--- a/backend/agents/shared_agent_invoke/limits.py
+++ b/backend/agents/shared_agent_invoke/limits.py
@@ -47,8 +47,19 @@ def max_writeback_bytes() -> int:
     The per-field ``output`` cap (:func:`max_output_bytes`) must not be shared
     with the audit, or a near-cap ``output`` could starve the audit (or vice
     versa). Defaults to 1 MiB; override via ``AGENT_COGNITION_WRITEBACK_MAX_BYTES``.
+
+    Parses defensively: an unset, unparseable, or non-positive override falls
+    back to the default, so a malformed setting can never raise on the invoke
+    response path or shrink the cap to a value that drops every audit entry.
     """
-    return int(os.getenv("AGENT_COGNITION_WRITEBACK_MAX_BYTES", str(DEFAULT_MAX_WRITEBACK_BYTES)))
+    raw = os.getenv("AGENT_COGNITION_WRITEBACK_MAX_BYTES")
+    if raw is None:
+        return DEFAULT_MAX_WRITEBACK_BYTES
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_MAX_WRITEBACK_BYTES
+    return value if value > 0 else DEFAULT_MAX_WRITEBACK_BYTES
 
 
 def default_exec_timeout_s() -> float:

--- a/backend/agents/shared_agent_invoke/tests/test_limits.py
+++ b/backend/agents/shared_agent_invoke/tests/test_limits.py
@@ -74,3 +74,10 @@ def test_max_writeback_bytes_default_and_override(monkeypatch: pytest.MonkeyPatc
     assert max_writeback_bytes() == DEFAULT_MAX_WRITEBACK_BYTES
     monkeypatch.setenv("AGENT_COGNITION_WRITEBACK_MAX_BYTES", "2048")
     assert max_writeback_bytes() == 2048
+
+
+@pytest.mark.parametrize("raw", ["", "junk", "0", "-1"])
+def test_max_writeback_bytes_defensive_fallback(monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+    """Unparseable or non-positive overrides fall back to the default, never raise."""
+    monkeypatch.setenv("AGENT_COGNITION_WRITEBACK_MAX_BYTES", raw)
+    assert max_writeback_bytes() == DEFAULT_MAX_WRITEBACK_BYTES

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -257,6 +257,18 @@ processed period costs one LLM summarization call, so the budget keeps a cold-st
 sequential LLM calls on the invoke hot path. The pass is oldest-first and idempotent: repeated
 budgeted invokes — and the unbudgeted central scheduler — drain the remainder.
 
+### AGENT_COGNITION_ROLLUP_INPUT_CHARS
+Character budget passed to `compact_text` for the events/lower-scale-summaries block before each
+rollup LLM summarization call (`agent_cognition/memory/rollup.py`, default `12000`; garbage or a
+non-positive value falls back to the default). Caps how much memory text one summarization period
+feeds the model.
+
+### AGENT_COGNITION_DIGEST_EVENT_TOP_N
+Number of most-recent in-progress memory events folded into an agent's memory digest at invoke time
+(`agent_cognition/memory/retrieval.py`, default `20`; garbage or a non-positive value falls back to
+the default). The summary half of the digest is bounded separately by the caller-supplied
+`token_budget` (trimmed via `compact_text`).
+
 ### NEO4J_BOLT_URL
 Bolt URL of the Neo4j server backing the Graphiti knowledge-graph layer over Agent Cognition (e.g.
 `bolt://neo4j:7687`). This is the layer's **enablement gate** (`shared_neo4j.is_neo4j_enabled()`): a
@@ -305,6 +317,18 @@ ledger. A *terminal* (`completed`/`blocked`) run row is retained this long so a 
 stored envelope without re-invoking; once `completed_at` is older than the TTL the scheduler's
 `gc_terminal_runs` pass reclaims it. `in_progress` rows are **never** GC'd here — an expired lease is
 reclaimed lazily by `claim_run`, preserving its `request_hash` for retry policing.
+
+### AGENT_COGNITION_RUN_LEASE_S
+Lease duration (seconds, default `120`, floored to `30`) a `claim_run` holds on an `in_progress`
+`agent_cognition_runs` row (`agent_cognition/context.py`). A still-leased row makes a concurrent
+retry conflict; once the lease expires the row is reclaimed in place (its `request_hash` retained) and
+re-executed. Distinct from `AGENT_COGNITION_RUN_TTL_S`, which bounds *terminal* rows for replay.
+
+### AGENT_COGNITION_WRITEBACK_MAX_BYTES
+Byte cap on the cognition `cognition_writeback` half of an invoke envelope
+(`agents/shared_agent_invoke/limits.py`, default `1048576` = 1 MiB). The user `output` field has its
+own bound (`AGENT_INVOKE_MAX_OUTPUT_BYTES`), so control/memory data never competes with user output;
+an over-cap writeback is truncated and flagged rather than dropping the response.
 
 ### AGENT_COGNITION_GRAPH_SEARCH_TOP_K
 Max related facts retrieved per knowledge-graph search in `build_graph_context` (default `10`),


### PR DESCRIPTION
## Summary

Step 13 of the Agent Cognition Core (Milestone D): sensible day-one guardrails + operability.

The seed-pack machinery already existed — `SEED_PACKS["default_guardrails"]` and an idempotent,
race-safe `install_seed_pack()` — but nothing called it, and the manifest's `cognition.rule_packs`
field was read by no code. This PR wires the install into the invoke boundary and documents the
cognition operability env.

## Changes

- **`manifest_scope.rule_packs(agent_id)`** — resolves the seed packs an agent declares in its
  manifest (`cognition.rule_packs`), `[]` on any missing manifest / lookup failure.
- **`rules/provision.ensure_seed_packs_installed(agent_id)`** — new lazy installer: idempotent
  (the underlying deterministic `(agent_id, pack, seed_key)` ids + `ON CONFLICT DO NOTHING`),
  memoized per process, and best-effort (unknown pack → logged & skipped; storage outage → deferred;
  never raises, so a cognition hiccup can't break an invoke).
- **`prepare_invoke`** calls the installer **before** context load, so the seeded rules are active
  for the very first invoke's context read and precondition gate.
- **Docs** — consolidated "Configuration & operability" section in the package README plus the three
  previously-undocumented cognition env vars (`AGENT_COGNITION_DIGEST_EVENT_TOP_N`,
  `…_ROLLUP_INPUT_CHARS`, `…_RUN_LEASE_S`) and the writeback cap added to `docs/ENV_VARS.md`; a
  pointer + seed-pack note in `CLAUDE.md`. The scheduler tick is documented under its implemented
  name `AGENT_COGNITION_SCHEDULER_INTERVAL_S` (the issue's `AGENT_COGNITION_TICK_S` is noted as the
  same knob).

## Testing

- New `tests/test_provision.py` (install/idempotency/unknown-pack/empty/Postgres-off/storage-outage
  cases) and extended `test_manifest_scope.py` + `test_invoke_gate.py` (wiring fires once; a
  provisioning failure never breaks the invoke).
- Full `agent_cognition` suite green against live Postgres: **539 passed, 99.23% coverage**
  (new files `provision.py` / `manifest_scope.py` / `invoke_gate.py` at 100%). `ruff check` + format
  clean.

## Notes / out of scope

- The `default_guardrails` pack content is unchanged — richer guardrails are deferred to a later step
  per `IMPLEMENTATION_PLAN.md`.
- No rename of `AGENT_COGNITION_SCHEDULER_INTERVAL_S`; no generator wiring (Step 14).

Closes #736

---
_Generated by [Claude Code](https://claude.ai/code/session_013uMDCXBbadooJeb3g6HP8U)_