### PR TITLE
fix(se-team): drop arbitrary 1-3 word cap from naming convention rules

### DIFF
--- a/backend/agents/software_engineering_team/backend_agent/prompts.py
+++ b/backend/agents/software_engineering_team/backend_agent/prompts.py
@@ -101,7 +101,7 @@ PROJECT STRUCTURE & FILE ORGANIZATION
    **Examples:** "Create user registration endpoint" -> `app/routers/users.py` | "Build the authentication service with JWT" -> `app/services/auth.py` | "Define data models for orders" -> `app/models/order.py`
 
    **HARD RULES:**
-   - Names must be concise and descriptive -- use the fewest words that clearly convey the purpose, with no fixed word limit; never sacrifice clarity for brevity
+   - File/module names must be a short, concise noun phrase (one or two nouns), never sentence-like: keep each path segment under ~30 characters and avoid 4+ hyphenated or 5+ underscored words, which path validation rejects. (This length guidance is for file/folder/module names only -- function, variable, and class names inside the code are NOT word-capped; keep them concise but as descriptive as the purpose requires, never sacrificing clarity for brevity.)
    - NEVER use the task description as a file name -- extract the noun only
    - NEVER start a name with a verb (implement_, create_, build_, add_, setup_, etc.)
    - NEVER include filler words (_the_, _that_, _with_, _using_, _which_, _for_)

--- a/backend/agents/software_engineering_team/backend_agent/prompts.py
+++ b/backend/agents/software_engineering_team/backend_agent/prompts.py
@@ -95,13 +95,13 @@ PROJECT STRUCTURE & FILE ORGANIZATION
    **How to derive a file/module name (FOLLOW THIS ALGORITHM):**
    a. Read the task description and identify the core NOUN (e.g., "user", "task", "auth", "order")
    b. DISCARD all verbs and filler words: implement, create, build, add, setup, configure, make, define, develop, write, design, establish, the, that, with, using, which, for, and, a, an, endpoint, service, module
-   c. Convert the remaining 1-3 word noun phrase to the appropriate case (snake_case for Python, PascalCase for Java)
+   c. Convert the remaining concise noun phrase to the appropriate case (snake_case for Python, PascalCase for Java)
    d. If the result is longer than 25 characters, shorten it
 
    **Examples:** "Create user registration endpoint" -> `app/routers/users.py` | "Build the authentication service with JWT" -> `app/services/auth.py` | "Define data models for orders" -> `app/models/order.py`
 
    **HARD RULES:**
-   - Names must be short and descriptive (1-3 words max)
+   - Names must be concise and descriptive -- use the fewest words that clearly convey the purpose, with no fixed word limit; never sacrifice clarity for brevity
    - NEVER use the task description as a file name -- extract the noun only
    - NEVER start a name with a verb (implement_, create_, build_, add_, setup_, etc.)
    - NEVER include filler words (_the_, _that_, _with_, _using_, _which_, _for_)

--- a/backend/agents/software_engineering_team/backend_agent/prompts.py
+++ b/backend/agents/software_engineering_team/backend_agent/prompts.py
@@ -96,12 +96,12 @@ PROJECT STRUCTURE & FILE ORGANIZATION
    a. Read the task description and identify the core NOUN (e.g., "user", "task", "auth", "order")
    b. DISCARD all verbs and filler words: implement, create, build, add, setup, configure, make, define, develop, write, design, establish, the, that, with, using, which, for, and, a, an, endpoint, service, module
    c. Convert the remaining concise noun phrase to the appropriate case (snake_case for Python, PascalCase for Java)
-   d. If the result is longer than 25 characters, shorten it
+   d. If the result is longer than ~30 characters, shorten it
 
    **Examples:** "Create user registration endpoint" -> `app/routers/users.py` | "Build the authentication service with JWT" -> `app/services/auth.py` | "Define data models for orders" -> `app/models/order.py`
 
    **HARD RULES:**
