### PR TITLE
Chunk review files at function boundaries instead of mid-body

### DIFF
--- a/backend/agents/software_engineering_team/backend_code_v2_team/phases/review.py
+++ b/backend/agents/software_engineering_team/backend_code_v2_team/phases/review.py
@@ -12,6 +12,7 @@ import logging
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from code_review_agent.coordinator import build_review_chunks
 from strands import Agent
 
 from llm_service import LLMClient
@@ -48,29 +49,49 @@ def _run_llm_review(
     task: Task,
     files: Dict[str, str],
 ) -> List[ReviewIssue]:
-    """LLM-based code review when no external review agent is available."""
-    code_text = "\n\n".join(f"--- {p} ---\n{c}" for p, c in files.items())
-    prompt = REVIEW_PROMPT.format(
-        requirements=task.requirements or task.description,
-        acceptance_criteria=", ".join(task.acceptance_criteria)
-        if task.acceptance_criteria
-        else "N/A",
-        code=code_text[:MAX_REVIEW_CODE_CHARS],
-    )
-    raw = (lambda _r: str(_r))(Agent(model=resolve_text_mode_strands_model(llm))(prompt)).strip()
-    data = parse_review_template(raw)
+    """LLM-based code review when no external review agent is available.
+
+    Preconditions:
+        - ``files`` maps file paths to their full source text.
+
+    Postconditions:
+        - Inputs that exceed the per-call budget are split into function-aware
+          chunks (cuts land between whole functions/methods, never mid-body)
+          and every chunk is reviewed; issues from all chunks are returned.
+          No file content is silently truncated away, so a large file's tail is
+          reviewed rather than dropped. Blank files contribute nothing.
+        - Small inputs are reviewed in a single call, as before.
+    """
+    blocks = [(path, content) for path, content in files.items() if content and content.strip()]
+    if not blocks:
+        return []
+    # Budget each prompt at the same per-call size the old code truncated to,
+    # but split at function/method boundaries so no construct is severed and no
+    # file tail is dropped.
     issues: List[ReviewIssue] = []
