### PR TITLE
Remove max-drawdown constraint; stop LLM reviewer vetoing on sizing/risk math

### DIFF
--- a/backend/agents/investment_team/execution/risk_filter.py
+++ b/backend/agents/investment_team/execution/risk_filter.py
@@ -5,12 +5,18 @@ carrying as an unvalidated ``Dict[str, Any]``.  ``RiskFilter`` consumes it at
 simulation runtime to:
 
 - vol-target position sizing (replaces the hard-coded ``position_pct = 0.06``),
-- enforce per-symbol concentration, gross leverage, and max-open-position caps,
-- circuit-break the run when trailing drawdown breaches ``max_drawdown_pct``.
+- enforce per-symbol concentration, gross leverage, and max-open-position caps.
+
+There is intentionally **no** drawdown circuit-breaker. Strategy Lab runs are
+experiments (backtest / paper trading, no real capital), and a strategy must be
+free to lose up to 100% of the account so its true downside is observed rather
+than truncated by an arbitrary trailing-loss limit. Realised drawdown is still
+*measured* and reported as a performance metric — it is just never a constraint
+that halts a run.
 
 Both the look-ahead-safe engine (Phase 2) and the legacy engine invoke the
-filter through the same ``size()`` / ``can_enter()`` / ``check_drawdown()``
-methods, so risk limits are tested identically in backtest and live modes.
+filter through the same ``size()`` / ``can_enter()`` methods, so risk limits are
+tested identically in backtest and live modes.
 """
 
 from __future__ import annotations
@@ -53,7 +59,6 @@ class RiskLimits(BaseModel):
         ),
     )
     max_symbol_concentration_pct: float = Field(default=20.0, ge=0, le=100)
-    max_drawdown_pct: float = Field(default=25.0, ge=0, le=100)
     max_open_positions: int = Field(default=10, ge=1)
     target_annual_vol: Optional[float] = Field(
         default=None,
@@ -117,7 +122,6 @@ _RISK_LIMIT_TIGHTEN_DIRECTION: Dict[str, Optional[str]] = {
     "max_gross_leverage": "lower",
     "max_position_pct": "lower",
     "max_symbol_concentration_pct": "lower",
-    "max_drawdown_pct": "lower",
     "max_open_positions": "lower",
     "target_annual_vol": "lower",
     "vol_lookback_days": None,
@@ -134,13 +138,6 @@ class SizingDecision:
 class EntryDecision:
     allowed: bool
     reason: str
-
-
-@dataclass
-class DrawdownBreach:
-    breached: bool
-    current_drawdown_pct: float
-    limit_pct: float
 
 
 #: Relative epsilon absorbing float noise so an order clamped exactly to
@@ -218,8 +215,9 @@ class RiskFilter:
         cap at the sizing price (``OrderRequest.risk_presized``): re-checking
         those at the fill price would falsely reject an order the dispatcher
         sized correctly whenever the fill gaps above the sizing price (the cap is
-        a sizing-time bound; ``max_drawdown_pct`` is the realised-exposure
-        backstop). It is ``True`` for custom-code orders, which bypass the
+        a sizing-time bound, and post-fill notional drift on already-committed
+        shares is normal holding behaviour — there is no drawdown backstop, by
+        design). It is ``True`` for custom-code orders, which bypass the
         dispatcher, so this gate is their sole position-cap enforcement point.
         The leverage and concentration checks always run on ``notional``.
         """
@@ -290,28 +288,6 @@ class RiskFilter:
                 )
 
         return EntryDecision(allowed=True, reason="within limits")
-
-    # ------------------------------------------------------------------
-    # Drawdown circuit-breaker
-    # ------------------------------------------------------------------
-
-    def check_drawdown(
-        self,
-        current_equity: float,
-        peak_equity: float,
-    ) -> DrawdownBreach:
-        """Return whether trailing drawdown breaches the configured limit."""
-        if peak_equity <= 0:
-            return DrawdownBreach(
-                breached=False, current_drawdown_pct=0.0, limit_pct=self.limits.max_drawdown_pct
-            )
-
-        dd_pct = (peak_equity - current_equity) / peak_equity * 100.0
-        return DrawdownBreach(
-            breached=dd_pct >= self.limits.max_drawdown_pct,
-            current_drawdown_pct=round(dd_pct, 2),
-            limit_pct=self.limits.max_drawdown_pct,
-        )
 
     # ------------------------------------------------------------------
     # Helpers