-   - File/module names must be a short, concise noun phrase (one or two nouns), never sentence-like: keep each path segment under ~30 characters and avoid 4+ hyphenated or 5+ underscored words, which path validation rejects. (This length guidance is for file/folder/module names only -- function, variable, and class names inside the code are NOT word-capped; keep them concise but as descriptive as the purpose requires, never sacrificing clarity for brevity.)
+   - File/module names must be a short, concise noun phrase, never sentence-like: keep each path segment under ~30 characters and avoid 4+ hyphenated or 5+ underscored words, which path validation rejects. (This length guidance is for file/folder/module names only -- function, variable, and class names inside the code are NOT word-capped; keep them concise but as descriptive as the purpose requires, never sacrificing clarity for brevity.)
    - NEVER use the task description as a file name -- extract the noun only
    - NEVER start a name with a verb (implement_, create_, build_, add_, setup_, etc.)
    - NEVER include filler words (_the_, _that_, _with_, _using_, _which_, _for_)

--- a/backend/agents/software_engineering_team/code_review_agent/prompts.py
+++ b/backend/agents/software_engineering_team/code_review_agent/prompts.py
@@ -35,7 +35,7 @@ Focus your energy on issues that would cause production incidents, data loss, or
    - Angular: kebab-case for components (e.g., `task-list/`, `user-profile/`)
    - Vue: PascalCase or kebab-case for components
    - Python: snake_case for modules/functions, PascalCase for classes
-   - Names must be short (1-3 words), descriptive, and NOT derived from task descriptions
+   - Names must be concise yet descriptive, and NOT derived from task descriptions. There is NO fixed word limit -- judge a name by whether it clearly and accurately conveys what the thing IS or DOES, not by counting words. Do NOT flag a name solely for exceeding some word count
    - CRITICAL: Reject any component/file name that looks like a task description or sentence
 
 3. **File Structure** - Does the code follow proper project structure?

--- a/backend/agents/software_engineering_team/shared/coding_standards.py
+++ b/backend/agents/software_engineering_team/shared/coding_standards.py
@@ -98,6 +98,7 @@ CODING_STANDARDS = """
    **General rules (ALL languages):**
    - Names describe WHAT the thing IS or DOES – never derived from a task description
    - Names must be concise yet fully descriptive: use the fewest words that make the purpose unmistakable, and no more. There is NO fixed word limit — readability comes first, so never drop a word a reader needs to understand the name (e.g. `user-list`, `auth_service`, `TaskController`, `list_changed_and_deleted`)
+   - Exception for files, folders, and modules: because these become filesystem path segments, keep each segment short — a concise noun phrase under ~30 characters that never reads like a sentence (avoid 4+ hyphen-separated or 5+ underscore-separated words; path validation rejects those). This length/word guidance applies ONLY to path segments — function, method, variable, and class names are NOT word-capped
    - BANNED words in file/folder/class names: `implement`, `create`, `build`, `setup`, `configure`, `add`, `make`, `define`, `develop`, `write`, `design`, `establish`, `the`, `that`, `with`, `using`, `which`, `for`, `and`, `a`, `an`
    - To derive a name: extract the core NOUN from the requirement, discard all verbs and filler words
    - Example: task "Implement the UserForm component using reactive forms" → name is `user-form`, NOT `implement-the-userform-component-using`
@@ -178,6 +179,7 @@ REVIEW_STANDARDS = """
 5. **Naming Conventions** -- Names must follow professional standards:
    - Names describe WHAT the thing IS or DOES -- never derived from task descriptions
    - Names must be concise yet fully descriptive: the fewest words that make the purpose unmistakable, and no more. There is NO fixed word limit -- do not flag a name solely for its word count; readability comes first
+   - File, folder, and module names are the exception: because they become filesystem path segments, they should stay short (a concise noun phrase under ~30 chars) and never read like a sentence. This applies only to path segments, not to function/variable/class names
    - Python: snake_case for modules/functions, PascalCase for classes
    - TypeScript: kebab-case for files/folders, PascalCase for components/classes, camelCase for variables
    - Java: PascalCase for classes, camelCase for methods/variables

