### PR TITLE
Make team-service worker deaths debuggable; idempotent OTel instrumentation

### DIFF
--- a/backend/agents/coding_team/orchestrator.py
+++ b/backend/agents/coding_team/orchestrator.py
@@ -1067,8 +1067,12 @@ class CodingTeamSwarm:
 
         except ImportError:
             logger.debug("Quality gate tools not available; skipping")
-        except Exception as e:
-            logger.warning("Quality gate tools error for task %s: %s; proceeding", task.id, e)
+        except Exception:
+            # Log the full traceback, not a one-line summary: a real bug in the
+            # review path (e.g. an OOM-precursor or a malformed evidence payload)
+            # must be debuggable. The swarm still proceeds — a failed gate must
+            # never abort the whole run — but the stack is now in the logs.
+            logger.exception("Quality gate tools error for task %s; proceeding", task.id)
 
         return True
 

--- a/backend/agents/coding_team/tests/test_swarm_review.py
+++ b/backend/agents/coding_team/tests/test_swarm_review.py
@@ -680,6 +680,26 @@ def test_quality_gate_tool_exception_proceeds_to_review(tmp_path, monkeypatch):
     assert graph.get_task("t1").status == TaskStatus.IN_REVIEW  # proceeded despite the tool error
 
 
+def test_quality_gate_tool_exception_logs_full_traceback(tmp_path, monkeypatch, caplog):
+    """An unexpected quality-gate tool error must be logged WITH a full traceback
+    (logger.exception → ERROR + exc_info), not a one-line WARNING — a silent
+    summary is exactly what made the review-phase crash undebuggable."""
+    import logging as _logging
+
+    _patch_gates(monkeypatch, build_raises=True)  # build() raises RuntimeError("tool crashed")
+    swarm, graph = _make_real_swarm(tmp_path)
+
+    with caplog.at_level(_logging.ERROR, logger="coding_team.orchestrator"):
+        swarm._implement_and_verify(swarm.workers[0], lambda **kw: None)
+
+    gate_errors = [r for r in caplog.records if "Quality gate tools error" in r.getMessage()]
+    assert gate_errors, "the quality-gate tool error must be logged"
+    record = gate_errors[0]
+    assert record.levelno == _logging.ERROR  # logger.exception logs at ERROR
+    assert record.exc_info is not None  # full traceback attached, not a bare string
+    assert "tool crashed" in _logging.Formatter().format(record)  # the cause is in the trace
+
+
 # ----------------------------------------------------- un-assignment / double-assignment guard
 
 

--- a/backend/agents/shared_observability/__init__.py
+++ b/backend/agents/shared_observability/__init__.py
@@ -48,12 +48,18 @@ from shared_observability.otel import (
     is_otel_enabled,
     shutdown_otel,
 )
+from shared_observability.process_health import (
+    install_fault_diagnostics,
+    start_memory_watchdog,
+)
 
 __all__ = [
     "get_meter",
     "get_tracer",
     "init_otel",
+    "install_fault_diagnostics",
     "instrument_fastapi_app",
     "is_otel_enabled",
     "shutdown_otel",
+    "start_memory_watchdog",
 ]

--- a/backend/agents/shared_observability/otel.py
+++ b/backend/agents/shared_observability/otel.py
@@ -246,12 +246,28 @@ def _install_global_instrumentors() -> None:
 
 
 def instrument_fastapi_app(app: Any, *, team_key: Optional[str] = None) -> None:
-    """Attach the FastAPI instrumentor to a team's app.
+    """Attach the FastAPI instrumentor to a team's app — idempotently.
 
