### PR TITLE
[Cognition] Restore structured block fields on replay of blocked runs

### DIFF
--- a/backend/agents/agent_cognition/README.md
+++ b/backend/agents/agent_cognition/README.md
@@ -163,7 +163,7 @@ so byte-identical keyless retries still dedup. The run is claimed in the leased
 | Ledger state on claim | Result |
 |---|---|
 | first sight | claimed; executes; `completed`/`blocked` stored on return |
-| terminal (`completed` **or** `blocked`), same body hash | **replays the stored envelope** without re-invoking (the proxy adds `X-Khala-Replayed: true`); a retried rule block replays the same 4xx |
+| terminal (`completed` **or** `blocked`), same body hash | **replays the stored envelope** without re-invoking (the proxy adds `X-Khala-Replayed: true`); a retried rule block replays the same 4xx **and restores the structured `blocked`/`block_phase`/`block_reason` fields** (rows stored before those keys existed degrade to `blocked=False`) |
 | any row, different body hash | `409` — one key, one body |
 | `in_progress`, valid lease | `409` — still in flight |
 | `in_progress`, expired lease | reclaimed in place (hash retained) and re-executed |
@@ -214,10 +214,14 @@ when an agent carrying enforced postcondition rules returns a 2xx without an obj
 `output` — the rules evaluate against an empty mapping (missing paths block) rather than
 being silently skipped. A pass persists the envelope's `memory_events` (validated
 defensively — one malformed event is dropped with a warning, never failing the call) and
-completes the ledger row with `{status_code, content}` for replay. The stored envelope
-never carries the per-invoke `sandbox` block, so a replay cannot masquerade as a fresh
-boot. Blocked outcomes carry structured `block_phase` / `block_reason` fields — callers
-read those, never parse the stored HTTP body.
+completes the ledger row with `{status_code, content}` for replay. A `blocked` row stores
+the structured fields (`blocked`/`block_phase`/`block_reason`) alongside that body, so a
+replayed block restores the same structured shape a fresh block reports — indistinguishable
+to callers branching on `fin.blocked` — while a row stored before those keys existed
+degrades to `blocked=False` (no migration). The stored envelope never carries the per-invoke
+`sandbox` block, so a replay cannot masquerade as a fresh boot. Blocked outcomes carry
+structured `block_phase` / `block_reason` fields — callers read those, never parse the
+stored HTTP body.
 
 ## Seed rule packs (`rules/seed_packs.py`, `rules/provision.py`)
 