-    for item in data.get("issues") or []:
-        if isinstance(item, dict):
-            issues.append(
-                ReviewIssue(
-                    source=item.get("source", "code_review"),
-                    severity=item.get("severity", "medium"),
-                    description=item.get("description", ""),
-                    file_path=item.get("file_path", ""),
-                    recommendation=item.get("recommendation", ""),
+    for chunk in build_review_chunks(blocks, MAX_REVIEW_CODE_CHARS):
+        prompt = REVIEW_PROMPT.format(
+            requirements=task.requirements or task.description,
+            acceptance_criteria=", ".join(task.acceptance_criteria)
+            if task.acceptance_criteria
+            else "N/A",
+            code=chunk.content,
+        )
+        raw = (lambda _r: str(_r))(
+            Agent(model=resolve_text_mode_strands_model(llm))(prompt)
+        ).strip()
+        data = parse_review_template(raw)
+        for item in data.get("issues") or []:
+            if isinstance(item, dict):
+                issues.append(
+                    ReviewIssue(
+                        source=item.get("source", "code_review"),
+                        severity=item.get("severity", "medium"),
+                        description=item.get("description", ""),
+                        file_path=item.get("file_path", ""),
+                        recommendation=item.get("recommendation", ""),
+                    )
                 )
-            )
     return issues
 
 
@@ -756,7 +777,9 @@ def run_qa_testing_phase(
                 )
 
     if qa_agent is None and not (tool_agents and ToolAgentKind.TESTING_QA in tool_agents):
-        logger.warning("[%s] QA agent not available for microtask %s — QA gate skipped", task_id, microtask_id)
+        logger.warning(
+            "[%s] QA agent not available for microtask %s — QA gate skipped", task_id, microtask_id
+        )
         issues.append(
             ReviewIssue(
                 source="qa",
@@ -868,7 +891,11 @@ def run_security_testing_phase(
                 )
 
     if security_agent is None and not (tool_agents and ToolAgentKind.SECURITY in tool_agents):
-        logger.warning("[%s] Security agent not available for microtask %s — security gate skipped", task_id, microtask_id)
+        logger.warning(
+            "[%s] Security agent not available for microtask %s — security gate skipped",
+            task_id,
+            microtask_id,
+        )
         issues.append(
             ReviewIssue(
                 source="security",
@@ -1031,7 +1058,9 @@ def run_documentation_self_review(
         )
 
         try:
-            raw = (lambda _r: str(_r))(Agent(model=resolve_text_mode_strands_model(llm))(prompt)).strip()
+            raw = (lambda _r: str(_r))(
+                Agent(model=resolve_text_mode_strands_model(llm))(prompt)
+            ).strip()
         except Exception as exc:
             logger.warning(
                 "Documentation self-review LLM call failed (iteration %d): %s",

--- a/backend/agents/software_engineering_team/backend_code_v2_team/phases/review.py
+++ b/backend/agents/software_engineering_team/backend_code_v2_team/phases/review.py
@@ -12,7 +12,6 @@ import logging
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from code_review_agent.coordinator import build_review_chunks
 from strands import Agent
 
 from llm_service import LLMClient
@@ -41,6 +40,10 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 MAX_REVIEW_CODE_CHARS = 60_000  # Generous limit; review all files, not just first 20
+# A file this many chunks deep means an unusually large review; log a warning
+# for cost/rate-limit visibility, but still review every chunk (dropping any
+# would re-introduce the tail truncation this fallback exists to avoid).
+MANY_CHUNKS_WARN_THRESHOLD = 20
 
 
 def _run_llm_review(
@@ -60,8 +63,16 @@ def _run_llm_review(
           and every chunk is reviewed; issues from all chunks are returned.
           No file content is silently truncated away, so a large file's tail is
           reviewed rather than dropped. Blank files contribute nothing.
+        - A chunk whose LLM call or parse fails is logged and skipped; issues
+          from the other chunks are still returned (one bad chunk never aborts
+          the whole review).
         - Small inputs are reviewed in a single call, as before.
     """
+    # Imported lazily, fully-qualified, to match this module's existing
+    # convention for code_review_agent imports and to avoid assuming the
+    # software_engineering_team package dir is itself on sys.path.
+    from software_engineering_team.code_review_agent.coordinator import build_review_chunks
+
     blocks = [(path, content) for path, content in files.items() if content and content.strip()]
     if not blocks:
         return []
@@ -69,7 +80,14 @@ def _run_llm_review(
     # but split at function/method boundaries so no construct is severed and no
     # file tail is dropped.
     chunks = list(build_review_chunks(blocks, MAX_REVIEW_CODE_CHARS))
-    logger.debug("LLM code review: %d chunk(s) for %d file(s)", len(chunks), len(blocks))
+    if len(chunks) > MANY_CHUNKS_WARN_THRESHOLD:
+        logger.warning(
+            "LLM code review: %d chunks for %d file(s) — large review, many LLM calls",
+            len(chunks),
+            len(blocks),
+        )
+    else:
+        logger.debug("LLM code review: %d chunk(s) for %d file(s)", len(chunks), len(blocks))
     issues: List[ReviewIssue] = []
     for idx, chunk in enumerate(chunks, start=1):
         logger.debug("LLM code review: reviewing chunk %d/%d", idx, len(chunks))
@@ -80,8 +98,12 @@ def _run_llm_review(
             else "N/A",
             code=chunk.content,
         )
-        raw = str(Agent(model=resolve_text_mode_strands_model(llm))(prompt)).strip()
-        data = parse_review_template(raw)
+        try:
+            raw = str(Agent(model=resolve_text_mode_strands_model(llm))(prompt)).strip()
+            data = parse_review_template(raw)
+        except Exception as exc:
+            logger.warning("LLM code review: chunk %d/%d failed: %s", idx, len(chunks), exc)
+            continue
         for item in data.get("issues") or []:
             if isinstance(item, dict):
                 issues.append(

--- a/backend/agents/software_engineering_team/backend_code_v2_team/phases/review.py
+++ b/backend/agents/software_engineering_team/backend_code_v2_team/phases/review.py
@@ -68,8 +68,11 @@ def _run_llm_review(
     # Budget each prompt at the same per-call size the old code truncated to,
     # but split at function/method boundaries so no construct is severed and no
     # file tail is dropped.
+    chunks = list(build_review_chunks(blocks, MAX_REVIEW_CODE_CHARS))
+    logger.debug("LLM code review: %d chunk(s) for %d file(s)", len(chunks), len(blocks))
     issues: List[ReviewIssue] = []
-    for chunk in build_review_chunks(blocks, MAX_REVIEW_CODE_CHARS):
+    for idx, chunk in enumerate(chunks, start=1):
+        logger.debug("LLM code review: reviewing chunk %d/%d", idx, len(chunks))
         prompt = REVIEW_PROMPT.format(
             requirements=task.requirements or task.description,
             acceptance_criteria=", ".join(task.acceptance_criteria)
@@ -77,9 +80,7 @@ def _run_llm_review(
             else "N/A",
             code=chunk.content,
         )
-        raw = (lambda _r: str(_r))(
-            Agent(model=resolve_text_mode_strands_model(llm))(prompt)
-        ).strip()
+        raw = str(Agent(model=resolve_text_mode_strands_model(llm))(prompt)).strip()
         data = parse_review_template(raw)
         for item in data.get("issues") or []:
             if isinstance(item, dict):
@@ -216,7 +217,7 @@ def run_review(
     # QA/security agents still take a single capped code string (their own
     # input contract); only the code review agent receives untruncated files.
     code_text = "\n\n".join(f"--- {p} ---\n{c}" for p, c in execution_result.files.items())
-    code_text_12k = code_text[:MAX_REVIEW_CODE_CHARS]
+    code_text_capped = code_text[:MAX_REVIEW_CODE_CHARS]
 
     # 4. QA agent
     if qa_agent is not None:
@@ -224,7 +225,7 @@ def run_review(
             from qa_agent.models import QAInput as _QAInput
 
             qa_input = _QAInput(
-                code=code_text_12k,
+                code=code_text_capped,
                 language=language,
                 task_description=task.description or "",
             )
@@ -248,7 +249,7 @@ def run_review(
             from security_agent.models import SecurityInput as _SecInput
 
             sec_input = _SecInput(
-                code=code_text_12k,
+                code=code_text_capped,
                 language=language,
                 task_description=task.description or "",
             )
@@ -442,7 +443,7 @@ def run_microtask_review(
     # QA agent still takes a single capped code string (its own input
     # contract); only the code review agent receives untruncated files.
     code_text = "\n\n".join(f"--- {p} ---\n{c}" for p, c in files.items())
-    code_text_12k = code_text[:MAX_REVIEW_CODE_CHARS]
+    code_text_capped = code_text[:MAX_REVIEW_CODE_CHARS]
 
     if qa_agent is not None:
         if detail_callback:
@@ -451,7 +452,7 @@ def run_microtask_review(
             from qa_agent.models import QAInput as _QAInput
 
             qa_input = _QAInput(
-                code=code_text_12k,
+                code=code_text_capped,
                 language=language,
                 task_description=f"Microtask: {microtask.description or microtask.title}",
             )
@@ -476,7 +477,7 @@ def run_microtask_review(
             from security_agent.models import SecurityInput as _SecInput
 
             sec_input = _SecInput(
-                code=code_text_12k,
+                code=code_text_capped,
                 language=language,
                 task_description=f"Microtask: {microtask.description or microtask.title}",
             )
@@ -719,7 +720,7 @@ def run_qa_testing_phase(
     )
 
     code_text = "\n\n".join(f"--- {p} ---\n{c}" for p, c in files.items())
-    code_text_12k = code_text[:MAX_REVIEW_CODE_CHARS]
+    code_text_capped = code_text[:MAX_REVIEW_CODE_CHARS]
 
     if qa_agent is not None:
         if detail_callback:
@@ -728,7 +729,7 @@ def run_qa_testing_phase(
             from qa_agent.models import QAInput as _QAInput
 
             qa_input = _QAInput(
-                code=code_text_12k,
+                code=code_text_capped,
                 language=language,
                 task_description=f"Microtask: {microtask.description or microtask.title}",
             )
@@ -831,7 +832,7 @@ def run_security_testing_phase(
     )
 
     code_text = "\n\n".join(f"--- {p} ---\n{c}" for p, c in files.items())
-    code_text_12k = code_text[:MAX_REVIEW_CODE_CHARS]
+    code_text_capped = code_text[:MAX_REVIEW_CODE_CHARS]
 
     if security_agent is not None:
         if detail_callback:
@@ -840,7 +841,7 @@ def run_security_testing_phase(
             from security_agent.models import SecurityInput as _SecInput
 
             sec_input = _SecInput(
-                code=code_text_12k,
+                code=code_text_capped,
                 language=language,
                 task_description=f"Microtask: {microtask.description or microtask.title}",
             )

--- a/backend/agents/software_engineering_team/code_review_agent/code_boundaries.py
+++ b/backend/agents/software_engineering_team/code_review_agent/code_boundaries.py
@@ -71,7 +71,10 @@ def _python_break_lines(content: str) -> frozenset[int]:
     """
     try:
         tree = ast.parse(content)
-    except (SyntaxError, ValueError):
+    except Exception:
+        # Honor the "never raises" postcondition: SyntaxError/ValueError on
+        # malformed source, but also RecursionError on deeply nested input,
+        # MemoryError, etc. Any parse failure degrades to "no boundaries".
         return frozenset()
     breaks: set[int] = set()
     for node in tree.body:
@@ -92,6 +95,16 @@ def _heuristic_break_lines(content: str) -> frozenset[int]:
     (``function``/``class``/``const x = () =>``/``export``/``interface``/
     ``@Component``/``def``) sit at column 0, while their bodies are indented —
     so this finds construct boundaries without parsing the language.
+
+    Known limitation: a column-0 *continuation* keyword (``else``/``elif``/
+    ``catch``/``finally`` followed by ``{`` or ``:``) is treated as a boundary,
+    so a top-level if/else or try/catch chain can be split between its arms.
+    This only yields a *suboptimal* split (a slightly different chunk edge); it
+    never severs a function/method/class, which is the guarantee callers rely
+    on. Keyword matching is intentionally avoided here because ``startswith``
+    cannot distinguish a continuation keyword from an identifier with the same
+    prefix (e.g. a top-level ``catchAll = ...``), and a missed continuation is
+    cheaper than a wrongly-skipped real declaration.
 
     Postconditions:
         - Returns 1-based line numbers in ``[1, len(content.splitlines())]``.

--- a/backend/agents/software_engineering_team/code_review_agent/code_boundaries.py
+++ b/backend/agents/software_engineering_team/code_review_agent/code_boundaries.py
@@ -14,7 +14,10 @@ from ``(path, content)`` (or ``content``) to a set of 1-based line numbers.
 from __future__ import annotations
 
 import ast
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 # Extensions parsed with Python's ``ast`` for exact, decorator-aware ranges.
 _PYTHON_EXTS = frozenset({".py", ".pyi"})
@@ -74,10 +77,12 @@ def _python_break_lines(content: str) -> frozenset[int]:
     """
     try:
         tree = ast.parse(content)
-    except Exception:
+    except Exception as exc:
         # Honor the "never raises" postcondition: SyntaxError/ValueError on
         # malformed source, but also RecursionError on deeply nested input,
         # MemoryError, etc. Any parse failure degrades to "no boundaries".
+        # Log at debug so unexpected failures are still diagnosable.
+        logger.debug("ast parse failed during break-line detection: %s", exc)
         return frozenset()
     breaks: set[int] = set()
     for node in tree.body:

--- a/backend/agents/software_engineering_team/code_review_agent/code_boundaries.py
+++ b/backend/agents/software_engineering_team/code_review_agent/code_boundaries.py
@@ -104,7 +104,9 @@ def _heuristic_break_lines(content: str) -> frozenset[int]:
             continue
         if line[0].isspace():
             continue
-        if line.lstrip().startswith(_HEURISTIC_SKIP_PREFIXES):
+        # Leading whitespace is already ruled out above, so the line starts at
+        # column 0 — no lstrip needed before checking the skip prefixes.
+        if line.startswith(_HEURISTIC_SKIP_PREFIXES):
             continue
         breaks.add(i)
     return frozenset(breaks)

--- a/backend/agents/software_engineering_team/code_review_agent/code_boundaries.py
+++ b/backend/agents/software_engineering_team/code_review_agent/code_boundaries.py
@@ -1,0 +1,110 @@
+"""Function/method boundary detection for code-review chunking.
+
+Pure source-analysis helpers that name the lines where a new top-level code
+construct begins, so the coordinator can cut oversized files *between* whole
+functions/methods/classes instead of mid-body. The detector degrades to "no
+boundaries" on anything it cannot parse (partial code, minified code, unknown
+language), which the caller reads as "fall back to line-boundary splitting" —
+so it never makes splitting worse than the previous behavior.
+
+This module does no I/O and holds no state; every function is a pure mapping
+from ``(path, content)`` (or ``content``) to a set of 1-based line numbers.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+
+# Extensions parsed with Python's ``ast`` for exact, decorator-aware ranges.
+_PYTHON_EXTS = frozenset({".py", ".pyi"})
+
+# A heuristic break line must not *start* with one of these tokens: a bare
+# closing bracket, a block-comment close, or a line comment would otherwise be
+# cut away from the block it belongs to.
+_HEURISTIC_SKIP_PREFIXES = ("}", ")", "]", "*/", "//", "#")
+
+
+def preferred_break_lines(path: str, content: str) -> frozenset[int]:
+    """Name the 1-based lines of ``content`` that start a top-level construct.
+
+    A returned line number ``b`` means "line ``b`` begins a new function,
+    method, class, or top-level declaration, so cutting *before* it keeps the
+    preceding construct whole." Numbers are relative to ``content`` (line 1 is
+    its first line), matching how the coordinator's splitter counts lines.
+
+    Preconditions:
+        - ``content`` is the full text of one file block (``path`` may be '' for
+          headerless code); neither argument is None.
+
+    Postconditions:
+        - Every returned number is in ``[1, len(content.splitlines())]``.
+        - Never raises: on a parse error, minified/single-line input, unknown
+          language, or empty content it returns ``frozenset()``, which the
+          caller treats as "no preferred breaks → split on line boundaries".
+        - Pure: no I/O, no mutation of the arguments or module state.
+    """
+    if not content or not content.strip():
+        return frozenset()
+    ext = os.path.splitext(path or "")[1].lower()
+    if ext in _PYTHON_EXTS:
+        breaks = _python_break_lines(content)
+        if breaks:
+            return breaks
+        # An empty Python result means the source did not parse (e.g. a partial
+        # snippet under review); fall through to the language-agnostic heuristic
+        # rather than giving up, since column-0 ``def``/``class`` lines are still
+        # good cut points.
+    return _heuristic_break_lines(content)
+
+
+def _python_break_lines(content: str) -> frozenset[int]:
+    """Top-level def/async-def/class start lines via ``ast``.
+
+    Postconditions:
+        - Returns the start line of every top-level function/class in
+          ``content``; for a decorated construct, the earliest decorator line
+          (so a cut lands above the decorators, never between a decorator and
+          its def).
+        - Returns ``frozenset()`` on ``SyntaxError`` or any other parse failure,
+          so the caller can fall back instead of crashing on partial code.
+    """
+    try:
+        tree = ast.parse(content)
+    except (SyntaxError, ValueError):
+        return frozenset()
+    breaks: set[int] = set()
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            start = node.lineno
+            for dec in node.decorator_list:
+                start = min(start, dec.lineno)
+            breaks.add(start)
+    return frozenset(breaks)
+
+
+def _heuristic_break_lines(content: str) -> frozenset[int]:
+    """Column-0 declaration lines, for non-Python (or unparseable) source.
+
+    A line is a break point when it is non-blank, begins at column 0 (no
+    leading whitespace), and does not start with a closing/continuation/comment
+    token. Across brace and indentation languages, top-level declarations
+    (``function``/``class``/``const x = () =>``/``export``/``interface``/
+    ``@Component``/``def``) sit at column 0, while their bodies are indented —
+    so this finds construct boundaries without parsing the language.
+
+    Postconditions:
+        - Returns 1-based line numbers in ``[1, len(content.splitlines())]``.
+        - Returns ``frozenset()`` for minified/single-construct input with no
+          interior column-0 lines, so the caller falls back to line boundaries.
+    """
+    breaks: set[int] = set()
+    for i, line in enumerate(content.splitlines(), start=1):
+        if not line or not line.strip():
+            continue
+        if line[0].isspace():
+            continue
+        if line.lstrip().startswith(_HEURISTIC_SKIP_PREFIXES):
+            continue
+        breaks.add(i)
+    return frozenset(breaks)

--- a/backend/agents/software_engineering_team/code_review_agent/code_boundaries.py
+++ b/backend/agents/software_engineering_team/code_review_agent/code_boundaries.py
@@ -20,9 +20,9 @@ import os
 _PYTHON_EXTS = frozenset({".py", ".pyi"})
 
 # A heuristic break line must not *start* with one of these tokens: a bare
-# closing bracket, a block-comment close, or a line comment would otherwise be
-# cut away from the block it belongs to.
-_HEURISTIC_SKIP_PREFIXES = ("}", ")", "]", "*/", "//", "#")
+# closing bracket, a block-comment open/close, or a line comment would
+# otherwise be cut away from the block it belongs to.
+_HEURISTIC_SKIP_PREFIXES = ("}", ")", "]", "*/", "/*", "//", "#")
 
 
 def preferred_break_lines(path: str, content: str) -> frozenset[int]:
@@ -53,10 +53,11 @@ def preferred_break_lines(path: str, content: str) -> frozenset[int]:
         breaks = _python_break_lines(content)
         if breaks:
             return breaks
-        # An empty Python result means the source did not parse (e.g. a partial
-        # snippet under review); fall through to the language-agnostic heuristic
-        # rather than giving up, since column-0 ``def``/``class`` lines are still
-        # good cut points.
+        # An empty Python result means either the source did not parse (e.g. a
+        # partial snippet under review) or it has no top-level functions/classes
+        # (a script of bare statements). In both cases fall through to the
+        # language-agnostic heuristic rather than giving up, since column-0
+        # ``def``/``class`` lines are still good cut points.
     return _heuristic_break_lines(content)
 
 

--- a/backend/agents/software_engineering_team/code_review_agent/code_boundaries.py
+++ b/backend/agents/software_engineering_team/code_review_agent/code_boundaries.py
@@ -39,9 +39,11 @@ def preferred_break_lines(path: str, content: str) -> frozenset[int]:
 
     Postconditions:
         - Every returned number is in ``[1, len(content.splitlines())]``.
-        - Never raises: on a parse error, minified/single-line input, unknown
-          language, or empty content it returns ``frozenset()``, which the
-          caller treats as "no preferred breaks → split on line boundaries".
+        - Never raises. On a parse error, unknown language, or empty/blank
+          content it returns ``frozenset()``; for minified/single-line input it
+          may return ``frozenset({1})``. Either way the caller falls back to
+          line-boundary splitting, because the splitter never cuts before line 1
+          and treats the absence of *interior* breaks as "no preferred breaks".
         - Pure: no I/O, no mutation of the arguments or module state.
     """
     if not content or not content.strip():
@@ -108,8 +110,10 @@ def _heuristic_break_lines(content: str) -> frozenset[int]:
 
     Postconditions:
         - Returns 1-based line numbers in ``[1, len(content.splitlines())]``.
-        - Returns ``frozenset()`` for minified/single-construct input with no
-          interior column-0 lines, so the caller falls back to line boundaries.
+        - Returns ``frozenset()`` only for truly empty/blank content. Single-line
+          input returns ``frozenset({1})`` (line 1 is column-0 and not skipped);
+          since the splitter never cuts before line 1, this still degrades to
+          line-boundary splitting — there are no *interior* breaks to use.
     """
     breaks: set[int] = set()
     for i, line in enumerate(content.splitlines(), start=1):

--- a/backend/agents/software_engineering_team/code_review_agent/coordinator.py
+++ b/backend/agents/software_engineering_team/code_review_agent/coordinator.py
@@ -38,6 +38,7 @@ from software_engineering_team.shared.context_sizing import (
 )
 
 from .chunk_reviewer import ChunkReviewAgent
+from .code_boundaries import preferred_break_lines
 from .models import (
     ChunkReviewInput,
     CodeReviewInput,
@@ -179,6 +180,12 @@ def split_block_into_segments(
           except when a single line alone exceeds it (line boundaries are
           never broken).
         - A within-budget block yields exactly one whole-file segment.
+        - Cuts prefer function/method/class boundaries: when an over-budget
+          buffer contains the start of a top-level construct, the split lands
+          before that construct so it is not severed mid-body. When no such
+          boundary exists in the buffer (minified code, one giant function,
+          unparseable or pre-numbered content), the split falls back to the
+          line boundary, keeping the other postconditions intact.
     """
     assert max_chars > 0, "max_chars must be positive"
     total_lines = len(content.splitlines()) or 1
@@ -192,6 +199,11 @@ def split_block_into_segments(
                 pre_numbered=pre_numbered,
             )
         ]
+    # Lines (1-based) that start a top-level construct; cutting before one keeps
+    # the preceding construct whole. Pre-numbered hunks carry "N: " prefixes that
+    # defeat boundary detection and are rarely whole functions, so they keep the
+    # plain line-boundary behavior (empty break set).
+    breaks = frozenset() if pre_numbered else preferred_break_lines(path, content)
     # Split pieces become partial segments, which render with "N: " prefixes
     # (unless already pre-numbered); budget each line's rendered size so the
     # prompt stays within max_chars after prefixing.
@@ -205,10 +217,22 @@ def split_block_into_segments(
     for ln in lines:
         rendered_len = len(ln) + prefix_width
         if buf and buf_len + rendered_len > max_chars:
-            pieces.append((buf_start, "".join(buf)))
-            buf = []
-            buf_len = 0
-            buf_start = line_no
+            # Prefer the latest construct boundary inside the buffer so the
+            # flushed head ends right before a function/method/class. Candidates
+            # are strictly after buf_start (a non-empty head) and at most the
+            # current line; with none, fall back to the line boundary.
+            cut = max((b for b in breaks if buf_start < b <= line_no), default=None)
+            if cut is not None:
+                head = buf[: cut - buf_start]
+                pieces.append((buf_start, "".join(head)))
+                buf = buf[cut - buf_start :]
+                buf_start = cut
+                buf_len = sum(len(x) + prefix_width for x in buf)
+            else:
+                pieces.append((buf_start, "".join(buf)))
+                buf = []
+                buf_len = 0
+                buf_start = line_no
         buf.append(ln)
         buf_len += rendered_len
         line_no += 1

--- a/backend/agents/software_engineering_team/frontend_code_v2_team/phases/review.py
+++ b/backend/agents/software_engineering_team/frontend_code_v2_team/phases/review.py
@@ -66,8 +66,11 @@ def _run_llm_review(
     # Budget each prompt at the same per-call size the old code truncated to,
     # but split at function/method boundaries so no construct is severed and no
     # file tail is dropped.
+    chunks = list(build_review_chunks(blocks, MAX_REVIEW_CODE_CHARS))
+    logger.debug("LLM code review: %d chunk(s) for %d file(s)", len(chunks), len(blocks))
     issues: List[ReviewIssue] = []
-    for chunk in build_review_chunks(blocks, MAX_REVIEW_CODE_CHARS):
+    for idx, chunk in enumerate(chunks, start=1):
+        logger.debug("LLM code review: reviewing chunk %d/%d", idx, len(chunks))
         prompt = REVIEW_PROMPT.format(
             requirements=task.requirements or task.description,
             acceptance_criteria=", ".join(task.acceptance_criteria)
@@ -75,9 +78,7 @@ def _run_llm_review(
             else "N/A",
             code=chunk.content,
         )
-        raw = (lambda _r: str(_r))(
-            Agent(model=resolve_text_mode_strands_model(llm))(prompt)
-        ).strip()
+        raw = str(Agent(model=resolve_text_mode_strands_model(llm))(prompt)).strip()
         data = parse_review_template(raw)
         for item in data.get("issues") or []:
             if isinstance(item, dict):
@@ -167,7 +168,7 @@ def run_review(
             logger.warning("[%s] Linting tool agent failed: %s", task_id, exc)
 
     code_text = "\n\n".join(f"--- {p} ---\n{c}" for p, c in list(execution_result.files.items()))
-    code_text_12k = code_text[:MAX_REVIEW_CODE_CHARS]
+    code_text_capped = code_text[:MAX_REVIEW_CODE_CHARS]
     if code_review_agent is not None:
         try:
             from code_review_agent.models import CodeReviewInput as _CRInput
@@ -207,7 +208,7 @@ def run_review(
             from qa_agent.models import QAInput as _QAInput
 
             qa_input = _QAInput(
-                code=code_text_12k,
+                code=code_text_capped,
                 language=language,
                 task_description=task.description or "",
             )
@@ -230,7 +231,7 @@ def run_review(
             from security_agent.models import SecurityInput as _SecInput
 
             sec_input = _SecInput(
-                code=code_text_12k,
+                code=code_text_capped,
                 language=language,
                 task_description=task.description or "",
             )
@@ -371,7 +372,7 @@ def run_microtask_review(
             )
 
     code_text = "\n\n".join(f"--- {p} ---\n{c}" for p, c in list(files.items()))
-    code_text_12k = code_text[:MAX_REVIEW_CODE_CHARS]
+    code_text_capped = code_text[:MAX_REVIEW_CODE_CHARS]
 
     if code_review_agent is not None:
         if detail_callback:
@@ -419,7 +420,7 @@ def run_microtask_review(
             from qa_agent.models import QAInput as _QAInput
 
             qa_input = _QAInput(
-                code=code_text_12k,
+                code=code_text_capped,
                 language=language,
                 task_description=f"Microtask: {microtask.description or microtask.title}",
             )
@@ -444,7 +445,7 @@ def run_microtask_review(
             from security_agent.models import SecurityInput as _SecInput
 
             sec_input = _SecInput(
-                code=code_text_12k,
+                code=code_text_capped,
                 language=language,
                 task_description=f"Microtask: {microtask.description or microtask.title}",
             )

--- a/backend/agents/software_engineering_team/frontend_code_v2_team/phases/review.py
+++ b/backend/agents/software_engineering_team/frontend_code_v2_team/phases/review.py
@@ -11,6 +11,7 @@ import logging
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from code_review_agent.coordinator import build_review_chunks
 from strands import Agent
 
 from llm_service import LLMClient
@@ -46,29 +47,49 @@ def _run_llm_review(
     task: Task,
     files: Dict[str, str],
 ) -> List[ReviewIssue]:
-    """LLM-based code review when no external review agent is available."""
-    code_text = "\n\n".join(f"--- {p} ---\n{c}" for p, c in list(files.items()))
-    prompt = REVIEW_PROMPT.format(
-        requirements=task.requirements or task.description,
-        acceptance_criteria=", ".join(task.acceptance_criteria)
-        if task.acceptance_criteria
-        else "N/A",
-        code=code_text[:MAX_REVIEW_CODE_CHARS],
-    )
-    raw = (lambda _r: str(_r))(Agent(model=resolve_text_mode_strands_model(llm))(prompt)).strip()
-    data = parse_review_template(raw)
+    """LLM-based code review when no external review agent is available.
+
+    Preconditions:
+        - ``files`` maps file paths to their full source text.
+
+    Postconditions:
+        - Inputs that exceed the per-call budget are split into function-aware
+          chunks (cuts land between whole functions/methods, never mid-body)
+          and every chunk is reviewed; issues from all chunks are returned.
+          No file content is silently truncated away, so a large file's tail is
+          reviewed rather than dropped. Blank files contribute nothing.
+        - Small inputs are reviewed in a single call, as before.
+    """
+    blocks = [(path, content) for path, content in files.items() if content and content.strip()]
+    if not blocks:
+        return []
+    # Budget each prompt at the same per-call size the old code truncated to,
+    # but split at function/method boundaries so no construct is severed and no
+    # file tail is dropped.
     issues: List[ReviewIssue] = []
-    for item in data.get("issues") or []:
-        if isinstance(item, dict):
-            issues.append(
-                ReviewIssue(
-                    source=item.get("source", "code_review"),
-                    severity=item.get("severity", "medium"),
-                    description=item.get("description", ""),
-                    file_path=item.get("file_path", ""),
-                    recommendation=item.get("recommendation", ""),
+    for chunk in build_review_chunks(blocks, MAX_REVIEW_CODE_CHARS):
+        prompt = REVIEW_PROMPT.format(
+            requirements=task.requirements or task.description,
+            acceptance_criteria=", ".join(task.acceptance_criteria)
+            if task.acceptance_criteria
+            else "N/A",
+            code=chunk.content,
+        )
+        raw = (lambda _r: str(_r))(
+            Agent(model=resolve_text_mode_strands_model(llm))(prompt)
+        ).strip()
+        data = parse_review_template(raw)
+        for item in data.get("issues") or []:
+            if isinstance(item, dict):
+                issues.append(
+                    ReviewIssue(
+                        source=item.get("source", "code_review"),
+                        severity=item.get("severity", "medium"),
+                        description=item.get("description", ""),
+                        file_path=item.get("file_path", ""),
+                        recommendation=item.get("recommendation", ""),
+                    )
                 )
-            )
     return issues
 
 
@@ -145,9 +166,7 @@ def run_review(
         except Exception as exc:
             logger.warning("[%s] Linting tool agent failed: %s", task_id, exc)
 
-    code_text = "\n\n".join(
-        f"--- {p} ---\n{c}" for p, c in list(execution_result.files.items())
-    )
+    code_text = "\n\n".join(f"--- {p} ---\n{c}" for p, c in list(execution_result.files.items()))
     code_text_12k = code_text[:MAX_REVIEW_CODE_CHARS]
     if code_review_agent is not None:
         try:
@@ -567,7 +586,9 @@ def run_documentation_self_review(
         )
 
         try:
-            raw = (lambda _r: str(_r))(Agent(model=resolve_text_mode_strands_model(llm))(prompt)).strip()
+            raw = (lambda _r: str(_r))(
+                Agent(model=resolve_text_mode_strands_model(llm))(prompt)
+            ).strip()
         except Exception as exc:
             logger.warning(
                 "Documentation self-review LLM call failed (iteration %d): %s",

--- a/backend/agents/software_engineering_team/frontend_code_v2_team/phases/review.py
+++ b/backend/agents/software_engineering_team/frontend_code_v2_team/phases/review.py
@@ -11,7 +11,6 @@ import logging
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from code_review_agent.coordinator import build_review_chunks
 from strands import Agent
 
 from llm_service import LLMClient
@@ -39,6 +38,10 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 MAX_REVIEW_CODE_CHARS = 60_000  # Generous limit; review all files, not just first 20
+# A file this many chunks deep means an unusually large review; log a warning
+# for cost/rate-limit visibility, but still review every chunk (dropping any
+# would re-introduce the tail truncation this fallback exists to avoid).
+MANY_CHUNKS_WARN_THRESHOLD = 20
 
 
 def _run_llm_review(
@@ -58,8 +61,16 @@ def _run_llm_review(
           and every chunk is reviewed; issues from all chunks are returned.
           No file content is silently truncated away, so a large file's tail is
           reviewed rather than dropped. Blank files contribute nothing.
+        - A chunk whose LLM call or parse fails is logged and skipped; issues
+          from the other chunks are still returned (one bad chunk never aborts
+          the whole review).
         - Small inputs are reviewed in a single call, as before.
     """
+    # Imported lazily, fully-qualified, to match this module's existing
+    # convention for code_review_agent imports and to avoid assuming the
+    # software_engineering_team package dir is itself on sys.path.
+    from software_engineering_team.code_review_agent.coordinator import build_review_chunks
+
     blocks = [(path, content) for path, content in files.items() if content and content.strip()]
     if not blocks:
         return []
@@ -67,7 +78,14 @@ def _run_llm_review(
     # but split at function/method boundaries so no construct is severed and no
     # file tail is dropped.
     chunks = list(build_review_chunks(blocks, MAX_REVIEW_CODE_CHARS))
-    logger.debug("LLM code review: %d chunk(s) for %d file(s)", len(chunks), len(blocks))
+    if len(chunks) > MANY_CHUNKS_WARN_THRESHOLD:
+        logger.warning(
+            "LLM code review: %d chunks for %d file(s) — large review, many LLM calls",
+            len(chunks),
+            len(blocks),
+        )
+    else:
+        logger.debug("LLM code review: %d chunk(s) for %d file(s)", len(chunks), len(blocks))
     issues: List[ReviewIssue] = []
     for idx, chunk in enumerate(chunks, start=1):
         logger.debug("LLM code review: reviewing chunk %d/%d", idx, len(chunks))
@@ -78,8 +96,12 @@ def _run_llm_review(
             else "N/A",
             code=chunk.content,
         )
-        raw = str(Agent(model=resolve_text_mode_strands_model(llm))(prompt)).strip()
-        data = parse_review_template(raw)
+        try:
+            raw = str(Agent(model=resolve_text_mode_strands_model(llm))(prompt)).strip()
+            data = parse_review_template(raw)
+        except Exception as exc:
+            logger.warning("LLM code review: chunk %d/%d failed: %s", idx, len(chunks), exc)
+            continue
         for item in data.get("issues") or []:
             if isinstance(item, dict):
                 issues.append(

--- a/backend/agents/software_engineering_team/tests/test_code_boundaries.py
+++ b/backend/agents/software_engineering_team/tests/test_code_boundaries.py
@@ -98,16 +98,22 @@ def test_heuristic_skips_closing_and_comment_lines() -> None:
             "  body();",  # 2
             "}",  # 3 skipped: closing brace
             "// a comment",  # 4 skipped: line comment
-            "*/",  # 5 skipped: block-comment close
-            "function b() {}",  # 6
+            "/* block open",  # 5 skipped: block-comment open
+            "*/",  # 6 skipped: block-comment close
+            "function b() {}",  # 7
         ]
     )
-    assert preferred_break_lines("m.js", src) == frozenset({1, 6})
+    assert preferred_break_lines("m.js", src) == frozenset({1, 7})
 
 
 def test_unknown_extension_uses_heuristic() -> None:
     src = "rule one\n    indented\nrule two\n"
     assert preferred_break_lines("config.unknown", src) == frozenset({1, 3})
+
+
+def test_empty_path_uses_heuristic() -> None:
+    # An empty path has no extension, so detection falls to the heuristic.
+    assert preferred_break_lines("", "def f(): pass") == frozenset({1})
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/software_engineering_team/tests/test_code_boundaries.py
+++ b/backend/agents/software_engineering_team/tests/test_code_boundaries.py
@@ -56,6 +56,13 @@ def test_python_syntax_error_falls_back_to_heuristic() -> None:
     assert preferred_break_lines("m.py", src) == frozenset({1})
 
 
+def test_python_no_constructs_falls_back_to_heuristic() -> None:
+    # Valid Python with no top-level def/class: ast yields no boundaries, so the
+    # column-0 heuristic takes over and treats each statement line as a break.
+    src = "print('hello')\nx = 1\n"
+    assert preferred_break_lines("m.py", src) == frozenset({1, 2})
+
+
 # ---------------------------------------------------------------------------
 # Heuristic (non-Python) detection
 # ---------------------------------------------------------------------------

--- a/backend/agents/software_engineering_team/tests/test_code_boundaries.py
+++ b/backend/agents/software_engineering_team/tests/test_code_boundaries.py
@@ -1,0 +1,127 @@
+"""Tests for function/method boundary detection used by review chunking.
+
+Pure-function tests: ``preferred_break_lines`` maps source text to the 1-based
+lines that start a top-level construct, and degrades to an empty set whenever it
+cannot find any (the coordinator reads that as "split on line boundaries").
+"""
+
+from __future__ import annotations
+
+from code_review_agent.code_boundaries import preferred_break_lines
+
+# ---------------------------------------------------------------------------
+# Python (ast) detection
+# ---------------------------------------------------------------------------
+
+
+def test_python_returns_each_top_level_construct_start() -> None:
+    src = "\n".join(
+        [
+            "import os",  # 1
+            "",  # 2
+            "def first():",  # 3
+            "    return 1",  # 4
+            "",  # 5
+            "class Foo:",  # 6
+            "    def method(self):",  # 7
+            "        return 2",  # 8
+            "",  # 9
+            "async def third():",  # 10
+            "    return 3",  # 11
+        ]
+    )
+    # Top-level def/class/async-def starts; the nested method is not top-level.
+    assert preferred_break_lines("m.py", src) == frozenset({3, 6, 10})
+
+
+def test_python_decorated_construct_breaks_above_the_decorator() -> None:
+    src = "\n".join(
+        [
+            "import functools",  # 1
+            "",  # 2
+            "@functools.cache",  # 3
+            "@staticmethod",  # 4
+            "def decorated():",  # 5
+            "    return 0",  # 6
+        ]
+    )
+    # The break lands on the first decorator (3), never between a decorator and
+    # its def, so cutting there keeps the whole decorated construct together.
+    assert preferred_break_lines("m.py", src) == frozenset({3})
+
+
+def test_python_syntax_error_falls_back_to_heuristic() -> None:
+    # Unbalanced paren -> ast fails; the column-0 heuristic still finds the def.
+    src = "def broken(:\n    pass\n"
+    assert preferred_break_lines("m.py", src) == frozenset({1})
+
+
+# ---------------------------------------------------------------------------
+# Heuristic (non-Python) detection
+# ---------------------------------------------------------------------------
+
+
+def test_typescript_column_zero_declarations_are_breaks() -> None:
+    src = "\n".join(
+        [
+            "import { x } from './x';",  # 1
+            "",  # 2
+            "export function alpha() {",  # 3
+            "  return 1;",  # 4
+            "}",  # 5 (closing brace, skipped)
+            "",  # 6
+            "const beta = () => {",  # 7
+            "  return 2;",  # 8
+            "};",  # 9 (starts with '}' continuation, skipped)
+            "",  # 10
+            "class Gamma {",  # 11
+            "  method() {",  # 12 (indented, skipped)
+            "    return 3;",  # 13
+            "  }",  # 14
+            "}",  # 15
+        ]
+    )
+    assert preferred_break_lines("m.ts", src) == frozenset({1, 3, 7, 11})
+
+
+def test_heuristic_skips_closing_and_comment_lines() -> None:
+    src = "\n".join(
+        [
+            "function a() {",  # 1
+            "  body();",  # 2
+            "}",  # 3 skipped: closing brace
+            "// a comment",  # 4 skipped: line comment
+            "*/",  # 5 skipped: block-comment close
+            "function b() {}",  # 6
+        ]
+    )
+    assert preferred_break_lines("m.js", src) == frozenset({1, 6})
+
+
+def test_unknown_extension_uses_heuristic() -> None:
+    src = "rule one\n    indented\nrule two\n"
+    assert preferred_break_lines("config.unknown", src) == frozenset({1, 3})
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation
+# ---------------------------------------------------------------------------
+
+
+def test_minified_single_line_has_no_interior_breaks() -> None:
+    src = "function a(){return 1};function b(){return 2};function c(){return 3}"
+    # One physical line -> only line 1, which the splitter never breaks before,
+    # so this degrades to line-boundary splitting.
+    assert preferred_break_lines("min.js", src) == frozenset({1})
+
+
+def test_empty_and_whitespace_content_return_empty() -> None:
+    assert preferred_break_lines("m.py", "") == frozenset()
+    assert preferred_break_lines("m.ts", "   \n\n\t\n") == frozenset()
+
+
+def test_pure_function_no_io_does_not_mutate_inputs() -> None:
+    src = "def f():\n    return 1\n"
+    before = src
+    preferred_break_lines("m.py", src)
+    assert src == before

--- a/backend/agents/software_engineering_team/tests/test_code_boundaries.py
+++ b/backend/agents/software_engineering_team/tests/test_code_boundaries.py
@@ -15,6 +15,7 @@ from code_review_agent.code_boundaries import preferred_break_lines
 
 
 def test_python_returns_each_top_level_construct_start() -> None:
+    """Top-level def/class/async-def start lines are returned; nested methods are not."""
     src = "\n".join(
         [
             "import os",  # 1
@@ -35,6 +36,7 @@ def test_python_returns_each_top_level_construct_start() -> None:
 
 
 def test_python_decorated_construct_breaks_above_the_decorator() -> None:
+    """A decorated def reports its first decorator line, so a cut keeps decorators attached."""
     src = "\n".join(
         [
             "import functools",  # 1
@@ -51,12 +53,14 @@ def test_python_decorated_construct_breaks_above_the_decorator() -> None:
 
 
 def test_python_syntax_error_falls_back_to_heuristic() -> None:
+    """When ast cannot parse the source, detection falls back to the column-0 heuristic."""
     # Unbalanced paren -> ast fails; the column-0 heuristic still finds the def.
     src = "def broken(:\n    pass\n"
     assert preferred_break_lines("m.py", src) == frozenset({1})
 
 
 def test_python_no_constructs_falls_back_to_heuristic() -> None:
+    """Valid Python with no top-level def/class falls through to the heuristic."""
     # Valid Python with no top-level def/class: ast yields no boundaries, so the
     # column-0 heuristic takes over and treats each statement line as a break.
     src = "print('hello')\nx = 1\n"
@@ -69,6 +73,7 @@ def test_python_no_constructs_falls_back_to_heuristic() -> None:
 
 
 def test_typescript_column_zero_declarations_are_breaks() -> None:
+    """Column-0 TS declarations are breaks; indented members and closers are not."""
     src = "\n".join(
         [
             "import { x } from './x';",  # 1
@@ -92,6 +97,7 @@ def test_typescript_column_zero_declarations_are_breaks() -> None:
 
 
 def test_heuristic_skips_closing_and_comment_lines() -> None:
+    """Column-0 closing braces and comment-open/close lines are not treated as breaks."""
     src = "\n".join(
         [
             "function a() {",  # 1
@@ -107,11 +113,13 @@ def test_heuristic_skips_closing_and_comment_lines() -> None:
 
 
 def test_unknown_extension_uses_heuristic() -> None:
+    """An unknown extension routes detection through the column-0 heuristic."""
     src = "rule one\n    indented\nrule two\n"
     assert preferred_break_lines("config.unknown", src) == frozenset({1, 3})
 
 
 def test_empty_path_uses_heuristic() -> None:
+    """An empty path (no extension) routes detection through the heuristic."""
     # An empty path has no extension, so detection falls to the heuristic.
     assert preferred_break_lines("", "def f(): pass") == frozenset({1})
 
@@ -122,6 +130,7 @@ def test_empty_path_uses_heuristic() -> None:
 
 
 def test_minified_single_line_has_no_interior_breaks() -> None:
+    """A one-line minified file yields only line 1, so the splitter degrades to line boundaries."""
     src = "function a(){return 1};function b(){return 2};function c(){return 3}"
     # One physical line -> only line 1, which the splitter never breaks before,
     # so this degrades to line-boundary splitting.
@@ -129,11 +138,13 @@ def test_minified_single_line_has_no_interior_breaks() -> None:
 
 
 def test_empty_and_whitespace_content_return_empty() -> None:
+    """Empty or whitespace-only content returns an empty set (no breaks)."""
     assert preferred_break_lines("m.py", "") == frozenset()
     assert preferred_break_lines("m.ts", "   \n\n\t\n") == frozenset()
 
 
 def test_pure_function_no_io_does_not_mutate_inputs() -> None:
+    """preferred_break_lines is pure: it does not mutate its content argument."""
     src = "def f():\n    return 1\n"
     before = src
     preferred_break_lines("m.py", src)

--- a/backend/agents/software_engineering_team/tests/test_code_review_coordinator.py
+++ b/backend/agents/software_engineering_team/tests/test_code_review_coordinator.py
@@ -394,6 +394,83 @@ def test_split_never_breaks_a_line_even_when_oversized() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Function-aware splitting: cuts land between whole constructs, never mid-body
+# ---------------------------------------------------------------------------
+
+
+def _python_functions(n_funcs: int, body_lines: int = 8) -> str:
+    """A .py file of equal-sized top-level functions, blank-line separated."""
+    parts: List[str] = []
+    for f in range(1, n_funcs + 1):
+        parts.append(f"def func_{f:03d}():")
+        for b in range(body_lines):
+            parts.append(f"    value_{f:03d}_{b} = compute({b})  " + "y" * 20)
+        parts.append("")
+    return "\n".join(parts)
+
+
+def _ts_functions(n_funcs: int, body_lines: int = 8) -> str:
+    """A .ts file of equal-sized top-level functions with column-0 braces."""
+    parts: List[str] = []
+    for f in range(1, n_funcs + 1):
+        parts.append(f"function fn_{f:03d}() {{")
+        for b in range(body_lines):
+            parts.append(f"  const value_{f:03d}_{b} = compute({b});  " + "z" * 20)
+        parts.append("}")
+        parts.append("")
+    return "\n".join(parts)
+
+
+def test_split_breaks_at_function_boundary_python() -> None:
+    content = _python_functions(12)  # ~12 functions, each well under the budget
+    segments = split_block_into_segments("svc.py", content, max_chars=1_500)
+    assert len(segments) > 1
+    # Every segment begins at a top-level ``def`` — no function is severed.
+    for seg in segments:
+        assert seg.content.splitlines()[0].startswith("def func_")
+    # No function start is lost or duplicated, and content reassembles exactly.
+    assert sum(s.content.count("def func_") for s in segments) == 12
+    assert "".join(s.content for s in segments) == content
+    assert all(len(s.prompt_content) <= 1_500 for s in segments)
+
+
+def test_split_breaks_at_function_boundary_typescript() -> None:
+    content = _ts_functions(12)
+    segments = split_block_into_segments("widget.ts", content, max_chars=1_500)
+    assert len(segments) > 1
+    for seg in segments:
+        assert seg.content.splitlines()[0].startswith("function fn_")
+    assert sum(s.content.count("function fn_") for s in segments) == 12
+    assert "".join(s.content for s in segments) == content
+    assert all(len(s.prompt_content) <= 1_500 for s in segments)
+
+
+def test_split_falls_back_to_line_boundary_when_no_constructs() -> None:
+    # One giant function larger than the budget: its only construct boundary is
+    # line 1, which the splitter never cuts before, so it degrades to splitting
+    # on line boundaries within the function body.
+    body = "\n".join(f"    step_{i:04d} = run({i})  " + "y" * 20 for i in range(300))
+    content = "def one_big_function():\n" + body
+    segments = split_block_into_segments("mono.py", content, max_chars=2_000)
+    assert len(segments) > 1
+    assert "".join(s.content for s in segments) == content
+    assert all(len(s.prompt_content) <= 2_000 for s in segments)
+
+
+def test_split_function_aware_keeps_contiguous_line_bookkeeping() -> None:
+    content = _python_functions(10)
+    segments = split_block_into_segments("svc.py", content, max_chars=1_200)
+    assert len(segments) > 1
+    assert "".join(s.content for s in segments) == content
+    assert segments[0].start_line == 1
+    for prev, cur in zip(segments, segments[1:]):
+        assert cur.start_line == prev.end_line + 1
+    total_lines = len(content.splitlines())
+    assert segments[-1].end_line == total_lines
+    assert all(s.total_lines == total_lines for s in segments)
+
+
+# ---------------------------------------------------------------------------
 # pre_numbered: explicit producer flag (never sniffed from content)
 # ---------------------------------------------------------------------------
 

--- a/backend/agents/software_engineering_team/tests/test_code_review_coordinator.py
+++ b/backend/agents/software_engineering_team/tests/test_code_review_coordinator.py
@@ -422,6 +422,7 @@ def _ts_functions(n_funcs: int, body_lines: int = 8) -> str:
 
 
 def test_split_breaks_at_function_boundary_python() -> None:
+    """An oversized .py file splits at top-level def boundaries, never mid-function."""
     content = _python_functions(12)  # ~12 functions, each well under the budget
     segments = split_block_into_segments("svc.py", content, max_chars=1_500)
     assert len(segments) > 1
@@ -435,6 +436,7 @@ def test_split_breaks_at_function_boundary_python() -> None:
 
 
 def test_split_breaks_at_function_boundary_typescript() -> None:
+    """An oversized .ts file splits at top-level function boundaries via the heuristic."""
     content = _ts_functions(12)
     segments = split_block_into_segments("widget.ts", content, max_chars=1_500)
     assert len(segments) > 1
@@ -446,6 +448,7 @@ def test_split_breaks_at_function_boundary_typescript() -> None:
 
 
 def test_split_falls_back_to_line_boundary_when_no_constructs() -> None:
+    """A single oversized function with no interior boundary degrades to line splitting."""
     # One giant function larger than the budget: its only construct boundary is
     # line 1, which the splitter never cuts before, so it degrades to splitting
     # on line boundaries within the function body.
@@ -458,6 +461,7 @@ def test_split_falls_back_to_line_boundary_when_no_constructs() -> None:
 
 
 def test_split_function_aware_keeps_contiguous_line_bookkeeping() -> None:
+    """Function-aware cuts keep start/end line bookkeeping contiguous and exact."""
     content = _python_functions(10)
     segments = split_block_into_segments("svc.py", content, max_chars=1_200)
     assert len(segments) > 1

--- a/backend/agents/software_engineering_team/tests/test_v2_fe_review_phase.py
+++ b/backend/agents/software_engineering_team/tests/test_v2_fe_review_phase.py
@@ -76,6 +76,44 @@ def test_fe_run_llm_review(monkeypatch):
     assert len(issues) == 1
 
 
+def test_fe_run_llm_review_chunks_large_file_without_dropping_tail(monkeypatch):
+    """The frontend fallback splits a too-large file into function-aware chunks,
+    so its tail is reviewed instead of truncated (mirrors the backend test)."""
+    from software_engineering_team.frontend_code_v2_team.phases import review as review_mod
+    from software_engineering_team.frontend_code_v2_team.phases.review import (
+        MAX_REVIEW_CODE_CHARS,
+        _run_llm_review,
+    )
+
+    prompts: list[str] = []
+    clean = (
+        "## PASSED ##\ntrue\n## END PASSED ##\n"
+        "## ISSUES ##\n## END ISSUES ##\n"
+        "## SUMMARY ##\nok\n## END SUMMARY ##\n"
+    )
+
+    class _RecordingAgent:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __call__(self, prompt):
+            prompts.append(prompt)
+            return clean
+
+    monkeypatch.setattr(review_mod, "Agent", lambda *a, **kw: _RecordingAgent())
+    monkeypatch.setattr(review_mod, "resolve_text_mode_strands_model", lambda llm: object())
+
+    big = "\n".join(f"function fn_{i:04d}() {{\n  return {i};\n}}" for i in range(2500))
+    assert len(big) > MAX_REVIEW_CODE_CHARS  # forces more than one chunk
+
+    _run_llm_review(llm=MagicMock(), task=_task(), files={"big.ts": big})
+
+    assert len(prompts) > 1  # chunked, not a single truncated call
+    joined = "\n".join(prompts)
+    assert "fn_0000" in joined  # head reviewed
+    assert "fn_2499" in joined  # tail reviewed — old truncation dropped this
+
+
 def test_fe_run_review_clean(monkeypatch, tmp_path: Path):
     from software_engineering_team.frontend_code_v2_team.phases import review as review_mod
     from software_engineering_team.frontend_code_v2_team.phases.review import run_review
@@ -98,7 +136,9 @@ def test_fe_run_review_build_fails(monkeypatch, tmp_path: Path):
     from software_engineering_team.frontend_code_v2_team.phases import review as review_mod
     from software_engineering_team.frontend_code_v2_team.phases.review import run_review
 
-    monkeypatch.setattr(review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n"))
+    monkeypatch.setattr(
+        review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n")
+    )
     monkeypatch.setattr(review_mod, "resolve_text_mode_strands_model", lambda llm: object())
 
     out = run_review(
@@ -116,7 +156,9 @@ def test_fe_run_review_with_qa_agent(monkeypatch, tmp_path: Path):
     from software_engineering_team.frontend_code_v2_team.phases import review as review_mod
     from software_engineering_team.frontend_code_v2_team.phases.review import run_review
 
-    monkeypatch.setattr(review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n"))
+    monkeypatch.setattr(
+        review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n")
+    )
     monkeypatch.setattr(review_mod, "resolve_text_mode_strands_model", lambda llm: object())
 
     qa_agent = MagicMock()
@@ -143,7 +185,9 @@ def test_fe_run_review_with_linting_failures(monkeypatch, tmp_path: Path):
     from software_engineering_team.frontend_code_v2_team.phases import review as review_mod
     from software_engineering_team.frontend_code_v2_team.phases.review import run_review
 
-    monkeypatch.setattr(review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n"))
+    monkeypatch.setattr(
+        review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n")
+    )
     monkeypatch.setattr(review_mod, "resolve_text_mode_strands_model", lambda llm: object())
 
     class _Issue:
@@ -172,7 +216,9 @@ def test_fe_run_review_with_security_agent(monkeypatch, tmp_path: Path):
     from software_engineering_team.frontend_code_v2_team.phases import review as review_mod
     from software_engineering_team.frontend_code_v2_team.phases.review import run_review
 
-    monkeypatch.setattr(review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n"))
+    monkeypatch.setattr(
+        review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n")
+    )
     monkeypatch.setattr(review_mod, "resolve_text_mode_strands_model", lambda llm: object())
 
     sec_agent = MagicMock()
@@ -199,7 +245,9 @@ def test_fe_run_review_with_code_review_agent(monkeypatch, tmp_path: Path):
     from software_engineering_team.frontend_code_v2_team.phases import review as review_mod
     from software_engineering_team.frontend_code_v2_team.phases.review import run_review
 
-    monkeypatch.setattr(review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n"))
+    monkeypatch.setattr(
+        review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n")
+    )
     monkeypatch.setattr(review_mod, "resolve_text_mode_strands_model", lambda llm: object())
 
     cr_agent = MagicMock()
@@ -259,7 +307,9 @@ def test_fe_run_review_with_tool_agents(monkeypatch, tmp_path: Path):
     from software_engineering_team.frontend_code_v2_team.phases import review as review_mod
     from software_engineering_team.frontend_code_v2_team.phases.review import run_review
 
-    monkeypatch.setattr(review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n"))
+    monkeypatch.setattr(
+        review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n")
+    )
     monkeypatch.setattr(review_mod, "resolve_text_mode_strands_model", lambda llm: object())
 
     tool_agent = MagicMock()

--- a/backend/agents/software_engineering_team/tests/test_v2_fe_review_phase.py
+++ b/backend/agents/software_engineering_team/tests/test_v2_fe_review_phase.py
@@ -114,6 +114,48 @@ def test_fe_run_llm_review_chunks_large_file_without_dropping_tail(monkeypatch):
     assert "fn_2499" in joined  # tail reviewed — old truncation dropped this
 
 
+def test_fe_run_llm_review_skips_failing_chunk_keeps_others(monkeypatch):
+    """A failing chunk is logged and skipped; the frontend review keeps the
+    other chunks' issues (mirrors the backend resilience test)."""
+    from software_engineering_team.frontend_code_v2_team.phases import review as review_mod
+    from software_engineering_team.frontend_code_v2_team.phases.review import (
+        MAX_REVIEW_CODE_CHARS,
+        _run_llm_review,
+    )
+
+    good = (
+        "## PASSED ##\nfalse\n## END PASSED ##\n"
+        "## ISSUES ##\n"
+        "description: real issue\nseverity: high\nfile_path: big.ts\nsource: code_review\n"
+        "## END ISSUES ##\n"
+        "## SUMMARY ##\nbad\n## END SUMMARY ##\n"
+    )
+    calls = {"n": 0}
+
+    class _FlakyAgent:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __call__(self, prompt):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("model unavailable")
+            return good
+
+    monkeypatch.setattr(review_mod, "Agent", lambda *a, **kw: _FlakyAgent())
+    monkeypatch.setattr(review_mod, "resolve_text_mode_strands_model", lambda llm: object())
+    monkeypatch.setattr(review_mod, "MANY_CHUNKS_WARN_THRESHOLD", 0)
+
+    big = "\n".join(f"function fn_{i:04d}() {{\n  return {i};\n}}" for i in range(2500))
+    assert len(big) > MAX_REVIEW_CODE_CHARS  # forces more than one chunk
+
+    issues = _run_llm_review(llm=MagicMock(), task=_task(), files={"big.ts": big})
+
+    assert calls["n"] > 1
+    assert len(issues) >= 1
+    assert all(i.description == "real issue" for i in issues)
+
+
 def test_fe_run_review_clean(monkeypatch, tmp_path: Path):
     from software_engineering_team.frontend_code_v2_team.phases import review as review_mod
     from software_engineering_team.frontend_code_v2_team.phases.review import run_review

--- a/backend/agents/software_engineering_team/tests/test_v2_review_phase.py
+++ b/backend/agents/software_engineering_team/tests/test_v2_review_phase.py
@@ -97,6 +97,49 @@ def test_run_llm_review_chunks_large_file_without_dropping_tail(monkeypatch):
     assert "fn_2499" in joined  # tail reviewed — old truncation dropped this
 
 
+def test_run_llm_review_skips_failing_chunk_keeps_others(monkeypatch):
+    """A chunk whose LLM call raises is logged and skipped; issues from the
+    other chunks survive instead of the whole review aborting."""
+    from software_engineering_team.backend_code_v2_team.phases import review as review_mod
+    from software_engineering_team.backend_code_v2_team.phases.review import (
+        MAX_REVIEW_CODE_CHARS,
+        _run_llm_review,
+    )
+
+    good = (
+        "## PASSED ##\nfalse\n## END PASSED ##\n"
+        "## ISSUES ##\n"
+        "description: real issue\nseverity: high\nfile_path: big.py\nsource: code_review\n"
+        "## END ISSUES ##\n"
+        "## SUMMARY ##\nbad\n## END SUMMARY ##\n"
+    )
+    calls = {"n": 0}
+
+    class _FlakyAgent:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __call__(self, prompt):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("model unavailable")
+            return good
+
+    monkeypatch.setattr(review_mod, "Agent", lambda *a, **kw: _FlakyAgent())
+    monkeypatch.setattr(review_mod, "resolve_text_mode_strands_model", lambda llm: object())
+    # Force the "many chunks" warning path too, so a large review logs visibly.
+    monkeypatch.setattr(review_mod, "MANY_CHUNKS_WARN_THRESHOLD", 0)
+
+    big = "\n".join(f"def fn_{i:04d}():\n    return {i}" for i in range(2500))
+    assert len(big) > MAX_REVIEW_CODE_CHARS  # forces more than one chunk
+
+    issues = _run_llm_review(llm=MagicMock(), task=_task(), files={"big.py": big})
+
+    assert calls["n"] > 1  # every chunk was attempted
+    assert len(issues) >= 1  # the failed first chunk did not abort the review
+    assert all(i.description == "real issue" for i in issues)
+
+
 def test_run_build_verification_no_verifier():
     from software_engineering_team.backend_code_v2_team.phases.review import _run_build_verification
 
@@ -152,7 +195,9 @@ def test_run_review_build_fails(monkeypatch, tmp_path: Path):
     from software_engineering_team.backend_code_v2_team.phases import review as review_mod
     from software_engineering_team.backend_code_v2_team.phases.review import run_review
 
-    monkeypatch.setattr(review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n"))
+    monkeypatch.setattr(
+        review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n")
+    )
     monkeypatch.setattr(review_mod, "resolve_text_mode_strands_model", lambda llm: object())
 
     result = run_review(
@@ -171,7 +216,9 @@ def test_run_review_with_external_qa_agent(monkeypatch, tmp_path: Path):
     from software_engineering_team.backend_code_v2_team.phases import review as review_mod
     from software_engineering_team.backend_code_v2_team.phases.review import run_review
 
-    monkeypatch.setattr(review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n"))
+    monkeypatch.setattr(
+        review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n")
+    )
     monkeypatch.setattr(review_mod, "resolve_text_mode_strands_model", lambda llm: object())
 
     qa_agent = MagicMock()
@@ -198,7 +245,9 @@ def test_run_review_qa_agent_raises(monkeypatch, tmp_path: Path):
     from software_engineering_team.backend_code_v2_team.phases import review as review_mod
     from software_engineering_team.backend_code_v2_team.phases.review import run_review
 
-    monkeypatch.setattr(review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n"))
+    monkeypatch.setattr(
+        review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n")
+    )
     monkeypatch.setattr(review_mod, "resolve_text_mode_strands_model", lambda llm: object())
 
     qa_agent = MagicMock()
@@ -219,7 +268,9 @@ def test_run_review_with_security_agent(monkeypatch, tmp_path: Path):
     from software_engineering_team.backend_code_v2_team.phases import review as review_mod
     from software_engineering_team.backend_code_v2_team.phases.review import run_review
 
-    monkeypatch.setattr(review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n"))
+    monkeypatch.setattr(
+        review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n")
+    )
     monkeypatch.setattr(review_mod, "resolve_text_mode_strands_model", lambda llm: object())
 
     sec_agent = MagicMock()
@@ -246,7 +297,9 @@ def test_run_review_with_code_review_agent(monkeypatch, tmp_path: Path):
     from software_engineering_team.backend_code_v2_team.phases import review as review_mod
     from software_engineering_team.backend_code_v2_team.phases.review import run_review
 
-    monkeypatch.setattr(review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n"))
+    monkeypatch.setattr(
+        review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n")
+    )
     monkeypatch.setattr(review_mod, "resolve_text_mode_strands_model", lambda llm: object())
 
     cr_agent = MagicMock()
@@ -303,7 +356,9 @@ def test_run_review_with_linting_agent_pass(monkeypatch, tmp_path: Path):
     from software_engineering_team.backend_code_v2_team.phases import review as review_mod
     from software_engineering_team.backend_code_v2_team.phases.review import run_review
 
-    monkeypatch.setattr(review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n"))
+    monkeypatch.setattr(
+        review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n")
+    )
     monkeypatch.setattr(review_mod, "resolve_text_mode_strands_model", lambda llm: object())
 
     lint_agent = MagicMock()
@@ -327,7 +382,9 @@ def test_run_review_with_linting_agent_failures(monkeypatch, tmp_path: Path):
     from software_engineering_team.backend_code_v2_team.phases import review as review_mod
     from software_engineering_team.backend_code_v2_team.phases.review import run_review
 
-    monkeypatch.setattr(review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n"))
+    monkeypatch.setattr(
+        review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n")
+    )
     monkeypatch.setattr(review_mod, "resolve_text_mode_strands_model", lambda llm: object())
 
     class _LintIssue:
@@ -361,7 +418,9 @@ def test_run_review_with_tool_agents(monkeypatch, tmp_path: Path):
     from software_engineering_team.backend_code_v2_team.phases import review as review_mod
     from software_engineering_team.backend_code_v2_team.phases.review import run_review
 
-    monkeypatch.setattr(review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n"))
+    monkeypatch.setattr(
+        review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n")
+    )
     monkeypatch.setattr(review_mod, "resolve_text_mode_strands_model", lambda llm: object())
 
     tool_agent = MagicMock()
@@ -402,7 +461,9 @@ def test_run_review_tool_agent_raises(monkeypatch, tmp_path: Path):
     from software_engineering_team.backend_code_v2_team.phases import review as review_mod
     from software_engineering_team.backend_code_v2_team.phases.review import run_review
 
-    monkeypatch.setattr(review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n"))
+    monkeypatch.setattr(
+        review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n")
+    )
     monkeypatch.setattr(review_mod, "resolve_text_mode_strands_model", lambda llm: object())
 
     tool_agent = MagicMock()
@@ -424,7 +485,9 @@ def test_run_review_tool_agent_without_review_method(monkeypatch, tmp_path: Path
     from software_engineering_team.backend_code_v2_team.phases import review as review_mod
     from software_engineering_team.backend_code_v2_team.phases.review import run_review
 
-    monkeypatch.setattr(review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n"))
+    monkeypatch.setattr(
+        review_mod, "Agent", lambda *a, **kw: _StubAgent("## PASSED ##\ntrue\n## END PASSED ##\n")
+    )
     monkeypatch.setattr(review_mod, "resolve_text_mode_strands_model", lambda llm: object())
 
     bare = object()  # no .review method

--- a/backend/agents/software_engineering_team/tests/test_v2_review_phase.py
+++ b/backend/agents/software_engineering_team/tests/test_v2_review_phase.py
@@ -59,6 +59,44 @@ def test_run_llm_review_parses_issues(monkeypatch):
     assert len(issues) == 1
 
 
+def test_run_llm_review_chunks_large_file_without_dropping_tail(monkeypatch):
+    """A file larger than one prompt budget is reviewed in function-aware
+    chunks, so its tail is seen by the reviewer instead of being truncated."""
+    from software_engineering_team.backend_code_v2_team.phases import review as review_mod
+    from software_engineering_team.backend_code_v2_team.phases.review import (
+        MAX_REVIEW_CODE_CHARS,
+        _run_llm_review,
+    )
+
+    prompts: list[str] = []
+    clean = (
+        "## PASSED ##\ntrue\n## END PASSED ##\n"
+        "## ISSUES ##\n## END ISSUES ##\n"
+        "## SUMMARY ##\nok\n## END SUMMARY ##\n"
+    )
+
+    class _RecordingAgent:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __call__(self, prompt):
+            prompts.append(prompt)
+            return clean
+
+    monkeypatch.setattr(review_mod, "Agent", lambda *a, **kw: _RecordingAgent())
+    monkeypatch.setattr(review_mod, "resolve_text_mode_strands_model", lambda llm: object())
+
+    big = "\n".join(f"def fn_{i:04d}():\n    return {i}" for i in range(2500))
+    assert len(big) > MAX_REVIEW_CODE_CHARS  # forces more than one chunk
+
+    _run_llm_review(llm=MagicMock(), task=_task(), files={"big.py": big})
+
+    assert len(prompts) > 1  # chunked, not a single truncated call
+    joined = "\n".join(prompts)
+    assert "fn_0000" in joined  # head reviewed
+    assert "fn_2499" in joined  # tail reviewed — old truncation dropped this
+
+
 def test_run_build_verification_no_verifier():
     from software_engineering_team.backend_code_v2_team.phases.review import _run_build_verification
 


### PR DESCRIPTION
## Summary

Large files that don't fit in the review LLM context were reduced in a way that could sever a function across the cut, so the reviewer saw partial code and raised erroneous findings. This makes the splitting function-aware.

- **New `code_review_agent/code_boundaries.py`** — `preferred_break_lines(path, content)`, a pure detector that names the lines starting a top-level construct: Python via `ast` (decorator-aware), other languages via a column-0 heuristic. Returns nothing it cannot parse (partial/minified/unknown), so callers degrade safely.
- **`coordinator.py::split_block_into_segments`** now backs an over-budget cut up to the nearest construct boundary in the buffer, falling back to the line boundary when none exists. All existing postconditions are preserved: exact reassembly, per-segment budget, whole-file fast path, original-absolute line numbering. `pre_numbered` diff hunks keep their byte-for-byte line-boundary behavior.
- **V2 fallback (`backend_code_v2_team` + `frontend_code_v2_team` `_run_llm_review`)** is routed through the same function-aware chunking instead of `code_text[:60_000]` truncation — inputs over the per-call budget are split into complete-construct chunks and every chunk is reviewed, so a large file's tail is reviewed rather than dropped.

## Tests

- New `tests/test_code_boundaries.py` (100% coverage of the new module): Python def/class/decorator detection, syntax-error fallback, TS/JS column-0 detection, comment/closing-brace exclusion, minified/empty degradation.
- New coordinator tests: cuts land on function boundaries for Python and TypeScript, line-boundary fallback for a single oversized function, contiguous line bookkeeping.
- New V2 test: a file larger than one prompt budget is chunked so its tail is reviewed (the old truncation dropped it).
- Full related suite green (`code_review_*`, `chunk_reviewer`, `v2_review_phase`, `v2_fe_review_phase`, `microtask_review_gates`); ruff clean.

## Out of scope (tracked separately)

- QA/Security agents still receive a single capped code string (their own input contract) — #876.
- Frontend documentation self-review still triple-truncates — #877.

Closes #875

---
_Generated by [Claude Code](https://claude.ai/code/session_015v7d7WVFehPWtrHxvdfGUX)_