--- a/backend/agents/investment_team/scripts/audit_recent_runs.py
+++ b/backend/agents/investment_team/scripts/audit_recent_runs.py
@@ -35,7 +35,6 @@ _RISK_LIMIT_TIGHTEN_DIR: Dict[str, Optional[str]] = {
     "max_gross_leverage": "lower",
     "max_position_pct": "lower",
     "max_symbol_concentration_pct": "lower",
-    "max_drawdown_pct": "lower",
     "max_open_positions": "lower",
     "target_annual_vol": "lower",
     "vol_lookback_days": None,

--- a/backend/agents/investment_team/strategy_lab/agents/design.py
+++ b/backend/agents/investment_team/strategy_lab/agents/design.py
@@ -40,7 +40,7 @@ from ._parse_helpers import (
     validate_structured_rules,
 )
 from ._response_schemas import CRITIQUE_SCHEMA, DESIGN_SPEC_SCHEMA
-from .design_review import _coerce_critique, format_prior_critiques
+from .design_review import _coerce_critique, _sizing_owned_by_gate, format_prior_critiques
 from .model_factory import get_strands_model
 
 if TYPE_CHECKING:
@@ -504,7 +504,18 @@ class DesignAgent:
         # self-revision round, so demote only on critical here. (The
         # external DesignReviewAgent keeps the stricter default, where any
         # non-info issue demotes.)
-        return _coerce_critique(parsed, readiness_findings=[], demote_min_severity="critical")
+        #
+        # The sizing carve-out only applies to gate-owned sizing kinds; a
+        # ``volatility_target`` plausibility objection (which the deterministic
+        # gate abstains on) must keep blocking, so resolve ``sizing_owned`` from
+        # the draft's sizing kind rather than assuming it.
+        sizing_kind = (strategy_dict.get("sizing") or {}).get("kind")
+        return _coerce_critique(
+            parsed,
+            readiness_findings=[],
+            demote_min_severity="critical",
+            sizing_owned=_sizing_owned_by_gate(sizing_kind),
+        )
 
 
 def _design_self_review_enabled() -> bool:

--- a/backend/agents/investment_team/strategy_lab/agents/design_review.py
+++ b/backend/agents/investment_team/strategy_lab/agents/design_review.py
@@ -83,20 +83,41 @@ _MAX_DRAWDOWN_LIMIT_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Sizing kinds whose realisability/coherence the deterministic gate FULLY owns
+# (Rule 5 realisability + Rule 9 deployed-vs-cap). ``volatility_target`` is
+# deliberately absent: ``SpecReadinessGate._check_sizing_realisable`` abstains on
+# it and only emits a *warning* (e.g. an implausible ``target_annual_vol``),
+# which the orchestrator treats as ready — so for vol-target the LLM reviewer's
+# sizing objection is the ONLY substantive check and must keep blocking.
+_GATE_OWNED_SIZING_KINDS: frozenset[str] = frozenset({"fixed_fraction", "fixed_notional"})
 
-def _is_demotable_issue(issue: "CritiqueIssue") -> bool:
+
+def _sizing_owned_by_gate(sizing_kind: object) -> bool:
+    """True when the deterministic gate fully validates this sizing kind.
+
+    Pre: ``sizing_kind`` is the spec's ``sizing.kind`` (str) or None.
+    Post: True iff ``sizing_kind`` is a gate-owned static kind; False for
+    ``volatility_target`` (gate abstains) and for unknown/missing kinds (fail
+    safe — keep a sizing objection blocking when we cannot confirm ownership).
+    """
+    return sizing_kind in _GATE_OWNED_SIZING_KINDS
+
+
+def _is_demotable_issue(issue: "CritiqueIssue", *, sizing_owned: bool) -> bool:
     """True when ``issue`` re-litigates a deterministic-gate-owned check or the
     removed max-drawdown constraint, so the reviewer may not block on it.
 
-    Pre: ``issue`` is a :class:`CritiqueIssue`.
-    Post: returns True iff the issue is a ``sizing`` objection OR references the
-    retired max-drawdown *limit* (per ``_MAX_DRAWDOWN_LIMIT_RE``). A substantive
-    objection that merely mentions the word "drawdown" (e.g. a missing
-    drawdown-protection *exit*) is NOT demoted; non-drawdown ``risk_limits``
-    objections are likewise left blocking.
+    Pre: ``issue`` is a :class:`CritiqueIssue`; ``sizing_owned`` says whether the
+    spec's sizing kind is one the deterministic gate fully validates.
+    Post: returns True iff (the issue is a ``sizing`` objection AND
+    ``sizing_owned``) OR it references the retired max-drawdown *limit* (per
+    ``_MAX_DRAWDOWN_LIMIT_RE``). A ``sizing`` objection on a non-owned kind
+    (``volatility_target``), a substantive objection that merely mentions the
+    word "drawdown" (e.g. a missing drawdown-protection *exit*), and non-drawdown
+    ``risk_limits`` objections are all left blocking.
     """
     if issue.field == "sizing":
-        return True
+        return sizing_owned
     return bool(_MAX_DRAWDOWN_LIMIT_RE.search(issue.description))
 
 
@@ -472,7 +493,11 @@ class DesignReviewAgent:
             logger.warning("DesignReviewAgent failed to produce parseable JSON: %s", exc)
             return _fail_closed_critique(exc, readiness_findings)
 
-        critique = _coerce_critique(parsed, readiness_findings)
+        critique = _coerce_critique(
+            parsed,
+            readiness_findings,
+            sizing_owned=_sizing_owned_by_gate(getattr(spec.sizing, "kind", None)),
+        )
         return critique
 
 
@@ -539,6 +564,7 @@ def _coerce_critique(
     readiness_findings: List[str],
     *,
     demote_min_severity: Literal["warning", "critical"] = "warning",
+    sizing_owned: bool = True,
 ) -> SpecCritique:
     """Convert a parsed LLM JSON dict into a :class:`SpecCritique`.
 
@@ -568,20 +594,23 @@ def _coerce_critique(
     a self-revision round.
 
     Deterministic-gate carve-out: issues for which :func:`_is_demotable_issue`
-    is true (``sizing`` objections, and any drawdown objection — max drawdown is
-    not a constraint) are demoted to ``info`` before the blocking computation,
-    because the deterministic readiness gate owns sizing and has already passed.
-    Non-drawdown ``risk_limits`` objections (e.g. ``max_gross_leverage=0``) are
-    NOT demoted — the gate does not check them, so they keep blocking. A
-    not-ready verdict whose ONLY blocking objections were demotable ones is
-    promoted to ``ready=True`` (with an audit-trail ``info`` note) rather than
-    left to churn the loop on a veto the reviewer may not cast.
+    is true are demoted to ``info`` before the blocking computation — i.e.
+    ``sizing`` objections *when* ``sizing_owned`` (the spec's sizing kind is one
+    the gate fully validates), and any objection referencing the retired
+    max-drawdown *limit* (max drawdown is not a constraint). ``sizing_owned`` is
+    ``False`` for ``volatility_target`` (the gate abstains and only warns, so the
+    reviewer's plausibility objection is the only substantive check) — such a
+    sizing objection keeps blocking. Non-drawdown ``risk_limits`` objections
+    (e.g. ``max_gross_leverage=0``) are likewise never demoted. A not-ready
+    verdict whose ONLY blocking objections were demotable ones is promoted to
+    ``ready=True`` (with an audit-trail ``info`` note) rather than left to churn
+    the loop on a veto the reviewer may not cast.
 
     Preconditions: ``parsed`` is a dict from a parsed LLM JSON payload;
     ``demote_min_severity`` is one of ``"warning"`` / ``"critical"``.
-    Postconditions: returns a :class:`SpecCritique`. ``sizing`` / ``risk_limits``
-    issues never carry a blocking severity (always demoted to ``info``).
-    ``ready`` is ``False`` whenever a blocking issue on any *other* field is
+    Postconditions: returns a :class:`SpecCritique`. Demotable issues (see
+    :func:`_is_demotable_issue`) never carry a blocking severity (demoted to
+    ``info``). ``ready`` is ``False`` whenever a non-demotable blocking issue is
     present; when ``ready`` is ``False`` the ``open_issue_ids`` set is non-empty
     (a blocking issue is synthesised if the reviewer named none, or only ``info``
     notes, with no demoted blocking objection to promote on).
@@ -614,17 +643,22 @@ def _coerce_critique(
             # Best-effort: one bad item shouldn't bin the rest.
             continue
 
-    # Demote sizing / drawdown objections to ``info``: the deterministic gate
-    # owns sizing and max drawdown is not a constraint, so the reviewer must not
-    # veto on them (see ``_is_demotable_issue``). Non-drawdown ``risk_limits``
-    # critiques are left untouched so genuine mechanically-unusable settings
-    # (e.g. ``max_gross_leverage=0``) still block. ``demoted_blocking`` records
+    # Demote gate-owned sizing objections and max-drawdown-limit objections to
+    # ``info``: the deterministic gate owns sizing for gate-owned kinds and max
+    # drawdown is not a constraint, so the reviewer must not veto on them (see
+    # ``_is_demotable_issue``). A ``volatility_target`` sizing objection (gate
+    # abstains) and non-drawdown ``risk_limits`` critiques (e.g.
+    # ``max_gross_leverage=0``) are left untouched so genuine mechanically-
+    # unusable settings still block. ``demoted_blocking`` records
     # how many *blocking* (warning/critical) issues were demoted this way, so a
     # not-ready verdict whose ONLY blocking objections were these can advance
     # rather than churn the loop on a veto the reviewer is not allowed to cast.
     demoted_blocking = 0
     for issue in issues:
-        if _is_demotable_issue(issue) and issue.severity in ("warning", "critical"):
+        if _is_demotable_issue(issue, sizing_owned=sizing_owned) and issue.severity in (
+            "warning",
+            "critical",
+        ):
             issue.severity = "info"
             demoted_blocking += 1
 

--- a/backend/agents/investment_team/strategy_lab/agents/design_review.py
+++ b/backend/agents/investment_team/strategy_lab/agents/design_review.py
@@ -62,8 +62,8 @@ _CRITIQUE_FIELDS: tuple[str, ...] = (
 #   * a ``sizing`` objection re-litigates a cleared check (Rule 5 realisability
 #     + Rule 9 deployed-vs-cap coherence) — including the recurring
 #     deployed-size-vs-stop "0.25% per trade" misread; and
-#   * any drawdown objection is moot — max drawdown is not a constraint (a
-#     strategy may lose up to 100% by design).
+#   * an objection about the retired max-drawdown *limit* is moot — max drawdown
+#     is not a constraint (a strategy may lose up to 100% by design).
 # Both are demoted to ``info`` in :func:`_coerce_critique`.
 #
 # This is deliberately NOT a blanket ``risk_limits`` carve-out: the gate does
@@ -71,18 +71,33 @@ _CRITIQUE_FIELDS: tuple[str, ...] = (
 # the gate yet makes ``RiskFilter.can_enter`` reject every order — a guaranteed
 # zero-trade strategy), so a genuine non-drawdown ``risk_limits`` critique
 # (leverage, open positions, concentration) MUST keep blocking readiness.
+
+# Matches a reference to the *retired max-drawdown limit/constraint* — NOT a
+# generic mention of "drawdown". A real exit-completeness defect such as
+# "no stop-loss or drawdown-protection exit" must keep blocking, so only the
+# limit phrasing ("max drawdown", "maximum drawdown", "max_drawdown_pct",
+# "drawdown limit/cap/ceiling/threshold/constraint") is treated as demotable.
+_MAX_DRAWDOWN_LIMIT_RE = re.compile(
+    r"max(?:imum)?[\s_-]*drawdown(?:_pct)?"
+    r"|drawdown[\s_-]+(?:limit|cap|constraint|ceiling|threshold)",
+    re.IGNORECASE,
+)
+
+
 def _is_demotable_issue(issue: "CritiqueIssue") -> bool:
     """True when ``issue`` re-litigates a deterministic-gate-owned check or the
     removed max-drawdown constraint, so the reviewer may not block on it.
 
     Pre: ``issue`` is a :class:`CritiqueIssue`.
-    Post: returns True iff the issue is a ``sizing`` objection OR mentions
-    drawdown (case-insensitive). Non-drawdown ``risk_limits`` objections return
-    False so they keep their blocking severity.
+    Post: returns True iff the issue is a ``sizing`` objection OR references the
+    retired max-drawdown *limit* (per ``_MAX_DRAWDOWN_LIMIT_RE``). A substantive
+    objection that merely mentions the word "drawdown" (e.g. a missing
+    drawdown-protection *exit*) is NOT demoted; non-drawdown ``risk_limits``
+    objections are likewise left blocking.
     """
     if issue.field == "sizing":
         return True
-    return "drawdown" in issue.description.lower()
+    return bool(_MAX_DRAWDOWN_LIMIT_RE.search(issue.description))
 
 
 def _normalize_issue_text(text: str) -> str:

--- a/backend/agents/investment_team/strategy_lab/agents/design_review.py
+++ b/backend/agents/investment_team/strategy_lab/agents/design_review.py
@@ -54,17 +54,35 @@ _CRITIQUE_FIELDS: tuple[str, ...] = (
     "signal_definition",
 )
 
-# Fields the deterministic ``SpecReadinessGate`` is the SOLE authority on:
-# sizing realisability and risk-limit coherence. The orchestrator only invokes
-# the LLM reviewer once that gate has already passed (no critical findings), so
-# any ``sizing`` / ``risk_limits`` objection the reviewer raises is
-# re-litigating a check the gate already cleared — including the recurring
-# deployed-size-vs-stop "0.25% per trade" misreading and max-drawdown
-# reachability (max drawdown is not a constraint; a strategy may lose up to 100%
-# by design). Issues on these fields are demoted to ``info`` in
-# :func:`_coerce_critique` so they are recorded for the audit trail but can never
-# block readiness.
-_DETERMINISTIC_OWNED_FIELDS: frozenset[str] = frozenset({"sizing", "risk_limits"})
+
+# The LLM reviewer must not block on objections the deterministic
+# ``SpecReadinessGate`` already owns, nor on the (removed) max-drawdown
+# constraint. The orchestrator only invokes the reviewer once that gate has
+# passed, so:
+#   * a ``sizing`` objection re-litigates a cleared check (Rule 5 realisability
+#     + Rule 9 deployed-vs-cap coherence) — including the recurring
+#     deployed-size-vs-stop "0.25% per trade" misread; and
+#   * any drawdown objection is moot — max drawdown is not a constraint (a
+#     strategy may lose up to 100% by design).
+# Both are demoted to ``info`` in :func:`_coerce_critique`.
+#
+# This is deliberately NOT a blanket ``risk_limits`` carve-out: the gate does
+# NOT check every risk-limit failure mode (e.g. ``max_gross_leverage=0`` passes
+# the gate yet makes ``RiskFilter.can_enter`` reject every order — a guaranteed
+# zero-trade strategy), so a genuine non-drawdown ``risk_limits`` critique
+# (leverage, open positions, concentration) MUST keep blocking readiness.
+def _is_demotable_issue(issue: "CritiqueIssue") -> bool:
+    """True when ``issue`` re-litigates a deterministic-gate-owned check or the
+    removed max-drawdown constraint, so the reviewer may not block on it.
+
+    Pre: ``issue`` is a :class:`CritiqueIssue`.
+    Post: returns True iff the issue is a ``sizing`` objection OR mentions
+    drawdown (case-insensitive). Non-drawdown ``risk_limits`` objections return
+    False so they keep their blocking severity.
+    """
+    if issue.field == "sizing":
+        return True
+    return "drawdown" in issue.description.lower()
 
 
 def _normalize_issue_text(text: str) -> str:
@@ -534,13 +552,15 @@ def _coerce_critique(
     on an otherwise-ready verdict are accepted verbatim instead of burning
     a self-revision round.
 
-    Deterministic-gate carve-out: issues whose ``field`` is in
-    ``_DETERMINISTIC_OWNED_FIELDS`` (``sizing`` / ``risk_limits``) are demoted
-    to ``info`` before the blocking computation, because the deterministic
-    readiness gate is the sole authority on that math and has already passed.
-    A not-ready verdict whose ONLY blocking objections were those demoted
-    fields is promoted to ``ready=True`` (with an audit-trail ``info`` note)
-    rather than left to churn the loop on a veto the reviewer may not cast.
+    Deterministic-gate carve-out: issues for which :func:`_is_demotable_issue`
+    is true (``sizing`` objections, and any drawdown objection — max drawdown is
+    not a constraint) are demoted to ``info`` before the blocking computation,
+    because the deterministic readiness gate owns sizing and has already passed.
+    Non-drawdown ``risk_limits`` objections (e.g. ``max_gross_leverage=0``) are
+    NOT demoted — the gate does not check them, so they keep blocking. A
+    not-ready verdict whose ONLY blocking objections were demotable ones is
+    promoted to ``ready=True`` (with an audit-trail ``info`` note) rather than
+    left to churn the loop on a veto the reviewer may not cast.
 
     Preconditions: ``parsed`` is a dict from a parsed LLM JSON payload;
     ``demote_min_severity`` is one of ``"warning"`` / ``"critical"``.
@@ -579,15 +599,17 @@ def _coerce_critique(
             # Best-effort: one bad item shouldn't bin the rest.
             continue
 
-    # Demote sizing / risk_limits objections to ``info``: the deterministic gate
-    # owns those checks and has already passed, so the reviewer must not veto on
-    # them (see ``_DETERMINISTIC_OWNED_FIELDS``). ``demoted_blocking`` records how
-    # many *blocking* (warning/critical) issues were demoted this way, so a
+    # Demote sizing / drawdown objections to ``info``: the deterministic gate
+    # owns sizing and max drawdown is not a constraint, so the reviewer must not
+    # veto on them (see ``_is_demotable_issue``). Non-drawdown ``risk_limits``
+    # critiques are left untouched so genuine mechanically-unusable settings
+    # (e.g. ``max_gross_leverage=0``) still block. ``demoted_blocking`` records
+    # how many *blocking* (warning/critical) issues were demoted this way, so a
     # not-ready verdict whose ONLY blocking objections were these can advance
     # rather than churn the loop on a veto the reviewer is not allowed to cast.
     demoted_blocking = 0
     for issue in issues:
-        if issue.field in _DETERMINISTIC_OWNED_FIELDS and issue.severity in ("warning", "critical"):
+        if _is_demotable_issue(issue) and issue.severity in ("warning", "critical"):
             issue.severity = "info"
             demoted_blocking += 1
 
@@ -630,20 +652,21 @@ def _coerce_critique(
     has_blocking = any(_SEVERITY_ORDER[i.severity] >= _SEVERITY_ORDER["warning"] for i in issues)
     if not ready and not has_blocking:
         if demoted_blocking:
-            # The reviewer's only blocking objections were on sizing /
-            # risk_limits — axes the deterministic gate owns and the reviewer is
-            # not permitted to block on. With nothing blockable left to act on,
-            # advance the spec rather than churn the design loop to the round cap
-            # on a veto we have already neutralised. Record the override as an
-            # info note so the lineage shows why a not-ready verdict was promoted.
+            # The reviewer's only blocking objections were sizing or drawdown
+            # concerns — the deterministic gate owns sizing and max drawdown is
+            # not a constraint, so the reviewer may not block on them. With
+            # nothing blockable left to act on, advance the spec rather than
+            # churn the design loop to the round cap on a veto we have already
+            # neutralised. Record the override as an info note so the lineage
+            # shows why a not-ready verdict was promoted.
             ready = True
             issues.append(
                 CritiqueIssue(
                     field="sizing",
                     severity="info",
                     description=(
-                        "Reviewer's only blocking objection(s) were on "
-                        "sizing/risk_limits, which the deterministic readiness "
+                        "Reviewer's only blocking objection(s) were sizing or "
+                        "drawdown concerns, which the deterministic readiness "
                         "gate owns; demoted to advisory and verdict promoted to "
                         "ready (max drawdown is not a constraint; deployed size, "
                         "not fraction×stop, is the per-trade risk)."

--- a/backend/agents/investment_team/strategy_lab/agents/design_review.py
+++ b/backend/agents/investment_team/strategy_lab/agents/design_review.py
@@ -54,6 +54,18 @@ _CRITIQUE_FIELDS: tuple[str, ...] = (
     "signal_definition",
 )
 
+# Fields the deterministic ``SpecReadinessGate`` is the SOLE authority on:
+# sizing realisability and risk-limit coherence. The orchestrator only invokes
+# the LLM reviewer once that gate has already passed (no critical findings), so
+# any ``sizing`` / ``risk_limits`` objection the reviewer raises is
+# re-litigating a check the gate already cleared — including the recurring
+# deployed-size-vs-stop "0.25% per trade" misreading and max-drawdown
+# reachability (max drawdown is not a constraint; a strategy may lose up to 100%
+# by design). Issues on these fields are demoted to ``info`` in
+# :func:`_coerce_critique` so they are recorded for the audit trail but can never
+# block readiness.
+_DETERMINISTIC_OWNED_FIELDS: frozenset[str] = frozenset({"sizing", "risk_limits"})
+
 
 def _normalize_issue_text(text: str) -> str:
     """Normalise critique prose so trivial rewordings map to one identity.
@@ -320,9 +332,13 @@ Speculative: {speculative}
 
 You are the only LLM in this loop. The deterministic gate already
 catches mechanical errors — do not duplicate them. Focus on substantive
-defects: thesis coherence, signal alignment, risk-control completeness,
-universe ↔ thesis fit, sizing realism, and hand-wavy or measurable-edge-
-absent specifications.
+defects: thesis coherence, signal alignment, exit/risk-control
+completeness, universe ↔ thesis fit, and hand-wavy or measurable-edge-
+absent specifications. Sizing and `risk_limits` arithmetic are owned by
+the deterministic gate — do NOT block on them (any sizing / risk_limits
+issue you raise is advisory only), and there is NO max-drawdown
+constraint: a strategy may lose up to 100% by design, so never flag
+drawdown reachability.
 
 Return ONLY a JSON object — no markdown — with this shape:
 
@@ -518,13 +534,22 @@ def _coerce_critique(
     on an otherwise-ready verdict are accepted verbatim instead of burning
     a self-revision round.
 
+    Deterministic-gate carve-out: issues whose ``field`` is in
+    ``_DETERMINISTIC_OWNED_FIELDS`` (``sizing`` / ``risk_limits``) are demoted
+    to ``info`` before the blocking computation, because the deterministic
+    readiness gate is the sole authority on that math and has already passed.
+    A not-ready verdict whose ONLY blocking objections were those demoted
+    fields is promoted to ``ready=True`` (with an audit-trail ``info`` note)
+    rather than left to churn the loop on a veto the reviewer may not cast.
+
     Preconditions: ``parsed`` is a dict from a parsed LLM JSON payload;
     ``demote_min_severity`` is one of ``"warning"`` / ``"critical"``.
-    Postconditions: returns a :class:`SpecCritique` whose ``ready`` is
-    ``False`` whenever a blocking issue (per the threshold) is present, and
-    whose ``open_issue_ids`` is non-empty whenever ``ready`` is ``False`` (a
-    not-ready verdict always carries at least one blocking issue, synthesised
-    if the reviewer named none or only ``info`` notes).
+    Postconditions: returns a :class:`SpecCritique`. ``sizing`` / ``risk_limits``
+    issues never carry a blocking severity (always demoted to ``info``).
+    ``ready`` is ``False`` whenever a blocking issue on any *other* field is
+    present; when ``ready`` is ``False`` the ``open_issue_ids`` set is non-empty
+    (a blocking issue is synthesised if the reviewer named none, or only ``info``
+    notes, with no demoted blocking objection to promote on).
     """
     ready = _coerce_strict_bool(parsed.get("ready"))
     rationale = str(parsed.get("rationale", "")).strip()
@@ -553,6 +578,18 @@ def _coerce_critique(
         except Exception:
             # Best-effort: one bad item shouldn't bin the rest.
             continue
+
+    # Demote sizing / risk_limits objections to ``info``: the deterministic gate
+    # owns those checks and has already passed, so the reviewer must not veto on
+    # them (see ``_DETERMINISTIC_OWNED_FIELDS``). ``demoted_blocking`` records how
+    # many *blocking* (warning/critical) issues were demoted this way, so a
+    # not-ready verdict whose ONLY blocking objections were these can advance
+    # rather than churn the loop on a veto the reviewer is not allowed to cast.
+    demoted_blocking = 0
+    for issue in issues:
+        if issue.field in _DETERMINISTIC_OWNED_FIELDS and issue.severity in ("warning", "critical"):
+            issue.severity = "info"
+            demoted_blocking += 1
 
     # Contract: ready=True alongside an issue at or above the demotion
     # threshold is incoherent. Demote the verdict and append a synthetic
@@ -592,14 +629,39 @@ def _coerce_critique(
     # open issue. ``info`` issues remain advisory and never block on their own.
     has_blocking = any(_SEVERITY_ORDER[i.severity] >= _SEVERITY_ORDER["warning"] for i in issues)
     if not ready and not has_blocking:
-        issues.append(
-            CritiqueIssue(
-                field="hypothesis",
-                severity="warning",
-                description=(rationale or "Reviewer reported not-ready without naming an issue."),
-                suggested_fix="Tighten the hypothesis or rule definitions.",
+        if demoted_blocking:
+            # The reviewer's only blocking objections were on sizing /
+            # risk_limits — axes the deterministic gate owns and the reviewer is
+            # not permitted to block on. With nothing blockable left to act on,
+            # advance the spec rather than churn the design loop to the round cap
+            # on a veto we have already neutralised. Record the override as an
+            # info note so the lineage shows why a not-ready verdict was promoted.
+            ready = True
+            issues.append(
+                CritiqueIssue(
+                    field="sizing",
+                    severity="info",
+                    description=(
+                        "Reviewer's only blocking objection(s) were on "
+                        "sizing/risk_limits, which the deterministic readiness "
+                        "gate owns; demoted to advisory and verdict promoted to "
+                        "ready (max drawdown is not a constraint; deployed size, "
+                        "not fraction×stop, is the per-trade risk)."
+                    ),
+                    suggested_fix="",
+                )
             )
-        )
+        else:
+            issues.append(
+                CritiqueIssue(
+                    field="hypothesis",
+                    severity="warning",
+                    description=(
+                        rationale or "Reviewer reported not-ready without naming an issue."
+                    ),
+                    suggested_fix="Tighten the hypothesis or rule definitions.",
+                )
+            )
 
     return SpecCritique(
         ready=ready,

--- a/backend/agents/investment_team/strategy_lab/prompts/design_review_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/design_review_system.md
@@ -22,14 +22,29 @@ Return `ready = true` only when **both** of the following hold:
 - **Hypothesis ↔ rules completeness** — every filter, condition, or indicator named in `hypothesis` / `signal_definition` MUST appear as a structured predicate. If the hypothesis says "only enter when ADX > 25 confirms trend," there MUST be an ADX-based predicate. Missing filters are NOT acceptable — the backtest will not test the actual claimed edge, and the strategy result becomes a lie. Flag as critical and demand the designer either add the predicate or rewrite the prose.
 - **Risk control completeness** — is there at least one meaningful exit besides a far-tailed stop? Does the strategy have any positive-edge exit, or only a stop and a "hope"?
 - **Universe ↔ thesis fit** — if the hypothesis names QQQ, does `target_symbols` include it? If the hypothesis is asset-class-wide ("US large-caps"), is `target_symbols` empty as intended?
-- **Mathematical coherence of sizing + risk + stops** — verify the algebra:
-  - `sizing` position size ≤ `risk_limits.max_position_pct` (e.g. `fraction=0.10` with `max_position_pct=5` is a contradiction).
-  - The deployed position size IS the per-trade loss cap (a trade can lose up to ~100% of what it deploys), so `sizing.fraction × 100 ≤ max_position_pct` is the per-trade risk check. `stop_loss.pct` is a separate, optional safeguard that limits a position's loss below a full wipeout — do NOT multiply it into the per-trade risk or treat it as part of sizing.
-  - `take_profit.pct` vs `stop_loss.pct` — payoff ratio implies a required win rate (`p ≥ stop / (stop + tp)`). Reject if the hypothesis cannot defend that win rate.
-  - `volatility_target` sizing implies stops sized to that vol budget — a 5% annual vol target with a 20% stop is incoherent.
-  - `max_drawdown_pct` must be reachable but not trivial (single losing streak shouldn't blow through it; nor should it be unreachable by design).
-  When the spec's numbers don't make sense together, flag as critical and quote the specific contradiction (e.g. "fraction=0.10 vs max_position_pct=5: sizing exceeds limit").
-- **Sizing realism** — does the sizing rule combine with `risk_limits` to produce something a real account could execute?
+- **Sizing and risk-limit math are NOT yours to judge.** The deterministic
+  readiness gate is the *sole* authority on sizing realisability and risk-limit
+  coherence (deployed-fraction ≤ `max_position_pct`, sizing realisable against
+  the universe, etc.). It has already run and passed before you see this spec.
+  Do **NOT** re-derive, re-check, or block on any sizing / `risk_limits`
+  arithmetic — any `sizing` or `risk_limits` issue you raise is treated as
+  advisory only and will **never** block readiness. Two interpretation rules so
+  you are not misled into raising spurious sizing critiques:
+  - **How to read the sizing line.** A line like `"risk 5% per trade"` (the
+    system's rendering of `fixed_fraction`) means the capital **DEPLOYED** into
+    the position — a fraction of the account — NOT a stop-multiplied loss budget.
+    The deployed size IS the per-trade loss cap, because a position can lose up
+    to ~100% of what it deploys. `stop_loss.pct` is a separate, optional price
+    move off entry that limits a position's loss *below* a full wipeout. Do
+    **NOT** multiply the stop into the deployment (`fraction × stop` is wrong)
+    and do **NOT** treat the stop as part of sizing. "Risk 5% per trade" with a
+    5% stop is **not** "0.25% per trade" — it is a 5% deployment with an
+    optional within-position safeguard.
+  - **There is NO max-drawdown constraint.** Max drawdown is not a limit in this
+    system. A strategy is an experiment (backtest / paper trading, no real
+    capital) and may lose up to 100% of the account by design. Do **NOT** flag
+    `max_drawdown_pct` reachability, "unreachable drawdown limit," or any
+    drawdown-based risk-control concern — it is not a defect and never blocks.
 - **Loose / hand-wavy hypothesis or signal_definition** — a one-line hypothesis with no measurable signal claim is not ready.
 
 You do **not** propose code. You do **not** rewrite the spec. You produce a critique a designer can act on.

--- a/backend/agents/investment_team/strategy_lab/prompts/design_self_review_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/design_self_review_system.md
@@ -14,15 +14,23 @@ Every filter, condition, or indicator NAMED in `hypothesis` or `signal_definitio
 
 If the prose makes a claim the rules cannot test, the backtest result is a lie — flag it `critical` with `field="entry_rules"` (or `exit_rules` as appropriate) and a `suggested_fix` that names the missing predicate.
 
-### 2. Risk-math coherence
+### 2. Sizing-vs-cap contradiction
 
-Verify the arithmetic between `sizing`, `risk_limits`, stop / take-profit rules, and any per-trade risk claim the prose makes:
+The deterministic gate is the authority on sizing and `risk_limits` math, and
+the external reviewer does NOT block on it. The ONE thing worth pre-catching
+here — because it is the single sizing defect the deterministic gate raises as
+critical — is a sizing rule that deploys more than the position cap:
 
-- **`sizing.fraction` vs `risk_limits.max_position_pct`** — `fraction=0.10` with `max_position_pct=5` is a direct contradiction. Flag critical with `field="sizing"`.
-- **The deployed position size IS the per-trade loss cap.** A trade can lose up to ~100% of what it deploys, so the per-trade risk is `sizing.fraction` (bounded by `max_position_pct`), NOT `fraction × stop`. If the prose claims "5% equity risk per trade" and `sizing.fraction=0.05`, that's coherent. If the prose claims "5% risk" but the spec deploys 50% (`fraction=0.50`), flag critical with `field="sizing"` and quote both numbers. `stop_loss.pct` is a separate, optional safeguard and is never multiplied into the per-trade risk.
-- **Take-profit ÷ stop-loss implies required win rate.** A `take_profit.pct < stop_loss.pct` strategy needs a >50% win rate to break even. If the hypothesis doesn't defend that, flag critical with `field="sizing"`.
-- **`volatility_target` + `stop_loss.pct`** — a 5% annual vol target with a 20% stop is incoherent. Flag critical with `field="sizing"`.
-- **`max_drawdown_pct` reachability** — should be reachable by a plausible losing streak but not trivial. A 50-trade strategy at 2% per-trade risk with `max_drawdown_pct=5` is incoherent (one 3-loss streak crosses it). Flag critical with `field="risk_limits"`.
+- **`sizing.fraction` vs `risk_limits.max_position_pct`** — `fraction=0.10` (10% deployed) with `max_position_pct=5` is a direct contradiction (sizing exceeds the cap). Flag critical with `field="sizing"`. This is the only sizing/risk check to make here.
+
+Read sizing correctly so you do not flag a coherent spec: `"risk X% per trade"`
+means capital **DEPLOYED** (a fraction of the account, which IS the per-trade
+loss cap), NOT a stop-multiplied loss budget. Never compute per-trade risk as
+`fraction × stop`, and never treat `stop_loss.pct` as part of sizing.
+
+Do **NOT** check max-drawdown reachability, take-profit/stop win-rate, or
+vol-target/stop coherence — none of those block the external reviewer, and max
+drawdown is not a constraint at all (a strategy may lose up to 100% by design).
 
 ## What NOT to check
 

--- a/backend/agents/investment_team/strategy_lab/prompts/design_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/design_system.md
@@ -169,7 +169,7 @@ Pick whichever option best matches your real signal — DO NOT silently encode a
 
 - **Volatility-target sizing implies a notional consistent with `target_annual_vol`.** Pairing `target_annual_vol = 0.05` (5%) with a stop_loss of 20% means the strategy holds positions through losses ~4× its annual vol budget — incoherent. Match the stop to the vol scale.
 
-- **`max_drawdown_pct` should be reachable but not trivial.** A 50-trade strategy with 2% per-trade risk should not declare `max_drawdown_pct = 5` (one losing streak of 3 trades crosses it). Conversely, `max_drawdown_pct = 80` is not a meaningful limit. Aim for 2-3× the standard deviation of cumulative losses under your sizing.
+- **There is NO max-drawdown constraint — do not author one or design around one.** Max drawdown is not a limit in this system. A strategy is an experiment (backtest / paper trading, no real capital) and may lose up to 100% of the account by design; realised drawdown is reported as a metric, never enforced. Do not add a `max_drawdown_pct` to `risk_limits`, do not size positions to "stay under" a drawdown number, and do not let a drawdown figure shape the thesis. The reviewer will not block on drawdown.
 
 When in doubt, add an explicit `note` on the sizing rule that states the deployed fraction and the cap ("deploy 4% per trade, within max_position_pct=5%"). Keep any `stop_loss` rationale separate — it bounds a position's loss below a full wipeout and is not part of the sizing math.
 

--- a/backend/agents/investment_team/strategy_lab/prompts/zero_trade_repair_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/zero_trade_repair_system.md
@@ -115,19 +115,25 @@ quality-gate warning will be raised. Fix the **code** instead.
 
 The only spec key you may adjust is `risk_limits`, and only when the
 **diagnostics** show the current limits are actually responsible for
-the zero-trade outcome (e.g. `orders_rejected` with a
-`risk_gate:max_drawdown` reason against an overly tight
-`max_drawdown_pct`). When you do propose a `risk_limits` update, return
-the FULL replacement object — for example:
+the zero-trade outcome (e.g. `orders_rejected` with a risk-gate reason
+such as a position-cap or concentration breach against an overly tight
+`max_position_pct` / `max_symbol_concentration_pct`, or every order
+rejected by a `max_gross_leverage` / `max_open_positions` cap of 0/1).
+When you do propose a `risk_limits` update, return the FULL replacement
+object — for example:
 
 ```json
 {
   "risk_limits": {
     "max_position_pct": 5,
-    "max_drawdown_pct": 10
+    "max_symbol_concentration_pct": 20
   }
 }
 ```
+
+There is no `max_drawdown_pct` field — max drawdown is not a constraint
+(a strategy may lose up to 100% by design), so never emit it; it would be
+discarded as an unknown key.
 
 The orchestrator will only honour `risk_limits`; any other key in
 `proposed_spec_updates` is silently dropped and logged.

--- a/backend/agents/investment_team/strategy_lab/quality_gates/strategy_validator.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/strategy_validator.py
@@ -92,12 +92,9 @@ class StrategySpecValidator(GateResultsMixin):
                     self._critical(f"max_position_pct={max_pos}% is outside safe range [1%, 25%].")
                 )
 
-            if risk.max_drawdown_pct < 5 or risk.max_drawdown_pct > 50:
-                results.append(
-                    self._warning(
-                        f"max_drawdown_pct={risk.max_drawdown_pct}% is outside typical range [5%, 50%]."
-                    )
-                )
+            # No drawdown check: max drawdown is not a constraint. A Strategy Lab
+            # run is an experiment and may lose up to 100% of the account;
+            # realised drawdown is reported as a metric, never enforced as a cap.
 
             # Spec rule fields are structured DSL nodes — render through the
             # spec_dsl formatters to recover a human-readable text view for the

--- a/backend/agents/investment_team/tests/test_audit_recent_runs.py
+++ b/backend/agents/investment_team/tests/test_audit_recent_runs.py
@@ -265,7 +265,10 @@ class TestCheckSpecStability:
             spec_history=[
                 {
                     "phase": "synthesis",
-                    "diff": '- "max_drawdown_pct": 0.20\n+ "max_drawdown_pct": 0.15',
+                    "diff": (
+                        '- "max_symbol_concentration_pct": 0.20\n'
+                        '+ "max_symbol_concentration_pct": 0.15'
+                    ),
                     "reason": "tighten risk",
                 },
             ]
@@ -279,7 +282,10 @@ class TestCheckSpecStability:
             spec_history=[
                 {
                     "phase": "synthesis",
-                    "diff": '- "max_drawdown_pct": 0.15\n+ "max_drawdown_pct": 0.25',
+                    "diff": (
+                        '- "max_symbol_concentration_pct": 0.15\n'
+                        '+ "max_symbol_concentration_pct": 0.25'
+                    ),
                     "reason": "relax risk",
                 },
             ]
@@ -287,7 +293,7 @@ class TestCheckSpecStability:
         result = check_spec_stability(rec)
         assert result.status == "FAIL"
         assert "loosened" in result.details
-        assert "max_drawdown_pct" in result.details
+        assert "max_symbol_concentration_pct" in result.details
 
     def test_fail_immutable_risk_limit(self) -> None:
         from investment_team.scripts.audit_recent_runs import check_spec_stability

--- a/backend/agents/investment_team/tests/test_risk_filter.py
+++ b/backend/agents/investment_team/tests/test_risk_filter.py
@@ -1,4 +1,9 @@
-"""Tests for the Phase 3 RiskFilter: sizing, entry gates, drawdown breaker."""
+"""Tests for the Phase 3 RiskFilter: sizing and entry gates.
+
+There is intentionally no drawdown circuit-breaker — a Strategy Lab run may lose
+up to 100% of the account by design, so drawdown is reported as a metric, never
+enforced as a constraint.
+"""
 
 from __future__ import annotations
 
@@ -16,7 +21,6 @@ def test_risk_limits_defaults():
     rl = RiskLimits()
     assert rl.max_position_pct == 6.0
     assert rl.max_gross_leverage == 1.0
-    assert rl.max_drawdown_pct == 25.0
     assert rl.max_open_positions == 10
 
 
@@ -34,15 +38,11 @@ def test_risk_limits_from_legacy_dict_drops_retired_max_loss_per_trade_pct():
     deployed cap would wrongly shrink the position. The authored
     ``max_position_pct`` stands; a 0 / negative / None legacy value must not zero
     or invalidate the cap."""
-    rl = RiskLimits.from_legacy_dict(
-        {"max_position_pct": 10.0, "max_loss_per_trade_pct": 0.5}
-    )
+    rl = RiskLimits.from_legacy_dict({"max_position_pct": 10.0, "max_loss_per_trade_pct": 0.5})
     assert rl.max_position_pct == 10.0  # not min(10, 0.5)
     # Degenerate legacy values are harmlessly ignored, not folded in.
     for bad in (0, -1, None, float("nan")):
-        rl = RiskLimits.from_legacy_dict(
-            {"max_position_pct": 12.0, "max_loss_per_trade_pct": bad}
-        )
+        rl = RiskLimits.from_legacy_dict({"max_position_pct": 12.0, "max_loss_per_trade_pct": bad})
         assert rl.max_position_pct == 12.0
 
 
@@ -198,19 +198,13 @@ def test_can_enter_allows_within_limits():
     assert result.allowed
 
 
-# ---------------------------------------------------------------------------
-# RiskFilter.check_drawdown()
-# ---------------------------------------------------------------------------
-
-
-def test_drawdown_breaches_on_limit():
-    rf = RiskFilter(RiskLimits(max_drawdown_pct=20.0))
-    result = rf.check_drawdown(current_equity=78_000.0, peak_equity=100_000.0)
-    assert result.breached
-    assert result.current_drawdown_pct == pytest.approx(22.0)
-
-
-def test_drawdown_not_breached():
-    rf = RiskFilter(RiskLimits(max_drawdown_pct=20.0))
-    result = rf.check_drawdown(current_equity=90_000.0, peak_equity=100_000.0)
-    assert not result.breached
+def test_risk_limits_has_no_drawdown_constraint():
+    """Max drawdown is not a constraint: the field and the circuit-breaker are
+    gone. A strategy may lose up to 100% of the account by design."""
+    rl = RiskLimits()
+    assert not hasattr(rl, "max_drawdown_pct")
+    assert not hasattr(RiskFilter(rl), "check_drawdown")
+    # A legacy spec dict carrying the retired key still loads (extra ignored).
+    revived = RiskLimits.from_legacy_dict({"max_position_pct": 5, "max_drawdown_pct": 20.0})
+    assert revived.max_position_pct == 5
+    assert not hasattr(revived, "max_drawdown_pct")

--- a/backend/agents/investment_team/tests/test_risk_limit_enforcement.py
+++ b/backend/agents/investment_team/tests/test_risk_limit_enforcement.py
@@ -92,12 +92,17 @@ def test_risk_limits_passes_through_explicit_instance() -> None:
 
 
 def test_spec_json_round_trips_through_model_dump() -> None:
-    """Ensure persisted StrategySpec rows still deserialize after the schema change."""
-    original = _base_spec(risk_limits={"max_position_pct": 7.5, "max_drawdown_pct": 12.0})
+    """Persisted StrategySpec rows still deserialize. A legacy row that carried
+    the retired ``max_drawdown_pct`` constraint loads cleanly with the key
+    dropped — it is no longer a field (max drawdown is not a constraint)."""
+    original = _base_spec(risk_limits={"max_position_pct": 7.5, "max_open_positions": 4})
     payload = original.model_dump(mode="json")
+    # Simulate a legacy persisted row that still carries the retired key.
+    payload["risk_limits"]["max_drawdown_pct"] = 12.0
     revived = StrategySpec.model_validate(payload)
     assert revived.risk_limits.max_position_pct == 7.5
-    assert revived.risk_limits.max_drawdown_pct == 12.0
+    assert revived.risk_limits.max_open_positions == 4
+    assert not hasattr(revived.risk_limits, "max_drawdown_pct")
 
 
 # ---------------------------------------------------------------------------
@@ -133,13 +138,14 @@ def test_trading_service_accepts_legacy_dict() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Drawdown circuit-breaker → terminated_reason propagation
+# No drawdown circuit-breaker: a deep crash must NOT terminate the run early —
+# a Strategy Lab run may lose up to 100% of the account by design.
 # ---------------------------------------------------------------------------
 
 
 _BUY_AND_HOLD_CODE = textwrap.dedent('''\
-    """Enter LONG immediately so a crash-mode price series blows past the
-    max_drawdown limit on the very first bar after entry."""
+    """Enter LONG immediately and ride a crash-mode price series all the way
+    down — there is no drawdown circuit-breaker to bail it out."""
     from contract import OrderSide, OrderType, Strategy
 
 
@@ -175,14 +181,15 @@ def _crash_bars(n: int) -> List[OHLCVBar]:
     return out
 
 
-def test_drawdown_breach_sets_terminated_reason_on_backtest_result() -> None:
-    """A strategy that enters and rides a crash past max_drawdown_pct must
-    record ``terminated_reason`` on the persisted ``BacktestResult``."""
+def test_deep_crash_does_not_terminate_run_early() -> None:
+    """A strategy that enters and rides a catastrophic crash runs to the end of
+    the stream — there is no max-drawdown circuit-breaker, so ``terminated_reason``
+    is never populated by a drawdown limit and the experiment's full downside is
+    observed (it may lose up to ~100%)."""
     spec = _base_spec(
         strategy_id="dd-crash",
         strategy_code=_BUY_AND_HOLD_CODE,
         risk_limits={
-            "max_drawdown_pct": 20.0,
             "max_position_pct": 80.0,
             "max_symbol_concentration_pct": 80.0,
         },
@@ -197,15 +204,9 @@ def test_drawdown_breach_sets_terminated_reason_on_backtest_result() -> None:
     market_data = {"AAA": _crash_bars(10)}
     result = run_backtest(strategy=spec, config=config, market_data=market_data)
 
-    assert result.service_result.terminated_reason is not None, (
-        "service_result should carry the termination signal"
-    )
-    assert "max_drawdown" in result.service_result.terminated_reason
-
-    assert result.result.terminated_reason is not None, (
-        "BacktestResult must propagate terminated_reason from TradingServiceResult"
-    )
-    assert "max_drawdown" in result.result.terminated_reason
+    # The run completes; nothing halted it on a drawdown limit.
+    assert result.service_result.terminated_reason is None
+    assert result.result.terminated_reason is None
 
 
 def test_clean_run_leaves_terminated_reason_none() -> None:

--- a/backend/agents/investment_team/tests/test_strategy_lab_design_review_agent.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_design_review_agent.py
@@ -683,6 +683,34 @@ def test_coerce_critique_keeps_non_drawdown_risk_limit_blocking() -> None:
     assert blocking[0].severity == "critical"
 
 
+@pytest.mark.parametrize(
+    "description",
+    [
+        # Genuine missing-exit defect that merely *mentions* drawdown — must NOT
+        # be demoted just because the word appears.
+        "strategy has neither a stop-loss nor a drawdown-protection exit",
+        "no protective exit; an adverse move produces an unbounded drawdown",
+    ],
+)
+def test_coerce_critique_keeps_defect_that_only_mentions_drawdown(description: str) -> None:
+    """Only references to the retired max-drawdown *limit* are demoted. A
+    substantive exit-completeness defect that merely contains the word
+    "drawdown" keeps blocking."""
+    parsed = {
+        "ready": False,
+        "rationale": "missing protective exit",
+        "issues": [{"field": "exit_rules", "severity": "critical", "description": description}],
+    }
+
+    critique = _coerce_critique(parsed, [])
+
+    assert critique.ready is False
+    blocking = [i for i in critique.issues if i.severity in ("warning", "critical")]
+    assert len(blocking) == 1
+    assert blocking[0].field == "exit_rules"
+    assert blocking[0].severity == "critical"
+
+
 def test_coerce_critique_not_ready_only_sizing_is_promoted_to_ready() -> None:
     """The recurring failure mode: the reviewer says not-ready solely because of
     a sizing/drawdown objection (e.g. the deployed-size-vs-stop '0.25% per trade'

--- a/backend/agents/investment_team/tests/test_strategy_lab_design_review_agent.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_design_review_agent.py
@@ -452,9 +452,9 @@ def test_ready_true_with_warning_issue_is_demoted(monkeypatch: pytest.MonkeyPatc
             "rationale": "passing with concerns",
             "issues": [
                 {
-                    "field": "sizing",
+                    "field": "exit_rules",
                     "severity": "warning",
-                    "description": "fraction looks tight",
+                    "description": "exit leg looks thin",
                 }
             ],
         }
@@ -507,7 +507,7 @@ def test_coerce_critique_critical_threshold_keeps_ready_true_with_warning() -> N
     parsed = {
         "ready": True,
         "rationale": "fine, minor note",
-        "issues": [{"field": "sizing", "severity": "warning", "description": "tight"}],
+        "issues": [{"field": "exit_rules", "severity": "warning", "description": "thin"}],
     }
 
     critique = _coerce_critique(parsed, [], demote_min_severity="critical")
@@ -556,7 +556,7 @@ def test_coerce_critique_default_threshold_demotes_warning() -> None:
     parsed = {
         "ready": True,
         "rationale": "passing with concerns",
-        "issues": [{"field": "sizing", "severity": "warning", "description": "tight"}],
+        "issues": [{"field": "exit_rules", "severity": "warning", "description": "thin"}],
     }
 
     critique = _coerce_critique(parsed, [])
@@ -619,3 +619,93 @@ def test_coerce_critique_not_ready_no_issues_still_gets_placeholder() -> None:
 
     assert critique.ready is False
     assert len(critique.open_issue_ids) == 1
+
+
+# ---------------------------------------------------------------------------
+# Deterministic-gate carve-out: the LLM reviewer may not block on sizing /
+# risk_limits (the deterministic SpecReadinessGate owns that math and has
+# already passed), and max drawdown is not a constraint at all. Such issues are
+# demoted to info, and a not-ready verdict whose ONLY blocking objections were
+# these is promoted to ready.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("field", ["sizing", "risk_limits"])
+def test_coerce_critique_demotes_owned_field_to_info(field: str) -> None:
+    """A blocking sizing/risk_limits issue is demoted to ``info`` so it can never
+    keep an otherwise-ready verdict from advancing."""
+    parsed = {
+        "ready": True,
+        "rationale": "fine",
+        "issues": [{"field": field, "severity": "critical", "description": "tight"}],
+    }
+
+    critique = _coerce_critique(parsed, [])
+
+    assert critique.ready is True
+    assert len(critique.issues) == 1
+    assert critique.issues[0].severity == "info"
+    # Demoted to info ⇒ not a blocking open issue.
+    assert critique.open_issue_ids == set()
+
+
+def test_coerce_critique_not_ready_only_sizing_is_promoted_to_ready() -> None:
+    """The recurring failure mode: the reviewer says not-ready solely because of
+    a sizing/drawdown objection (e.g. the deployed-size-vs-stop '0.25% per trade'
+    misread or 'max drawdown unreachable'). With those demoted, there is nothing
+    blockable left, so the verdict is promoted to ready rather than churning the
+    design loop to the round cap."""
+    parsed = {
+        "ready": False,
+        "rationale": (
+            "sizing 'risk 5% per trade' is 0.25% with the stop, and the 20% max "
+            "drawdown limit is unreachable"
+        ),
+        "issues": [
+            {
+                "field": "sizing",
+                "severity": "critical",
+                "description": "risk 5% per trade is 0.25% per trade with the 5% stop",
+            },
+            {
+                "field": "risk_limits",
+                "severity": "critical",
+                "description": "20% max drawdown limit is unreachable by design",
+            },
+        ],
+    }
+
+    critique = _coerce_critique(parsed, [])
+
+    assert critique.ready is True
+    # No blocking open issues remain — both objections were on owned fields.
+    assert critique.open_issue_ids == set()
+    # An audit-trail info note records the override.
+    assert all(i.severity == "info" for i in critique.issues)
+    assert any("deterministic readiness gate owns" in i.description for i in critique.issues)
+
+
+def test_coerce_critique_not_ready_sizing_plus_real_defect_stays_not_ready() -> None:
+    """A genuine non-owned defect (thesis/signal/etc.) still blocks even when a
+    sizing objection rides alongside it — only the sizing issue is neutralised."""
+    parsed = {
+        "ready": False,
+        "rationale": "mean-reversion entry on a momentum thesis, and sizing is tight",
+        "issues": [
+            {
+                "field": "entry_rules",
+                "severity": "critical",
+                "description": "entry contradicts the momentum hypothesis",
+            },
+            {"field": "sizing", "severity": "critical", "description": "fraction tight"},
+        ],
+    }
+
+    critique = _coerce_critique(parsed, [])
+
+    assert critique.ready is False
+    # The entry_rules critical still blocks; the sizing issue is demoted to info.
+    blocking = [i for i in critique.issues if i.severity in ("warning", "critical")]
+    assert len(blocking) == 1
+    assert blocking[0].field == "entry_rules"
+    assert any(i.field == "sizing" and i.severity == "info" for i in critique.issues)

--- a/backend/agents/investment_team/tests/test_strategy_lab_design_review_agent.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_design_review_agent.py
@@ -22,14 +22,17 @@ from investment_team.strategy_lab.agents.design_review import (
     DesignReviewAgent,
     SpecCritique,
     _coerce_critique,
+    _sizing_owned_by_gate,
     format_prior_critiques,
 )
 from investment_team.strategy_lab.quality_gates.models import QualityGateResult
 from investment_team.strategy_lab.spec_dsl import (
     EntryRule,
+    FixedFractionSizing,
     IndicatorRef,
     Predicate,
     SignalExitRule,
+    VolatilityTargetSizing,
 )
 
 # ---------------------------------------------------------------------------
@@ -709,6 +712,104 @@ def test_coerce_critique_keeps_defect_that_only_mentions_drawdown(description: s
     assert len(blocking) == 1
     assert blocking[0].field == "exit_rules"
     assert blocking[0].severity == "critical"
+
+
+@pytest.mark.parametrize(
+    ("kind", "owned"),
+    [
+        ("fixed_fraction", True),
+        ("fixed_notional", True),
+        ("volatility_target", False),
+        (None, False),
+        ("bogus", False),
+    ],
+)
+def test_sizing_owned_by_gate(kind: object, owned: bool) -> None:
+    """Only the static sizing kinds the deterministic gate fully validates are
+    'owned'. volatility_target (gate abstains) and unknown/missing kinds are not."""
+    assert _sizing_owned_by_gate(kind) is owned
+
+
+def test_coerce_critique_volatility_sizing_objection_keeps_blocking() -> None:
+    """When the spec's sizing kind is NOT gate-owned (volatility_target), a
+    sizing objection must keep blocking — the deterministic gate abstains on it,
+    so the reviewer's plausibility critique is the only substantive check."""
+    parsed = {
+        "ready": False,
+        "rationale": "implausible vol target",
+        "issues": [
+            {
+                "field": "sizing",
+                "severity": "critical",
+                "description": "target_annual_vol=0.001 is implausibly low and untradeable",
+            }
+        ],
+    }
+
+    critique = _coerce_critique(parsed, [], sizing_owned=False)
+
+    assert critique.ready is False
+    blocking = [i for i in critique.issues if i.severity in ("warning", "critical")]
+    assert len(blocking) == 1
+    assert blocking[0].field == "sizing"
+    assert blocking[0].severity == "critical"
+
+
+def test_design_review_run_keeps_volatility_target_sizing_objection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: a volatility_target spec whose reviewer flags an implausible
+    target keeps the verdict not-ready — ``run`` resolves ``sizing_owned`` from
+    the spec's sizing kind, so the gate-abstained objection is not demoted."""
+    spec = _spec().model_copy(update={"sizing": VolatilityTargetSizing(target_annual_vol=0.001)})
+    payload = json.dumps(
+        {
+            "ready": False,
+            "rationale": "implausible vol target",
+            "issues": [
+                {
+                    "field": "sizing",
+                    "severity": "critical",
+                    "description": "target_annual_vol=0.001 is implausibly low and untradeable",
+                }
+            ],
+        }
+    )
+    _patch_review(monkeypatch, payload)
+
+    critique = DesignReviewAgent().run(spec, readiness_results=[])
+
+    assert critique.ready is False
+    blocking = [i for i in critique.issues if i.severity in ("warning", "critical")]
+    assert len(blocking) == 1
+    assert blocking[0].field == "sizing"
+
+
+def test_design_review_run_demotes_sizing_for_gate_owned_kind(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end counterpart: for a gate-owned kind (fixed_fraction) a sole
+    sizing objection IS demoted and the verdict promoted to ready."""
+    spec = _spec().model_copy(update={"sizing": FixedFractionSizing(fraction=0.05)})
+    payload = json.dumps(
+        {
+            "ready": False,
+            "rationale": "risk 5% per trade is 0.25% with the stop",
+            "issues": [
+                {
+                    "field": "sizing",
+                    "severity": "critical",
+                    "description": "risk 5% per trade is only 0.25% per trade with the 5% stop",
+                }
+            ],
+        }
+    )
+    _patch_review(monkeypatch, payload)
+
+    critique = DesignReviewAgent().run(spec, readiness_results=[])
+
+    assert critique.ready is True
+    assert all(i.severity == "info" for i in critique.issues)
 
 
 def test_coerce_critique_not_ready_only_sizing_is_promoted_to_ready() -> None:

--- a/backend/agents/investment_team/tests/test_strategy_lab_design_review_agent.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_design_review_agent.py
@@ -622,22 +622,30 @@ def test_coerce_critique_not_ready_no_issues_still_gets_placeholder() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Deterministic-gate carve-out: the LLM reviewer may not block on sizing /
-# risk_limits (the deterministic SpecReadinessGate owns that math and has
-# already passed), and max drawdown is not a constraint at all. Such issues are
+# Deterministic-gate carve-out: the LLM reviewer may not block on sizing (the
+# deterministic SpecReadinessGate owns that math and has already passed) or on
+# any drawdown objection (max drawdown is not a constraint). Such issues are
 # demoted to info, and a not-ready verdict whose ONLY blocking objections were
-# these is promoted to ready.
+# these is promoted to ready. Non-drawdown risk_limits objections still block.
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("field", ["sizing", "risk_limits"])
-def test_coerce_critique_demotes_owned_field_to_info(field: str) -> None:
-    """A blocking sizing/risk_limits issue is demoted to ``info`` so it can never
-    keep an otherwise-ready verdict from advancing."""
+@pytest.mark.parametrize(
+    ("field", "description"),
+    [
+        ("sizing", "fraction looks tight"),
+        ("risk_limits", "the 20% max drawdown limit is unreachable by design"),
+        ("hypothesis", "thesis implies a max drawdown the sizing can't reach"),
+    ],
+)
+def test_coerce_critique_demotes_sizing_and_drawdown_to_info(field: str, description: str) -> None:
+    """A blocking ``sizing`` objection or any ``drawdown`` objection (whatever
+    field) is demoted to ``info`` so it can never keep a ready verdict from
+    advancing."""
     parsed = {
         "ready": True,
         "rationale": "fine",
-        "issues": [{"field": field, "severity": "critical", "description": "tight"}],
+        "issues": [{"field": field, "severity": "critical", "description": description}],
     }
 
     critique = _coerce_critique(parsed, [])
@@ -647,6 +655,32 @@ def test_coerce_critique_demotes_owned_field_to_info(field: str) -> None:
     assert critique.issues[0].severity == "info"
     # Demoted to info ⇒ not a blocking open issue.
     assert critique.open_issue_ids == set()
+
+
+def test_coerce_critique_keeps_non_drawdown_risk_limit_blocking() -> None:
+    """A genuine risk_limits defect the deterministic gate does NOT check —
+    ``max_gross_leverage=0`` rejects every order at runtime — must keep blocking
+    rather than be demoted and promoted (the deterministic gate only guards the
+    zero/ceiling cases of ``max_position_pct``, not leverage)."""
+    parsed = {
+        "ready": False,
+        "rationale": "leverage cap makes the strategy untradeable",
+        "issues": [
+            {
+                "field": "risk_limits",
+                "severity": "critical",
+                "description": "max_gross_leverage=0 rejects every positive-notional order",
+            }
+        ],
+    }
+
+    critique = _coerce_critique(parsed, [])
+
+    assert critique.ready is False
+    blocking = [i for i in critique.issues if i.severity in ("warning", "critical")]
+    assert len(blocking) == 1
+    assert blocking[0].field == "risk_limits"
+    assert blocking[0].severity == "critical"
 
 
 def test_coerce_critique_not_ready_only_sizing_is_promoted_to_ready() -> None:

--- a/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
@@ -688,13 +688,13 @@ def test_zero_trade_repair_applies_proposed_spec_updates(
                 evidence="entries_filled=4 closed_trades=0",
                 proposed_code=_REPAIRED_CODE,
                 proposed_spec_updates={
-                    "risk_limits": {"max_position_pct": 5, "max_drawdown_pct": 10},
+                    "risk_limits": {"max_position_pct": 5},
                     # Off-list keys MUST NOT mutate the spec (#530).
                     "exit_rules": [StopLossRule(pct=0.05, note="added stop").model_dump()],
                     "strategy_id": "hijacked",
                     "asset_class": "crypto",
                 },
-                changes_made="loosened drawdown limit",
+                changes_made="adjusted position cap",
             ),
         ],
         sandbox_results=[
@@ -712,7 +712,6 @@ def test_zero_trade_repair_applies_proposed_spec_updates(
     assert outcome.new_spec is not None
     # Whitelisted update applied …
     assert outcome.new_spec.risk_limits.max_position_pct == 5
-    assert outcome.new_spec.risk_limits.max_drawdown_pct == 10
     # … and off-list mutations were silently dropped (rule + immutable keys).
     original_exit_rules = _spec().exit_rules
     assert outcome.new_spec.exit_rules == original_exit_rules
@@ -961,14 +960,14 @@ def test_zero_trade_repair_accepted_carries_post_repair_spec_gates(
                 root_cause_category="ENTRY_WITH_NO_EXIT",
                 evidence="entries_filled=4 closed_trades=0",
                 proposed_code=_REPAIRED_CODE,
-                # ``max_drawdown_pct=4`` is below the validator's warning
-                # threshold of 5% (strategy_validator.py:91-102) — warning,
-                # not critical — so the repair is accepted but the gate must
-                # be carried forward.
-                proposed_spec_updates={
-                    "risk_limits": {"max_position_pct": 5, "max_drawdown_pct": 4}
-                },
-                changes_made="tightened risk limits",
+                # The risk_limits mutation is Pydantic-valid and non-critical
+                # (max_position_pct in the safe [1, 25] band). The base spec's
+                # hypothesis ("hyp") names no indicator while its rules use RSI,
+                # so the post-repair StrategySpecValidator emits a non-critical
+                # hypothesis/rules-consistency WARNING — accepted, but the gate
+                # must still be carried forward onto the committed outcome.
+                proposed_spec_updates={"risk_limits": {"max_position_pct": 8}},
+                changes_made="adjusted position cap",
             ),
         ],
         sandbox_results=[

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -726,9 +726,9 @@ class FillSimulator:
         # remainder of that one already-clamped order — the total share count is
         # bounded by the dispatcher's one-time cap, not a fresh sizing decision.
         # Notional drift from price movement on those committed shares is normal
-        # holding behaviour (``max_drawdown_pct`` is the realised-exposure
-        # backstop), and the catastrophic case — equity falling to non-positive
-        # before a later slice — is still rejected unconditionally inside
+        # holding behaviour (there is no drawdown backstop, by design), and the
+        # catastrophic case — equity falling to non-positive before a later
+        # slice — is still rejected unconditionally inside
         # ``can_enter``. Leverage / concentration always run on the post-extend
         # notional.
         gate = self.risk.can_enter(

--- a/backend/agents/investment_team/trading_service/modes/paper_trade.py
+++ b/backend/agents/investment_team/trading_service/modes/paper_trade.py
@@ -310,10 +310,6 @@ def run_paper_trade(
         final_reason = "lookahead_violation"
     elif service_result.error:
         final_reason = "provider_error"
-    elif service_result.terminated_reason and service_result.terminated_reason.startswith(
-        "max_drawdown"
-    ):
-        final_reason = "max_drawdown"
     elif terminated_reason["reason"] != "unknown":
         final_reason = terminated_reason["reason"]
     else:

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -558,8 +558,9 @@ class _EngineEntryDispatcher:
         # decide how much capital may be deployed BEFORE placing the order, then
         # let the order fill like a real broker fill — a price gap between the
         # sizing bar and the fill bar may leave the realised position marginally
-        # above the cap, and that is acceptable holding behaviour governed by the
-        # ``max_drawdown_pct`` backstop, not a reason to drop the entry. This also
+        # above the cap, and that is acceptable holding behaviour (post-fill
+        # notional drift on committed shares), not a reason to drop the entry.
+        # This also
         # gates ``risk_presized``: a clamped order tells ``RiskFilter.can_enter``
         # to skip the fill-time cap re-check (which would otherwise falsely reject
         # the gap). ``fixed_fraction`` deploys ``fraction`` of current equity, so
@@ -1509,20 +1510,16 @@ class TradingService:
                             for trade in outcome.closed_trades:
                                 on_trade(trade)
 
-                        # 3) Drawdown circuit-breaker.
+                        # 3) Mark-to-market and stamp the equity curve. There is
+                        # no drawdown circuit-breaker — a Strategy Lab run is an
+                        # experiment and must be free to lose up to 100% so its
+                        # true downside is observed, not truncated by a limit.
                         portfolio.update_last_price(cur_bar.symbol, cur_bar.close)
                         equity = portfolio.mark_to_market()
                         # #430: stamp EOD equity for the streaming curve.
                         # Sub-daily bars overwrite the same calendar-day key,
                         # so the last MTM of each trading day wins.
                         eod_buffer.record(cur_bar.timestamp, equity)
-                        dd = self._risk.check_drawdown(equity, portfolio.peak_equity)
-                        if dd.breached:
-                            result.terminated_reason = (
-                                f"max_drawdown breached "
-                                f"({dd.current_drawdown_pct:.1f}% >= {dd.limit_pct}%)"
-                            )
-                            break
 
                         # Issue #527 — refresh engine-side per-position state
                         # for ``cur_bar.symbol`` based on the post-fill
@@ -1783,19 +1780,14 @@ class TradingService:
                         for trade in outcome.closed_trades:
                             on_trade(trade)
 
-                    # 3) Drawdown circuit-breaker.
+                    # 3) Mark-to-market and stamp the equity curve. There is no
+                    # drawdown circuit-breaker — a Strategy Lab run is an
+                    # experiment and must be free to lose up to 100% so its true
+                    # downside is observed, not truncated by a limit.
                     portfolio.update_last_price(cur_bar.symbol, cur_bar.close)
                     equity = portfolio.mark_to_market()
                     # #430: stamp EOD equity for the streaming curve.
                     eod_buffer.record(cur_bar.timestamp, equity)
-                    dd = self._risk.check_drawdown(equity, portfolio.peak_equity)
-                    if dd.breached:
-                        result.terminated_reason = (
-                            f"max_drawdown breached "
-                            f"({dd.current_drawdown_pct:.1f}% >= {dd.limit_pct}%)"
-                        )
-                        chunk_buffer.clear()
-                        return False
 
                     result.bars_processed += 1
 


### PR DESCRIPTION
## Why

The Strategy Lab design loop kept burning all rounds without reaching readiness. The verdict is an **AND** of (1) the deterministic `SpecReadinessGate` — which already encodes the correct risk model — and (2) the LLM `DesignReviewAgent`, which holds the final veto. The deterministic gate passed, but the LLM kept rejecting on two things:

- **Sizing misread** — it re-derived "risk 5% per trade" as `5% × 5% = 0.25% per trade` (deployed-size × stop). That phrase is the codebase's own `format_sizing_rule()` rendering, and reads to a quant-trained model as a *loss budget* rather than capital *deployed*.
- **Max-drawdown reachability** — it flagged the drawdown limit as "unreachable," because the prompts still *instructed* it to check `max_drawdown_pct` reachability.

Prose alone can't reliably constrain an LLM, and nothing forced the reviewer to honour the deterministic verdict. Separately, max drawdown should not be a constraint at all: a Strategy Lab run is an experiment (backtest/paper, no real capital) and must be free to lose up to 100% so its true downside is observed.

## What

Three coordinated changes:

1. **Prompts** (`design_review_system.md`, `design_system.md`, `design_self_review_system.md` + the reviewer user-template) — sizing/`risk_limits` math is now declared owned by the deterministic gate (reviewer must not block on it); "risk X% per trade" is spelled out as capital **deployed** (the per-trade loss cap, never `fraction × stop`); every max-drawdown reachability check is removed and drawdown is stated to be unbounded.

2. **Deterministic backstop** (`_coerce_critique`) — any `sizing`/`risk_limits` issue the reviewer raises is demoted to `info` (advisory, non-blocking), and a not-ready verdict whose *only* blocking objections were those is promoted to ready. The reviewer can no longer veto readiness on math the gate already cleared. Genuine non-owned defects (thesis/signal/etc.) still block.

3. **Remove max drawdown as a runtime constraint** — dropped `RiskLimits.max_drawdown_pct`, the `check_drawdown` circuit-breaker and both engine call sites in `service.py`, the `DrawdownBreach` type, the validator range warning, the paper-trade `max_drawdown` termination mapping, and the refinement/audit tighten-direction entries. **Realised drawdown is still measured and reported as a performance metric** (`PerformanceMetrics`, regime/walk-forward, UI display) — only the *constraint* is gone. Legacy specs carrying the retired key load cleanly (extra key ignored), so the UI (which only displays the metric) needs no change.

## Tests

- Updated `test_risk_filter`, `test_risk_limit_enforcement`, `test_strategy_lab_zero_trade_repair`, `test_strategy_lab_design_review_agent`, `test_audit_recent_runs`.
- New regression tests: a deep crash now runs to completion without early termination; sizing/risk_limits critiques are demoted to info; a not-ready verdict whose only objections were sizing/drawdown is promoted to ready; a real non-owned defect alongside a sizing objection still blocks.
- `3371 passed` locally for the investment_team suite (the only failures were modules needing `pyarrow`/`ollama`, which aren't installed in this sandbox; CI has them). `ruff check` + `ruff format` clean.

Closes #868

---
_Generated by [Claude Code](https://claude.ai/code/session_019HmDNJg3XjubDpMYMyffyY)_