--- a/backend/agents/agent_cognition/invoke_gate.py
+++ b/backend/agents/agent_cognition/invoke_gate.py
@@ -52,9 +52,13 @@ dedups a re-sent writeback; across attempts the keyspaces are disjoint.
 Stored-envelope shape: the ledger's purpose is to replay the exact response
 a retry would otherwise recompute, so the stored ``content`` (and a blocked
 outcome's ``content``) is deliberately the full HTTP response body —
-including the FastAPI-style ``{"detail": ...}`` framing for rule blocks.
-Transport-agnostic callers should read the structured
-``FinalizeOutcome.block_phase`` / ``block_reason`` (and
+including the FastAPI-style ``{"detail": ...}`` framing for rule blocks. A
+blocked envelope additionally stores the structured block fields
+(``blocked`` / ``block_phase`` / ``block_reason``) so a replay restores the
+same structured shape a fresh block reports rather than forcing callers to
+re-sniff ``content``; envelopes written before those keys existed degrade on
+replay to ``blocked=False`` (no migration). Transport-agnostic callers should
+read the structured ``FinalizeOutcome.block_phase`` / ``block_reason`` (and
 ``GateOutcome.reason``) fields instead of parsing ``content``.
 
 Design by Contract: every public function documents explicit Preconditions /
@@ -234,7 +238,12 @@ class GateOutcome:
     Invariants:
         * ``kind is PROCEED``  → ``prepared`` is set; all other fields unset.
         * ``kind is REPLAY``   → ``status_code`` + ``content`` carry the stored
-          terminal envelope.
+          terminal envelope. When that envelope is a *blocked* run stored with
+          the structured fields, ``replay_blocked`` is ``True`` and
+          ``block_phase`` / ``block_reason`` carry the original cause so the
+          mapper can rebuild a structurally-identical block; an envelope stored
+          before those keys existed leaves them unset (replay degrades to
+          ``blocked=False``).
         * ``kind is BLOCKED``  → ``status_code`` + ``content`` carry the 4xx
           envelope (also stored in the ledger when the run was claimed) and
           ``reason`` carries the failing rule's reason. A BLOCKED outcome is
@@ -252,6 +261,12 @@ class GateOutcome:
     status_code: int | None = None
     content: Any = None
     reason: str | None = None
+    # Set only on a REPLAY of a previously *blocked* run stored with the
+    # structured fields (added by ``_record_block``). ``replay_blocked`` is the
+    # explicit stored flag — absent on legacy rows, which then degrade.
+    replay_blocked: bool = False
+    block_phase: str | None = None
+    block_reason: str | None = None
 
 
 @dataclass(frozen=True)
@@ -267,12 +282,16 @@ class FinalizeOutcome:
         * ``replayed`` is ``True`` exactly when the response was served from
           the run ledger without re-invoking the agent — transports use this
           (not the gate outcome's kind) to mark replays, e.g. the proxy's
-          ``X-Khala-Replayed`` header. A replay is a **verbatim** re-serve of
-          the stored envelope, so a replay of a previously *blocked* run
-          reports ``replayed=True`` with ``blocked=False`` and no
-          ``block_phase``/``block_reason`` — the structured block fields
-          describe this attempt's gating, which did not run. Callers handling
-          replays must branch on ``status_code``/``content``, not ``blocked``.
+          ``X-Khala-Replayed`` header. A replay re-serves the stored envelope's
+          ``status_code``/``content`` verbatim; for a replay of a previously
+          *blocked* run the gate **restores the structured block fields** from
+          the ledger too, so it reports ``replayed=True`` with ``blocked=True``
+          and the original ``block_phase``/``block_reason`` — a replayed block
+          is indistinguishable from a fresh one to callers branching on the
+          structured fields. A blocked run stored *before* those fields were
+          persisted lacks the keys and degrades to ``blocked=False`` (no
+          ``block_phase``/``block_reason``); such callers should still treat
+          the 4xx ``status_code``/``content`` as authoritative.
         * otherwise ``status_code``/``content`` echo the upstream response.
     """
 
@@ -704,14 +723,21 @@ def _replay_outcome(agent_id: str, source_run_id: str, response: Any) -> GateOut
     """Map a terminal ledger row's stored envelope to a ``REPLAY`` outcome.
 
     Postconditions: a well-formed stored envelope (``{status_code, content}``)
-    replays verbatim; a malformed/missing one degrades to ``CONFLICT`` (never a
-    forged 200) with the anomaly logged.
+    replays verbatim; a blocked envelope additionally carrying the structured
+    fields (``blocked``/``block_phase``/``block_reason``) carries them onto the
+    outcome so the mapper rebuilds the same structured shape a fresh block
+    reports — a row stored before those keys existed leaves them unset and
+    degrades to ``blocked=False``. A malformed/missing envelope degrades to
+    ``CONFLICT`` (never a forged 200) with the anomaly logged.
     """
     if isinstance(response, Mapping) and isinstance(response.get("status_code"), int):
         return GateOutcome(
             kind=GateOutcomeKind.REPLAY,
             status_code=response["status_code"],
             content=response.get("content"),
+            replay_blocked=bool(response.get("blocked")),
+            block_phase=response.get("block_phase"),
+            block_reason=response.get("block_reason"),
         )
     logger.error(
         "cognition: terminal run %s/%s has no replayable envelope; refusing replay",
@@ -777,12 +803,24 @@ def _record_block(
     )
     _persist_events_best_effort(agent_id, event_run_id, events)
     if claim_token is not None:
+        # Persist the structured block fields alongside the replayable body so a
+        # same-key retry can restore the same shape a fresh block reports
+        # (blocked/block_phase/block_reason) instead of re-sniffing ``content``.
+        # Additive keys in the ``agent_cognition_runs.response`` JSONB — no
+        # schema change; rows written before this degrade on replay (the keys
+        # are simply absent → blocked=False).
         _complete_best_effort(
             agent_id,
             source_run_id,
             claim_token,
             status="blocked",
-            response={"status_code": 422, "content": content},
+            response={
+                "status_code": 422,
+                "content": content,
+                "blocked": True,
+                "block_phase": phase,
+                "block_reason": reason,
+            },
         )
     return content
 
@@ -978,12 +1016,14 @@ def outcome_as_finalized(outcome: GateOutcome) -> FinalizeOutcome:
     Preconditions:
         * ``outcome.kind is not PROCEED`` (a PROCEED has no response to map).
     Postconditions:
-        * ``REPLAY`` → the stored terminal envelope verbatim, with
-          ``replayed=True`` so transports can mark it. Verbatim means a replay
-          of a previously *blocked* run carries the stored 4xx in
-          ``status_code``/``content`` but ``blocked=False`` — the structured
-          block fields describe the current attempt's gating, which a replay
-          skips (see :class:`FinalizeOutcome`). ``BLOCKED`` → the 422
+        * ``REPLAY`` → the stored terminal envelope's ``status_code``/``content``
+          verbatim, with ``replayed=True`` so transports can mark it. A replay
+          of a previously *blocked* run also **restores the structured block
+          fields** from the ledger (``blocked=True`` with the original
+          ``block_phase``/``block_reason``), so it is indistinguishable from a
+          fresh block to callers branching on those fields; a blocked run
+          stored before those keys existed lacks them and degrades to
+          ``blocked=False`` (see :class:`FinalizeOutcome`). ``BLOCKED`` → the 422
           block envelope with ``blocked``/``block_phase``/``block_reason``
           set. ``block_phase`` is always ``"precondition"`` here by the
           :class:`GateOutcome` invariant — :func:`prepare_invoke` is the sole
@@ -1002,7 +1042,12 @@ def outcome_as_finalized(outcome: GateOutcome) -> FinalizeOutcome:
     if outcome.kind is GateOutcomeKind.REPLAY:
         assert outcome.status_code is not None, "outcome_as_finalized: replay lacks status"
         return FinalizeOutcome(
-            status_code=outcome.status_code, content=outcome.content, replayed=True
+            status_code=outcome.status_code,
+            content=outcome.content,
+            replayed=True,
+            blocked=outcome.replay_blocked,
+            block_phase=outcome.block_phase,
+            block_reason=outcome.block_reason,
         )
     if outcome.kind is GateOutcomeKind.BLOCKED:
         return FinalizeOutcome(

--- a/backend/agents/agent_cognition/tests/test_invoke_gate.py
+++ b/backend/agents/agent_cognition/tests/test_invoke_gate.py
@@ -228,12 +228,43 @@ def test_prepare_replays_blocked_row_as_4xx(seams: SimpleNamespace) -> None:
         "status": "blocked",
         "hash": gate.derive_source_run_id({"q": 1})[1],
         "token": "t",
-        "response": {"status_code": 422, "content": {"detail": {"phase": "precondition"}}},
+        "response": {
+            "status_code": 422,
+            "content": {"detail": {"phase": "precondition"}},
+            "blocked": True,
+            "block_phase": "precondition",
+            "block_reason": "blocked by rule r",
+        },
         "lease_valid": False,
     }
     out = _run(gate.prepare_invoke(_AGENT, {"q": 1}, idempotency_key="k1"))
     assert out.kind is gate.GateOutcomeKind.REPLAY
     assert out.status_code == 422
+    # The structured fields are restored from the ledger onto the outcome…
+    assert out.replay_blocked is True
+    assert out.block_phase == "precondition"
+    assert out.block_reason == "blocked by rule r"
+    # …and the finalized replay is indistinguishable from a fresh block.
+    fin = gate.outcome_as_finalized(out)
+    assert fin.replayed and fin.blocked and fin.block_phase == "precondition"
+
+
+def test_prepare_replays_legacy_blocked_row_degrades(seams: SimpleNamespace) -> None:
+    """A blocked row stored before the structured fields existed lacks the new
+    keys; replay must degrade to blocked=False rather than erroring."""
+    seams.ledger.rows[(_AGENT, "k1")] = {
+        "status": "blocked",
+        "hash": gate.derive_source_run_id({"q": 1})[1],
+        "token": "t",
+        "response": {"status_code": 422, "content": {"detail": {"phase": "precondition"}}},
+        "lease_valid": False,
+    }
+    out = _run(gate.prepare_invoke(_AGENT, {"q": 1}, idempotency_key="k1"))
+    assert out.kind is gate.GateOutcomeKind.REPLAY
+    assert out.status_code == 422  # HTTP body unchanged from today
+    assert out.replay_blocked is False and out.block_phase is None
+    fin = gate.outcome_as_finalized(out)
+    assert fin.replayed and not fin.blocked  # graceful degradation, no error
 
 
 def test_prepare_malformed_stored_envelope_degrades_to_conflict(seams: SimpleNamespace) -> None:
@@ -336,14 +367,26 @@ def test_prepare_precondition_block_is_durable(seams: SimpleNamespace) -> None:
     assert writeback.events[0].data["phase"] == "precondition"
     assert out.reason  # structured cause carried on the outcome
 
-    # …and the 4xx envelope stored as blocked, so a retry replays it verbatim.
+    # …and the 4xx envelope stored as blocked — with the structured block
+    # fields alongside the replayable body — so a retry replays it verbatim AND
+    # restores the same structured shape a fresh block reports.
     row = seams.ledger.rows[(_AGENT, "k1")]
     assert row["status"] == "blocked"
     assert row["response"]["status_code"] == 422
+    assert row["response"]["blocked"] is True
+    assert row["response"]["block_phase"] == "precondition"
+    assert row["response"]["block_reason"] == out.reason
     replay = _run(gate.prepare_invoke(_AGENT, {"q": 1}, idempotency_key="k1"))
     assert replay.kind is gate.GateOutcomeKind.REPLAY
     assert replay.status_code == 422
-    assert replay.content == out.content
+    assert replay.content == out.content  # HTTP body byte-identical to the fresh block
+    # The structured fields ride the outcome onto the finalized replay, so an
+    # in-process caller branching on fin.blocked sees the block.
+    assert replay.replay_blocked is True
+    fin = gate.outcome_as_finalized(replay)
+    assert fin.replayed and fin.blocked
+    assert fin.block_phase == "precondition"
+    assert fin.block_reason == out.reason
 
 
 def test_prepare_precondition_block_unledgered_still_records_event(
@@ -684,18 +727,35 @@ def test_outcome_as_finalized_uses_shared_status_map(seams: SimpleNamespace) -> 
         gate.GateOutcome(kind=gate.GateOutcomeKind.REPLAY, status_code=200, content={"output": 1})
     )
     assert replay.replayed and replay.status_code == 200
-    # A replay of a previously BLOCKED run is a verbatim re-serve: the stored
-    # 4xx rides in status_code/content, but the structured block fields stay
-    # unset — they describe THIS attempt's gating, which a replay skips.
+    # A replay of a previously BLOCKED run restores the structured block fields
+    # the ledger stored, so it is indistinguishable from a fresh block to a
+    # caller branching on the structured fields — the point of the change.
     replayed_block = gate.outcome_as_finalized(
+        gate.GateOutcome(
+            kind=gate.GateOutcomeKind.REPLAY,
+            status_code=422,
+            content={"detail": {"phase": "precondition", "reason": "r"}},
+            replay_blocked=True,
+            block_phase="precondition",
+            block_reason="r",
+        )
+    )
+    assert replayed_block.replayed and replayed_block.status_code == 422
+    assert replayed_block.blocked and replayed_block.block_phase == "precondition"
+    assert replayed_block.block_reason == "r"
+    # Graceful degradation: a blocked run stored BEFORE the structured fields
+    # existed replays the 4xx body but lacks the keys, so it degrades to
+    # blocked=False (documented) rather than erroring.
+    legacy_block = gate.outcome_as_finalized(
         gate.GateOutcome(
             kind=gate.GateOutcomeKind.REPLAY,
             status_code=422,
             content={"detail": {"phase": "precondition", "reason": "r"}},
         )
     )
-    assert replayed_block.replayed and replayed_block.status_code == 422
-    assert not replayed_block.blocked and replayed_block.block_phase is None
+    assert legacy_block.replayed and legacy_block.status_code == 422
+    assert not legacy_block.blocked and legacy_block.block_phase is None
+    assert legacy_block.block_reason is None
     # An unmapped future kind raises the typed exhaustiveness error.
     with pytest.raises(gate.UnmappedGateOutcomeError, match="future_kind"):
         gate.outcome_as_finalized(gate.GateOutcome(kind="future_kind"))  # type: ignore[arg-type]


### PR DESCRIPTION
## Problem

The run ledger stored a blocked run's terminal envelope as `{status_code, content}` and replayed it verbatim. A same-key retry of a rule-blocked run got the stored 422 body, but the structured `FinalizeOutcome` fields denied the block: `replayed=True`, `blocked=False`, `block_phase=None`, `block_reason=None`. An in-process consumer branching on `fin.blocked` would mishandle a replayed block unless it also re-implemented the status/content sniffing the structured fields exist to prevent.

## Change

The invoke gate now persists the structured block fields in the ledger envelope and restores them on replay, so a replayed block reports the same structured shape as a fresh one:

- **`_record_block`** stores `{status_code, content, blocked, block_phase, block_reason}` when completing a run as `blocked` — additive keys in the `agent_cognition_runs.response` JSONB, no schema change.
- **`GateOutcome`** grows an explicit `replay_blocked` boolean plus `block_phase` / `block_reason`; **`_replay_outcome`** reads them off the stored envelope.
- **`outcome_as_finalized`** maps a replayed block to `replayed=True, blocked=True, block_phase=…, block_reason=…` — replays and fresh blocks become indistinguishable to callers branching on the structured fields.

## Backward compatibility

Envelopes stored before this change lack the new keys; replay degrades to today's behavior (`blocked=False`, documented) rather than erroring. No migration.

## Docs

Updated the module docstring's "Stored-envelope shape" note, the `FinalizeOutcome` invariant, the `outcome_as_finalized` postconditions, and the "Invoke gate" section of `agent_cognition/README.md` — the Step-10 "replays carry only the stored envelope — branch on status_code/content" scoping becomes "replays restore the structured block fields; pre-existing rows degrade".

## Acceptance

- [x] A retried precondition-blocked run replays with `replayed=True`, `blocked=True`, and the original `block_phase`/`block_reason`; the HTTP body is byte-identical to today.
- [x] A ledger row stored without the new keys replays with `blocked=False` (graceful degradation), covered by a dedicated test.
- [x] Fresh-block behavior unchanged; mapper exhaustiveness guard unchanged.
- [x] ruff clean; 100% line coverage on `invoke_gate.py` (48 tests pass).

Closes #845

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGXS2EcsYLmMrQ2Ri9SuDD)_