-    Must be called after the app is created. No-ops if OpenTelemetry is
-    not initialized or the instrumentor package is missing.
+    Teams that own their FastAPI app self-instrument at import time, and the
+    generic team-service wrapper instruments again on every worker boot. The
+    underlying ``FastAPIInstrumentor`` is *not* idempotent: a second call emits a
+    confusing ``Attempting to instrument FastAPI app while already instrumented``
+    WARNING that muddies crash debugging. A sentinel attribute makes the repeat
+    call a quiet no-op instead.
+
+    Preconditions:
+        - ``app`` accepts attribute assignment (a FastAPI instance does).
+    Postconditions:
+        - When OpenTelemetry is enabled, ``app`` is instrumented exactly once
+          across any number of calls and ``app._khala_otel_instrumented`` is True.
+        - No-ops (returns without raising) when OpenTelemetry is not initialized,
+          the instrumentor package is missing, or the app was already
+          instrumented by a prior call.
     """
     if not _enabled:
+        return
+    if getattr(app, "_khala_otel_instrumented", False):
+        logger.debug("FastAPI already instrumented for team=%s; skipping", team_key or _team_key)
         return
     try:
         from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
@@ -260,6 +276,7 @@ def instrument_fastapi_app(app: Any, *, team_key: Optional[str] = None) -> None:
             app,
             excluded_urls="health,healthz,ready,metrics",
         )
+        app._khala_otel_instrumented = True
         logger.debug("FastAPI instrumented for team=%s", team_key or _team_key)
     except Exception as exc:
         logger.warning("FastAPI instrumentation failed: %s", exc)

--- a/backend/agents/shared_observability/process_health.py
+++ b/backend/agents/shared_observability/process_health.py
@@ -1,0 +1,379 @@
+"""Process-health diagnostics shared by every Khala team microservice.
+
+Turns "the worker just died with no traceback" into something debuggable:
+
+* :func:`install_fault_diagnostics` arms :mod:`faulthandler` (so a native
+  fault — SIGSEGV / SIGABRT / SIGBUS / SIGFPE / SIGILL — dumps a Python stack to
+  stderr instead of vanishing) and routes uncaught exceptions from the main
+  thread *and* worker threads through :mod:`logging` with a full traceback.
+* :func:`start_memory_watchdog` runs a tiny daemon thread that samples the
+  process RSS and logs a WARNING as it approaches the cgroup / env memory
+  budget, so the last line before an OOM-kill names the cause — the kernel's
+  SIGKILL itself is uncatchable and otherwise leaves no trace at all.
+
+Everything here is best-effort and import-safe: a missing ``/proc``, missing
+cgroup files, or a platform without :mod:`faulthandler` degrade to no-ops and
+never raise, so arming diagnostics can never stop a service from booting.
+
+Environment variables (all parse defensively — garbage falls back to the
+documented default, out-of-range values clamp to the floor/ceiling):
+
+* ``TEAM_MEMORY_WATCHDOG_ENABLED`` — master switch (default ``true``).
+* ``TEAM_MEMORY_WATCHDOG_LIMIT_MB`` — override the detected memory budget, in MB.
+* ``TEAM_MEMORY_WATCHDOG_THRESHOLD`` — warn fraction in ``(0, 1]`` (default 0.85).
+* ``TEAM_MEMORY_WATCHDOG_INTERVAL_S`` — sample interval in seconds (default 30).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+from typing import Callable, Optional
+
+# cgroup files live at fixed paths; expose them as module constants so tests can
+# point them at temp files without monkeypatching ``open``.
+_CGROUP_V2_MAX = "/sys/fs/cgroup/memory.max"
+_CGROUP_V1_LIMIT = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+_PROC_STATUS = "/proc/self/status"
+
+# Values at/above this are the kernel's "no limit" sentinels (cgroup v1 reports
+# something near ``PAGE_COUNTER_MAX``; v2 reports the literal string ``max``).
+_UNLIMITED_BYTES = 1 << 62
+
+_DEFAULT_INTERVAL_S = 30.0
+_DEFAULT_THRESHOLD = 0.85
+
+_log: Optional[logging.Logger] = None
+_diagnostics_installed = False
+_original_sys_excepthook = sys.excepthook
+
+
+def _get_logger() -> logging.Logger:
+    """Return the logger diagnostics should write to (set by install, else default)."""
+    return _log if _log is not None else logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Defensive env parsing
+# ---------------------------------------------------------------------------
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _env_float(
+    name: str,
+    default: float,
+    *,
+    minimum: Optional[float] = None,
+    maximum: Optional[float] = None,
+) -> float:
+    raw = os.environ.get(name)
+    value = default
+    if raw is not None and raw.strip():
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            value = default
+    if minimum is not None and value < minimum:
+        value = minimum
+    if maximum is not None and value > maximum:
+        value = maximum
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Memory accounting
+# ---------------------------------------------------------------------------
+
+
+def _mb(num_bytes: int) -> int:
+    """Render a byte count as whole megabytes for human-readable log lines."""
+    return int(num_bytes / (1024 * 1024))
+
+
+def _read_int_file(path: str) -> Optional[int]:
+    """Read a single integer from *path*, or None if absent / non-numeric / 'max'."""
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            raw = fh.read().strip()
+    except OSError:
+        return None
+    if not raw or raw == "max":
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def read_rss_bytes(status_path: str = _PROC_STATUS) -> Optional[int]:
+    """Return the process resident set size (RSS) in bytes, or None if unavailable.
+
+    Preconditions:
+        - ``status_path`` points at a ``/proc/<pid>/status``-formatted file.
+    Postconditions:
+        - Returns a non-negative byte count parsed from the ``VmRSS:`` line, or
+          None when the file is missing/unreadable or has no ``VmRSS:`` entry.
+          Never raises.
+    """
+    try:
+        with open(status_path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                if line.startswith("VmRSS:"):
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        try:
+                            # /proc reports VmRSS in kB.
+                            return int(parts[1]) * 1024
+                        except (TypeError, ValueError):
+                            return None
+    except OSError:
+        return None
+    return None
+
+
+def detect_memory_limit_bytes() -> Optional[int]:
+    """Return the process memory budget in bytes, or None when there is no limit.
+
+    Resolution order: ``TEAM_MEMORY_WATCHDOG_LIMIT_MB`` env override → cgroup v2
+    ``memory.max`` → cgroup v1 ``memory.limit_in_bytes``. Kernel "unlimited"
+    sentinels are treated as no limit.
+
+    Postconditions:
+        - Returns a positive byte count, or None. Never raises.
+    """
+    raw = os.environ.get("TEAM_MEMORY_WATCHDOG_LIMIT_MB")
+    if raw and raw.strip():
+        try:
+            mb = int(float(raw))
+            if mb > 0:
+                return mb * 1024 * 1024
+        except (TypeError, ValueError):
+            pass
+
+    for path in (_CGROUP_V2_MAX, _CGROUP_V1_LIMIT):
+        value = _read_int_file(path)
+        if value is not None and 0 < value < _UNLIMITED_BYTES:
+            return value
+    return None
+
+
+def evaluate_memory_pressure(rss_bytes: int, limit_bytes: int, threshold: float) -> bool:
+    """Return True when RSS has reached ``threshold`` of the memory limit.
+
+    Preconditions:
+        - ``rss_bytes >= 0``.
+        - ``limit_bytes > 0``.
+        - ``0 < threshold <= 1``.
+    Postconditions:
+        - Returns ``rss_bytes >= limit_bytes * threshold``; no side effects.
+    """
+    assert rss_bytes >= 0, "rss_bytes must be non-negative"
+    assert limit_bytes > 0, "limit_bytes must be positive"
+    assert 0 < threshold <= 1, "threshold must be in (0, 1]"
+    return rss_bytes >= limit_bytes * threshold
+
+
+def _watchdog_tick(
+    *,
+    limit_bytes: int,
+    threshold: float,
+    warned: bool,
+    rss_reader: Optional[Callable[[], Optional[int]]] = None,
+) -> tuple[bool, Optional[str]]:
+    """Evaluate one watchdog sample.
+
+    Returns ``(new_warned, message_or_None)``. A WARNING message is produced only
+    on the transition *into* the pressured state, so a sustained high-memory
+    period logs once rather than every interval; recovery re-arms the warning.
+
+    Preconditions:
+        - ``limit_bytes > 0`` and ``0 < threshold <= 1``.
+    Postconditions:
+        - ``message`` is non-None iff this sample crossed into pressure while the
+          previous state was un-warned.
+    """
+    # Resolve at call time (not as a default arg) so the module-level
+    # ``read_rss_bytes`` can be monkeypatched in tests.
+    reader = rss_reader if rss_reader is not None else read_rss_bytes
+    rss = reader()
+    if rss is None:
+        return warned, None
+    pressured = evaluate_memory_pressure(rss, limit_bytes, threshold)
+    if pressured and not warned:
+        pct = rss / limit_bytes * 100.0
+        message = (
+            f"High memory: RSS {_mb(rss)}MB / {_mb(limit_bytes)}MB "
+            f"({pct:.0f}%, warn at {threshold * 100:.0f}%) — approaching the "
+            f"container memory limit; an OOM kill (SIGKILL, no traceback) is imminent"
+        )
+        return True, message
+    if not pressured and warned:
+        return False, None
+    return warned, None
+
+
+def _watchdog_loop(
+    *,
+    team: str,
+    limit_bytes: int,
+    threshold: float,
+    interval_s: float,
+    stop_event: threading.Event,
+    logger: logging.Logger,
+) -> None:
+    """Sample memory on *interval_s* until *stop_event* is set, logging pressure."""
+    warned = False
+    while not stop_event.wait(interval_s):
+        try:
+            warned, message = _watchdog_tick(
+                limit_bytes=limit_bytes, threshold=threshold, warned=warned
+            )
+            if message:
+                logger.warning("[%s] %s", team, message)
+        except Exception:  # noqa: BLE001 — a diagnostic thread must never crash the worker
+            logger.debug("memory watchdog tick failed", exc_info=True)
+
+
+def start_memory_watchdog(
+    team: str,
+    *,
+    logger: Optional[logging.Logger] = None,
+    interval_s: Optional[float] = None,
+    threshold: Optional[float] = None,
+    limit_bytes: Optional[int] = None,
+) -> Optional[threading.Thread]:
+    """Start a daemon thread that warns as RSS approaches the memory budget.
+
+    The thread is the only early signal of an impending OOM kill: the kernel's
+    SIGKILL cannot be caught, so without this the worker simply vanishes. The
+    WARNING it emits becomes the last (and explanatory) log line before death.
+
+    Preconditions:
+        - ``team`` is a non-empty identifier used in log lines.
+    Postconditions:
+        - Returns the started daemon ``Thread`` (with a ``stop_event`` attribute
+          for shutdown), or None when disabled via env or when no memory limit
+          can be detected. Never raises.
+    """
+    assert team, "team must be a non-empty identifier"
+    log = logger or _get_logger()
+
+    if not _env_bool("TEAM_MEMORY_WATCHDOG_ENABLED", True):
+        log.debug("memory watchdog disabled via TEAM_MEMORY_WATCHDOG_ENABLED")
+        return None
+
+    if limit_bytes is None:
+        limit_bytes = detect_memory_limit_bytes()
+    if not limit_bytes or limit_bytes <= 0:
+        log.debug("memory watchdog: no memory limit detected; not starting for %s", team)
+        return None
+
+    if interval_s is None:
+        interval_s = _env_float("TEAM_MEMORY_WATCHDOG_INTERVAL_S", _DEFAULT_INTERVAL_S, minimum=1.0)
+    if threshold is None:
+        threshold = _env_float(
+            "TEAM_MEMORY_WATCHDOG_THRESHOLD", _DEFAULT_THRESHOLD, minimum=0.1, maximum=0.99
+        )
+
+    stop_event = threading.Event()
+    thread = threading.Thread(
+        target=_watchdog_loop,
+        kwargs={
+            "team": team,
+            "limit_bytes": limit_bytes,
+            "threshold": threshold,
+            "interval_s": interval_s,
+            "stop_event": stop_event,
+            "logger": log,
+        },
+        name=f"mem-watchdog-{team}",
+        daemon=True,
+    )
+    # Expose the stop event so callers/tests can shut the thread down cleanly.
+    thread.stop_event = stop_event  # type: ignore[attr-defined]
+    thread.start()
+    log.info(
+        "Memory watchdog armed for %s: warn at %.0f%% of %dMB (every %.0fs)",
+        team,
+        threshold * 100,
+        _mb(limit_bytes),
+        interval_s,
+    )
+    return thread
+
+
+# ---------------------------------------------------------------------------
+# Fault / uncaught-exception diagnostics
+# ---------------------------------------------------------------------------
+
+
+def _sys_excepthook(exc_type, exc_value, exc_tb) -> None:
+    """Log an uncaught main-thread exception with a full traceback before exit."""
+    if issubclass(exc_type, KeyboardInterrupt):
+        _original_sys_excepthook(exc_type, exc_value, exc_tb)
+        return
+    _get_logger().critical(
+        "Uncaught exception in main thread; process is terminating",
+        exc_info=(exc_type, exc_value, exc_tb),
+    )
+
+
+def _thread_excepthook(args) -> None:
+    """Log an uncaught exception raised in any non-main thread, with a traceback."""
+    if args.exc_type is SystemExit:
+        return
+    thread_name = getattr(args.thread, "name", "?")
+    _get_logger().critical(
+        "Uncaught exception in thread %r",
+        thread_name,
+        exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+    )
+
+
+def install_fault_diagnostics(logger: Optional[logging.Logger] = None) -> None:
+    """Arm faulthandler and uncaught-exception logging for this process.
+
+    Idempotent within a process. After this call:
+      * a native fatal signal dumps a Python stack to stderr (faulthandler), and
+      * an uncaught exception in any thread is logged with a full traceback
+        instead of a bare stderr dump that container log scrapers often miss.
+
+    It deliberately does **not** install SIGTERM/SIGINT handlers, leaving
+    uvicorn's graceful-shutdown handling untouched.
+
+    Postconditions:
+        - ``sys.excepthook`` and ``threading.excepthook`` route through the
+          module logger; faulthandler is enabled when available. Never raises.
+    """
+    global _diagnostics_installed, _log
+    if logger is not None:
+        _log = logger
+    if _diagnostics_installed:
+        return
+    _diagnostics_installed = True
+
+    try:
+        import faulthandler
+
+        if not faulthandler.is_enabled():
+            faulthandler.enable()
+        # Inherited by forked workers; read at interpreter start by spawned ones.
+        os.environ.setdefault("PYTHONFAULTHANDLER", "1")
+    except Exception:  # noqa: BLE001 — diagnostics must never block startup
+        _get_logger().debug("faulthandler unavailable", exc_info=True)
+
+    sys.excepthook = _sys_excepthook
+    try:
+        threading.excepthook = _thread_excepthook  # Python 3.8+
+    except Exception:  # noqa: BLE001
+        _get_logger().debug("threading.excepthook not settable", exc_info=True)
+
+    _get_logger().info("Fault diagnostics armed: faulthandler + uncaught-exception logging")

--- a/backend/agents/shared_observability/tests/test_otel.py
+++ b/backend/agents/shared_observability/tests/test_otel.py
@@ -120,6 +120,30 @@ def test_instrument_fastapi_app_attaches_server_spans(span_exporter) -> None:
     assert resource_attrs.get("service.name")  # set, any value from first init_otel
 
 
+def test_instrument_fastapi_app_is_idempotent(span_exporter, caplog) -> None:
+    """A second instrument call is a quiet no-op — no re-instrumentation, and none
+    of opentelemetry's 'already instrumented' WARNING that muddies crash logs."""
+    import logging
+
+    pytest.importorskip("opentelemetry.instrumentation.fastapi")
+    pytest.importorskip("fastapi")
+
+    from fastapi import FastAPI
+
+    from shared_observability import instrument_fastapi_app
+
+    app = FastAPI()
+    instrument_fastapi_app(app, team_key=_TEAM_KEY)
+    assert getattr(app, "_khala_otel_instrumented", False) is True
+
+    with caplog.at_level(logging.WARNING):
+        instrument_fastapi_app(app, team_key=_TEAM_KEY)  # second call
+
+    assert not any(
+        "already instrumented" in record.getMessage().lower() for record in caplog.records
+    ), "second instrument call must not trigger the 'already instrumented' warning"
+
+
 def test_llm_service_record_call_emits_otel_span(span_exporter) -> None:
     import llm_service.telemetry as telemetry_module
 

--- a/backend/agents/shared_observability/tests/test_process_health.py
+++ b/backend/agents/shared_observability/tests/test_process_health.py
@@ -1,0 +1,339 @@
+"""Unit tests for shared_observability.process_health.
+
+These cover the diagnostics that turn a silent worker death into a debuggable
+event: defensive env parsing, RSS / cgroup-limit reads, the memory-pressure
+evaluation and watchdog tick/loop, the watchdog lifecycle, and the faulthandler
+/ uncaught-exception hook installation.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+import types
+
+import pytest
+
+from shared_observability import process_health as ph
+
+# --------------------------------------------------------------------- env parsing
+
+
+def test_env_bool_default_blank_and_truthy(monkeypatch) -> None:
+    monkeypatch.delenv("X_BOOL", raising=False)
+    assert ph._env_bool("X_BOOL", True) is True
+    assert ph._env_bool("X_BOOL", False) is False
+    monkeypatch.setenv("X_BOOL", "   ")
+    assert ph._env_bool("X_BOOL", True) is True  # blank → default
+    for val in ("1", "true", "YES", "On"):
+        monkeypatch.setenv("X_BOOL", val)
+        assert ph._env_bool("X_BOOL", False) is True
+    for val in ("0", "false", "nope"):
+        monkeypatch.setenv("X_BOOL", val)
+        assert ph._env_bool("X_BOOL", True) is False
+
+
+def test_env_float_default_garbage_and_clamp(monkeypatch) -> None:
+    monkeypatch.delenv("X_F", raising=False)
+    assert ph._env_float("X_F", 30.0) == 30.0
+    monkeypatch.setenv("X_F", "garbage")
+    assert ph._env_float("X_F", 30.0) == 30.0  # unparseable → default
+    monkeypatch.setenv("X_F", "0.5")
+    assert ph._env_float("X_F", 30.0) == 0.5
+    monkeypatch.setenv("X_F", "0.001")
+    assert ph._env_float("X_F", 0.85, minimum=0.1) == 0.1  # clamped to floor
+    monkeypatch.setenv("X_F", "5")
+    assert ph._env_float("X_F", 0.85, maximum=0.99) == 0.99  # clamped to ceiling
+
+
+# --------------------------------------------------------------------- memory reads
+
+
+def test_read_rss_bytes_parses_vmrss(tmp_path) -> None:
+    status = tmp_path / "status"
+    status.write_text("Name:\tpython\nVmRSS:\t  2048 kB\nVmSize:\t 9999 kB\n")
+    assert ph.read_rss_bytes(str(status)) == 2048 * 1024
+
+
+def test_read_rss_bytes_missing_file_and_no_vmrss(tmp_path) -> None:
+    assert ph.read_rss_bytes(str(tmp_path / "nope")) is None
+    no_rss = tmp_path / "status2"
+    no_rss.write_text("Name:\tpython\nVmSize:\t 10 kB\n")
+    assert ph.read_rss_bytes(str(no_rss)) is None
+
+
+def test_read_int_file_variants(tmp_path) -> None:
+    good = tmp_path / "g"
+    good.write_text("12345\n")
+    assert ph._read_int_file(str(good)) == 12345
+    mx = tmp_path / "m"
+    mx.write_text("max\n")
+    assert ph._read_int_file(str(mx)) is None  # cgroup v2 'no limit'
+    bad = tmp_path / "b"
+    bad.write_text("not-a-number\n")
+    assert ph._read_int_file(str(bad)) is None
+    assert ph._read_int_file(str(tmp_path / "absent")) is None
+
+
+def test_detect_memory_limit_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("TEAM_MEMORY_WATCHDOG_LIMIT_MB", "512")
+    assert ph.detect_memory_limit_bytes() == 512 * 1024 * 1024
+
+
+def test_detect_memory_limit_env_garbage_falls_through(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("TEAM_MEMORY_WATCHDOG_LIMIT_MB", "garbage")
+    monkeypatch.setattr(ph, "_CGROUP_V2_MAX", str(tmp_path / "absent_v2"))
+    monkeypatch.setattr(ph, "_CGROUP_V1_LIMIT", str(tmp_path / "absent_v1"))
+    assert ph.detect_memory_limit_bytes() is None
+
+
+def test_detect_memory_limit_reads_cgroup_v2(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("TEAM_MEMORY_WATCHDOG_LIMIT_MB", raising=False)
+    v2 = tmp_path / "memory.max"
+    v2.write_text(str(256 * 1024 * 1024))
+    monkeypatch.setattr(ph, "_CGROUP_V2_MAX", str(v2))
+    monkeypatch.setattr(ph, "_CGROUP_V1_LIMIT", str(tmp_path / "absent_v1"))
+    assert ph.detect_memory_limit_bytes() == 256 * 1024 * 1024
+
+
+def test_detect_memory_limit_reads_cgroup_v1(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("TEAM_MEMORY_WATCHDOG_LIMIT_MB", raising=False)
+    monkeypatch.setattr(ph, "_CGROUP_V2_MAX", str(tmp_path / "absent_v2"))
+    v1 = tmp_path / "limit"
+    v1.write_text(str(128 * 1024 * 1024))
+    monkeypatch.setattr(ph, "_CGROUP_V1_LIMIT", str(v1))
+    assert ph.detect_memory_limit_bytes() == 128 * 1024 * 1024
+
+
+def test_detect_memory_limit_ignores_unlimited_sentinels(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("TEAM_MEMORY_WATCHDOG_LIMIT_MB", raising=False)
+    v2 = tmp_path / "memory.max"
+    v2.write_text("max")  # cgroup v2 'no limit'
+    v1 = tmp_path / "limit"
+    v1.write_text(str(ph._UNLIMITED_BYTES + 1))  # cgroup v1 huge sentinel
+    monkeypatch.setattr(ph, "_CGROUP_V2_MAX", str(v2))
+    monkeypatch.setattr(ph, "_CGROUP_V1_LIMIT", str(v1))
+    assert ph.detect_memory_limit_bytes() is None
+
+
+# --------------------------------------------------------------- pressure / tick / loop
+
+
+def test_evaluate_memory_pressure_threshold() -> None:
+    assert ph.evaluate_memory_pressure(85, 100, 0.85) is True
+    assert ph.evaluate_memory_pressure(84, 100, 0.85) is False
+    assert ph.evaluate_memory_pressure(100, 100, 0.85) is True
+
+
+@pytest.mark.parametrize(
+    "rss,limit,thr",
+    [(-1, 100, 0.5), (10, 0, 0.5), (10, 100, 0.0), (10, 100, 1.5)],
+)
+def test_evaluate_memory_pressure_precondition_violations(rss, limit, thr) -> None:
+    with pytest.raises(AssertionError):
+        ph.evaluate_memory_pressure(rss, limit, thr)
+
+
+def test_watchdog_tick_warns_once_then_recovers() -> None:
+    limit = 100
+    warned, msg = ph._watchdog_tick(
+        limit_bytes=limit, threshold=0.85, warned=False, rss_reader=lambda: 90
+    )
+    assert warned is True and msg is not None and "OOM" in msg  # first crossing warns
+    warned, msg = ph._watchdog_tick(
+        limit_bytes=limit, threshold=0.85, warned=True, rss_reader=lambda: 95
+    )
+    assert warned is True and msg is None  # sustained pressure does not repeat
+    warned, msg = ph._watchdog_tick(
+        limit_bytes=limit, threshold=0.85, warned=True, rss_reader=lambda: 10
+    )
+    assert warned is False and msg is None  # recovery re-arms the warning
+
+
+def test_watchdog_tick_no_rss_is_noop() -> None:
+    warned, msg = ph._watchdog_tick(
+        limit_bytes=100, threshold=0.85, warned=False, rss_reader=lambda: None
+    )
+    assert warned is False and msg is None
+
+
+def test_watchdog_loop_logs_once_then_exits_on_stop(monkeypatch, caplog) -> None:
+    """One pressured sample logs a WARNING; the loop then exits when stop is set.
+
+    Deterministic: the fake RSS reader sets the stop event during the first tick,
+    so the loop runs exactly one body iteration and exits on the next ``wait``.
+    """
+    stop = threading.Event()
+
+    def fake_rss(*_a, **_k):
+        stop.set()  # request shutdown so the loop exits after this iteration
+        return 1024 * 1024 * 1024
+
+    monkeypatch.setattr(ph, "read_rss_bytes", fake_rss)
+    logger = logging.getLogger("test.ph.loop")
+    with caplog.at_level(logging.WARNING, logger="test.ph.loop"):
+        ph._watchdog_loop(
+            team="coding_team",
+            limit_bytes=1024 * 1024 * 1024,
+            threshold=0.5,
+            interval_s=0.0,
+            stop_event=stop,
+            logger=logger,
+        )
+    assert any("High memory" in r.getMessage() for r in caplog.records)
+
+
+def test_watchdog_loop_survives_tick_errors(monkeypatch, caplog) -> None:
+    """A reader that raises must not crash the diagnostic thread — it is swallowed."""
+    stop = threading.Event()
+
+    def boom(*_a, **_k):
+        stop.set()
+        raise RuntimeError("proc read failed")
+
+    monkeypatch.setattr(ph, "read_rss_bytes", boom)
+    logger = logging.getLogger("test.ph.loop_err")
+    # Should not raise out of the loop.
+    ph._watchdog_loop(
+        team="coding_team",
+        limit_bytes=100,
+        threshold=0.5,
+        interval_s=0.0,
+        stop_event=stop,
+        logger=logger,
+    )
+
+
+# ----------------------------------------------------------------- watchdog lifecycle
+
+
+def test_start_memory_watchdog_disabled_via_env(monkeypatch) -> None:
+    monkeypatch.setenv("TEAM_MEMORY_WATCHDOG_ENABLED", "false")
+    assert ph.start_memory_watchdog("coding_team") is None
+
+
+def test_start_memory_watchdog_no_limit_returns_none(monkeypatch) -> None:
+    monkeypatch.setenv("TEAM_MEMORY_WATCHDOG_ENABLED", "true")
+    monkeypatch.setattr(ph, "detect_memory_limit_bytes", lambda: None)
+    assert ph.start_memory_watchdog("coding_team") is None
+
+
+def test_start_memory_watchdog_returns_stoppable_thread(monkeypatch) -> None:
+    monkeypatch.setenv("TEAM_MEMORY_WATCHDOG_ENABLED", "true")
+    # Long interval: the thread blocks on wait() immediately and never ticks, so
+    # the test exercises only start + clean stop without any timing race.
+    thread = ph.start_memory_watchdog(
+        "coding_team", limit_bytes=10 * 1024 * 1024, threshold=0.9, interval_s=100.0
+    )
+    assert thread is not None and thread.is_alive()
+    assert hasattr(thread, "stop_event")
+    thread.stop_event.set()  # type: ignore[attr-defined]
+    thread.join(timeout=2)
+    assert not thread.is_alive()
+
+
+def test_start_memory_watchdog_requires_team() -> None:
+    with pytest.raises(AssertionError):
+        ph.start_memory_watchdog("")
+
+
+# ------------------------------------------------------ fault / excepthook diagnostics
+
+
+@pytest.fixture()
+def _restore_diag_state():
+    """Save/restore process-global hooks the diagnostics installer mutates."""
+    saved = (
+        sys.excepthook,
+        threading.excepthook,
+        ph._diagnostics_installed,
+        ph._log,
+        ph._original_sys_excepthook,
+    )
+    try:
+        yield
+    finally:
+        (
+            sys.excepthook,
+            threading.excepthook,
+            ph._diagnostics_installed,
+            ph._log,
+            ph._original_sys_excepthook,
+        ) = saved
+
+
+def test_install_fault_diagnostics_sets_hooks_and_is_idempotent(_restore_diag_state) -> None:
+    import faulthandler
+
+    ph._diagnostics_installed = False
+    ph.install_fault_diagnostics(logging.getLogger("test.ph.install"))
+
+    assert sys.excepthook is ph._sys_excepthook
+    assert threading.excepthook is ph._thread_excepthook
+    assert faulthandler.is_enabled()
+
+    # A second call is a no-op (does not raise; hooks remain installed).
+    ph.install_fault_diagnostics()
+    assert sys.excepthook is ph._sys_excepthook
+
+
+def test_sys_excepthook_logs_uncaught_with_traceback(_restore_diag_state, caplog) -> None:
+    ph._log = logging.getLogger("test.ph.sysexc")
+    try:
+        raise ValueError("boom in main")
+    except ValueError:
+        exc = sys.exc_info()
+
+    with caplog.at_level(logging.CRITICAL, logger="test.ph.sysexc"):
+        ph._sys_excepthook(*exc)
+
+    assert any("Uncaught exception in main thread" in r.getMessage() for r in caplog.records)
+    assert any(r.exc_info for r in caplog.records)
+
+
+def test_sys_excepthook_delegates_keyboardinterrupt(_restore_diag_state) -> None:
+    captured = {}
+    ph._original_sys_excepthook = lambda *a: captured.setdefault("args", a)
+    try:
+        raise KeyboardInterrupt()
+    except KeyboardInterrupt:
+        exc = sys.exc_info()
+
+    ph._sys_excepthook(*exc)
+
+    assert "args" in captured  # Ctrl-C delegates to the original hook, not logged
+
+
+def test_thread_excepthook_logs_uncaught(_restore_diag_state, caplog) -> None:
+    ph._log = logging.getLogger("test.ph.thread")
+    try:
+        raise RuntimeError("boom in thread")
+    except RuntimeError:
+        exc_type, exc_value, exc_tb = sys.exc_info()
+    args = types.SimpleNamespace(
+        exc_type=exc_type,
+        exc_value=exc_value,
+        exc_traceback=exc_tb,
+        thread=threading.current_thread(),
+    )
+
+    with caplog.at_level(logging.CRITICAL, logger="test.ph.thread"):
+        ph._thread_excepthook(args)
+
+    assert any("Uncaught exception in thread" in r.getMessage() for r in caplog.records)
+    assert any(r.exc_info for r in caplog.records)
+
+
+def test_thread_excepthook_ignores_systemexit(_restore_diag_state, caplog) -> None:
+    ph._log = logging.getLogger("test.ph.sysexit")
+    args = types.SimpleNamespace(
+        exc_type=SystemExit,
+        exc_value=SystemExit(),
+        exc_traceback=None,
+        thread=threading.current_thread(),
+    )
+    with caplog.at_level(logging.CRITICAL, logger="test.ph.sysexit"):
+        ph._thread_excepthook(args)
+
+    assert not caplog.records  # a thread's SystemExit is a normal exit, not an error

--- a/backend/team_service/entrypoint.py
+++ b/backend/team_service/entrypoint.py
@@ -155,6 +155,22 @@ def _resolve_app() -> str:
         "        return None\n"
     )
 
+    # Each worker is its own process: re-arm fault diagnostics (the excepthooks
+    # are not inherited across a 'spawn' start-method) and start a per-worker
+    # memory watchdog, so an impending OOM kill is logged before the worker
+    # vanishes and a native fault dumps a stack instead of dying silently.
+    body += (
+        "try:\n"
+        "    from shared_observability import install_fault_diagnostics, start_memory_watchdog\n"
+        "    install_fault_diagnostics()\n"
+        f"    start_memory_watchdog('{TEAM_NAME}')\n"
+        "except Exception:\n"
+        "    import logging\n"
+        "    logging.getLogger('team_service').warning(\n"
+        "        'fault diagnostics / memory watchdog unavailable', exc_info=True\n"
+        "    )\n"
+    )
+
     if TEAM_APP_ATTR == "router":
         body += (
             "from fastapi import FastAPI\n"
@@ -221,6 +237,14 @@ def _startup_recovery() -> None:
 
 if __name__ == "__main__":
     logger.info("Starting %s on port %d (module=%s)", TEAM_NAME, TEAM_PORT, TEAM_MODULE)
+    # Arm fault diagnostics in the supervisor process first; forked workers
+    # inherit faulthandler, and the generated wrapper re-arms it per worker.
+    try:
+        from shared_observability import install_fault_diagnostics
+
+        install_fault_diagnostics(logger)
+    except Exception:
+        logger.warning("fault diagnostics unavailable", exc_info=True)
     _startup_recovery()
     _start_temporal_worker()
     atexit.register(_shutdown_hook)


### PR DESCRIPTION
Closes #883

## Root cause

The coding-team service dies "without errors" during a code review. The log lines (`Child process [9] died`, OTel re-init, `already instrumented`) are **uvicorn reacting to a worker that already died**, not the cause:

- Team services run under `backend/team_service/entrypoint.py` with `uvicorn.run(..., workers=2)`. uvicorn's `Multiprocess` supervisor auto-restarts a worker that stops being alive (`Waiting for child process` → `Child process [pid] died`), and the fresh worker re-runs the generated wrapper → re-inits OTel and re-instruments the app (`already instrumented`).
- A normal Python exception can't kill the worker (the job runs in a daemon thread whose `try/except` logs and fails the job). A worker vanishing with **no traceback** means an OS-level kill Python never reports — most likely the **OOM killer (SIGKILL)** during the unbounded diff/repo-context loads in the review path, with a native segfault as the secondary candidate.
- It was invisible because nothing armed `faulthandler`, hooked uncaught exceptions, or tracked memory; and a broad `except Exception` in the quality gate logged only a one-line WARNING.

## What this PR changes (diagnostics + logging)

- **`shared_observability/process_health.py` (new):**
  - `install_fault_diagnostics()` — enables `faulthandler` (dumps a native stack on SIGSEGV/SIGABRT/SIGBUS/SIGFPE/SIGILL) and routes `sys`/`threading` uncaught exceptions through logging with a full traceback. Leaves uvicorn's SIGTERM/SIGINT handling untouched.
  - `start_memory_watchdog()` — optional per-worker daemon that samples RSS (`/proc/self/status`) against the cgroup v2/v1 limit (or `TEAM_MEMORY_WATCHDOG_LIMIT_MB`) and WARNs once as it nears the budget, so the **last log line before an OOM names the cause**. Env-gated; no-op when no limit is known.
- **`team_service/entrypoint.py`:** arms the diagnostics in the supervisor process and injects them into the generated per-worker wrapper — so **all ~20 team services** gain the visibility.
- **`shared_observability/otel.py`:** `instrument_fastapi_app` is now idempotent (sentinel attribute), removing the misleading `already instrumented` warning emitted on every worker boot.
- **`coding_team/orchestrator.py`:** the quality-gate catch now uses `logger.exception` (full traceback) instead of a one-line WARNING. Resilient "proceed" behavior unchanged.

## New env vars

`TEAM_MEMORY_WATCHDOG_ENABLED` (default true), `TEAM_MEMORY_WATCHDOG_LIMIT_MB`, `TEAM_MEMORY_WATCHDOG_THRESHOLD` (default 0.85), `TEAM_MEMORY_WATCHDOG_INTERVAL_S` (default 30) — all parse defensively.

## Tests

- `shared_observability/tests/test_process_health.py` (new, 28 tests): env parsing, RSS/cgroup reads, pressure eval + watchdog tick/loop, lifecycle, and the faulthandler/excepthook installation.
- `test_otel.py`: idempotency — a second instrument call is a quiet no-op (no `already instrumented` warning).
- `test_swarm_review.py`: a quality-gate tool error is now logged at ERROR **with** `exc_info` (full traceback).
- `make lint` clean; 91 tests pass locally (`process_health` + `otel` + `coding_team` swarm-review suites).

## Recommended follow-ups (not implemented — scoped out per request)

These prevent the OOM precondition itself and pair with the watchdog:

1. **Bound the review evidence/diff** in `_review_and_merge`: when it exceeds a memory-safety ceiling, fail that one task cleanly via the existing `error` path (`_fail_task`) with a logged diagnostic, instead of building a giant string and OOM-ing mid-call. Respects the existing "never review partial evidence" contract.
2. **Add a container memory limit + reservation** to `coding-team-service` in `docker/docker-compose.yml` (mirrors the unified-api precedent). Docker then marks the container `OOMKilled: true` (queryable) and contains the blast radius; align the limit with the watchdog budget.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1FLKktgt3stZwrEBTpjaG)_