--- a/backend/agents/software_engineering_team/shared/coding_standards.py
+++ b/backend/agents/software_engineering_team/shared/coding_standards.py
@@ -97,7 +97,7 @@ CODING_STANDARDS = """
 
    **General rules (ALL languages):**
    - Names describe WHAT the thing IS or DOES – never derived from a task description
-   - Names must be 1-3 words maximum (e.g. `user-list`, `auth_service`, `TaskController`)
+   - Names must be concise yet fully descriptive: use the fewest words that make the purpose unmistakable, and no more. There is NO fixed word limit — readability comes first, so never drop a word a reader needs to understand the name (e.g. `user-list`, `auth_service`, `TaskController`, `list_changed_and_deleted`)
    - BANNED words in file/folder/class names: `implement`, `create`, `build`, `setup`, `configure`, `add`, `make`, `define`, `develop`, `write`, `design`, `establish`, `the`, `that`, `with`, `using`, `which`, `for`, `and`, `a`, `an`
    - To derive a name: extract the core NOUN from the requirement, discard all verbs and filler words
    - Example: task "Implement the UserForm component using reactive forms" → name is `user-form`, NOT `implement-the-userform-component-using`
@@ -177,7 +177,7 @@ REVIEW_STANDARDS = """
 
 5. **Naming Conventions** -- Names must follow professional standards:
    - Names describe WHAT the thing IS or DOES -- never derived from task descriptions
-   - Names must be 1-3 words maximum
+   - Names must be concise yet fully descriptive: the fewest words that make the purpose unmistakable, and no more. There is NO fixed word limit -- do not flag a name solely for its word count; readability comes first
    - Python: snake_case for modules/functions, PascalCase for classes
    - TypeScript: kebab-case for files/folders, PascalCase for components/classes, camelCase for variables
    - Java: PascalCase for classes, camelCase for methods/variables


### PR DESCRIPTION
## Summary

The SE team's coding standards and the code review agent enforced a hard **"1-3 words maximum"** limit on all names (files, folders, classes, functions, variables). This caused the code review agent to flag accurate, readable names purely for their word count — e.g. rejecting `list_changed_and_deleted` for being "4 words".

A fixed word ceiling is the wrong constraint: it can force names that are vague or inaccurate, working against readability. This replaces the hard cap with guidance that keeps the genuinely valuable intent of the rule (don't derive names from task descriptions, no verb prefixes, no filler words) while requiring names to be **concise yet fully descriptive** — the fewest words that clearly and accurately convey purpose, with no fixed word limit and readability first.

## Changes

- `shared/coding_standards.py` — reworded `CODING_STANDARDS` (general naming rule) and `REVIEW_STANDARDS` to drop the "1-3 words maximum" cap; the v2 backend/frontend sub-teams import these, so they inherit the change.
- `code_review_agent/prompts.py` — naming-conventions check now judges names by clarity/accuracy, not word count, and explicitly tells the reviewer **not** to flag a name solely for exceeding a word count.
- `backend_agent/prompts.py` — file-name derivation algorithm and HARD RULES no longer impose a "1-3 word" cap.

## Notes

- The offending `list_changed_and_deleted` flag was produced by the **LLM** code review agent following the `REVIEW_STANDARDS` text — there is no deterministic word-count validator for function names. The deterministic path-segment validators (`backend_agent/agent.py`, `shared/repo_writer.py`) only reject file/folder names that look like sentences (4+ hyphenated / 5+ underscored words) and are left unchanged.
- The deprecated `frontend_team_deprecated/` still contains the old wording; it is dead code outside the active review pipeline and was intentionally left untouched.
- No tests assert on the old "1-3 words" text.

Closes #864

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsJVDZwG4XHcouNNdyLAWz)_